### PR TITLE
Add training harness and pilot configuration

### DIFF
--- a/src/gcpvqvae/__init__.py
+++ b/src/gcpvqvae/__init__.py
@@ -1,5 +1,18 @@
 """Top-level package for the GCP-VQVAE project."""
 
+from .models.gcpvqvae import (
+    DataPipelineConfig,
+    GCPVQVAE,
+    GCPVQVAEConfig,
+    RotationHeadConfig,
+    VectorQuantizerConfig,
+)
+
 __all__ = [
     "cli",
+    "GCPVQVAE",
+    "GCPVQVAEConfig",
+    "VectorQuantizerConfig",
+    "RotationHeadConfig",
+    "DataPipelineConfig",
 ]

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -1,6 +1,75 @@
-# Base configuration for full-scale training (stub).
+# Full-scale training configuration reflecting the two-stage schedule described
+# in the manuscript.  The defaults match Table 4/5 and can serve as a template
+# for distributed runs once adequate data is available.
+
+data:
+  root: "data/train"          # path to a directory with mmCIF files
+  k: 16                        # kNN edges per residue
+  num_workers: 8
+  cache: true
+
 model:
-  latent_dim: 256
-training:
-  batch_size: 32
-  epochs: 100
+  gcp:
+    hidden_scalar_dim: 128
+    hidden_vector_dim: 16
+    edge_scalar_dim: 32
+    edge_vector_dim: 1
+    latent_dim: 256
+    layers: 6
+  vq:
+    num_codes: 4096
+    dim: 256
+    beta: 0.5
+    decay: 0.99
+    kmeans_iters: 10
+    orthogonal_reg_weight: 10.0
+    orthogonal_reg_max_codes: 512
+  encoder:
+    model_dim: 1024
+    num_layers: 12
+    num_heads: 12
+    num_kv_heads: 3
+    dropout: 0.0
+    ffn_multiplier: 4.0
+  decoder:
+    model_dim: 1024
+    num_layers: 16
+    num_heads: 16
+    num_kv_heads: 1
+    dropout: 0.0
+    ffn_multiplier: 4.0
+
+train:
+  seed: 42
+  amp: true
+  clip_grad: 1.0
+  random_rotation: true
+  log_interval: 100
+  checkpoint_interval: 5000
+  output_dir: "runs/full"
+  export:
+    enabled: true
+    directory: "runs/full/exports"
+    on_stage_end: true
+    num_samples: 2
+  stages:
+    - name: stage1
+      length_cap: 512
+      batch_size: 16
+      base_lr: 0.0001
+      min_lr: 0.000001
+      warmup_steps: 16000
+      total_steps: 375000
+      accumulation_steps: 1
+      nan_mask_prob: 0.0
+      nan_mask_span: [1, 1]
+    - name: stage2
+      length_cap: 1280
+      batch_size: 4
+      base_lr: 0.00005
+      min_lr: 0.000001
+      warmup_steps: 16000
+      total_steps: 1500000
+      accumulation_steps: 1
+      nan_mask_prob: 0.05
+      nan_mask_span: [1, 30]

--- a/src/gcpvqvae/configs/pilot.yaml
+++ b/src/gcpvqvae/configs/pilot.yaml
@@ -1,6 +1,57 @@
-# Pilot configuration for smoke tests (stub).
+# Lightweight configuration for quick smoke tests on a small mmCIF folder.
+
+data:
+  root: "data/pilot"
+  k: 12
+  num_workers: 4
+  cache: true
+
 model:
-  latent_dim: 128
-training:
-  batch_size: 4
-  epochs: 2
+  gcp:
+    hidden_scalar_dim: 64
+    hidden_vector_dim: 8
+    edge_scalar_dim: 16
+    edge_vector_dim: 1
+    latent_dim: 128
+    layers: 3
+  vq:
+    num_codes: 512
+    dim: 128
+    beta: 0.25
+    decay: 0.99
+    kmeans_iters: 5
+    orthogonal_reg_weight: 1.0
+  encoder:
+    model_dim: 384
+    num_layers: 4
+    num_heads: 6
+    num_kv_heads: 2
+    dropout: 0.0
+  decoder:
+    model_dim: 384
+    num_layers: 6
+    num_heads: 6
+    num_kv_heads: 1
+    dropout: 0.0
+
+train:
+  seed: 1234
+  amp: false
+  clip_grad: 1.0
+  random_rotation: true
+  log_interval: 5
+  checkpoint_interval: 5
+  output_dir: "runs/pilot"
+  export:
+    enabled: false
+  stages:
+    - name: pilot
+      length_cap: 512
+      batch_size: 4
+      base_lr: 0.0003
+      min_lr: 0.00001
+      warmup_steps: 500
+      epochs: 3
+      accumulation_steps: 1
+      nan_mask_prob: 0.0
+      nan_mask_span: [1, 1]

--- a/src/gcpvqvae/data/dataset.py
+++ b/src/gcpvqvae/data/dataset.py
@@ -2,19 +2,211 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import torch
 from torch.utils.data import Dataset
+
+from .featurize import featurize_backbone
+from .mmcif import PAD_INDEX, BackboneRecord, load_mmcif
+
+Tensor = torch.Tensor
+
+
+def _discover_files(root: Path) -> List[Path]:
+    if root.is_file():
+        return [root]
+
+    patterns = ["*.cif", "*.cif.gz", "*.mmcif", "*.mmcif.gz"]
+    files: List[Path] = []
+    for pattern in patterns:
+        files.extend(sorted(root.rglob(pattern)))
+    return files
 
 
 class BackboneDataset(Dataset):
     """Dataset of protein backbones ready for GCP featurization."""
 
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        chain_ids: Optional[Iterable[str]] = None,
+        length_cap: int = 2048,
+        k: int = 16,
+        cache: bool = True,
+    ) -> None:
+        self.root = Path(root)
+        if not self.root.exists():
+            raise FileNotFoundError(root)
+
+        self.length_cap = length_cap
+        self.k = k
+        self.chain_filter = set(chain_ids) if chain_ids is not None else None
+        self._cache_enabled = cache
+        self._records: Dict[Tuple[str, str], BackboneRecord] = {}
+        self._keys: List[Tuple[str, str]] = []
+
+        for file in _discover_files(self.root):
+            records = load_mmcif(str(file), length_cap=length_cap)
+            for record in records:
+                if self.chain_filter and record.chain_id not in self.chain_filter:
+                    continue
+                key = (record.path, record.chain_id)
+                self._keys.append(key)
+                if self._cache_enabled:
+                    self._records[key] = record
+
     def __len__(self) -> int:
-        raise NotImplementedError
+        return len(self._keys)
 
-    def __getitem__(self, index: int):
-        raise NotImplementedError
+    def _get_record(self, key: Tuple[str, str]) -> BackboneRecord:
+        if self._cache_enabled and key in self._records:
+            return self._records[key]
+
+        path, chain_id = key
+        records = load_mmcif(path, chain_id=chain_id, length_cap=self.length_cap)
+        if not records:
+            raise KeyError(f"Unable to load chain {chain_id!r} from {path}")
+        record = records[0]
+        if self._cache_enabled:
+            self._records[key] = record
+        return record
+
+    def __getitem__(self, index: int) -> Dict[str, Tensor | Dict[str, object]]:
+        key = self._keys[index]
+        record = self._get_record(key)
+
+        features = featurize_backbone(record, k=self.k)
+
+        sample: Dict[str, Tensor | Dict[str, object]] = {
+            "coords": record.coords.clone(),
+            "mask": record.mask.clone(),
+            "atom_mask": record.atom_mask.clone(),
+            "seq": record.seq.clone(),
+            "seq_str": record.seq_string,
+            "nan_mask": record.nan_mask.clone(),
+            "node_scalars": features["node_scalars"],
+            "node_vectors": features["node_vectors"],
+            "backbone_vectors": features["backbone_vectors"],
+            "torsion_angles": features["torsion_angles"],
+            "edge_index": features["edge_index"],
+            "edge_scalars": features["edge_scalars"],
+            "edge_vectors": features["edge_vectors"],
+            "edge_frames": features["edge_frames"],
+            "pose": {
+                "rotation": record.rotation.clone(),
+                "translation": record.translation.clone(),
+            },
+            "metadata": {
+                "path": record.path,
+                "chain_id": record.chain_id,
+                "sequence": record.seq_string,
+                "residue_ids": list(record.residue_ids),
+                "residue_names": list(record.residue_names),
+            },
+        }
+
+        return sample
 
 
-def collate_backbones(batch):
-    """Collate function for backbone samples (stub)."""
-    raise NotImplementedError("collate_backbones is not yet implemented")
+def collate_backbones(batch: List[Dict[str, Tensor | Dict[str, object]]]) -> Dict[str, Tensor | List[Dict[str, object]]]:
+    if not batch:
+        raise ValueError("Batch must not be empty")
+
+    max_len = max(item["coords"].shape[0] for item in batch)  # type: ignore[arg-type]
+    batch_size = len(batch)
+
+    dtype = batch[0]["coords"].dtype  # type: ignore[index]
+    device = batch[0]["coords"].device  # type: ignore[index]
+
+    coords = torch.zeros((batch_size, max_len, 3, 3), dtype=dtype, device=device)
+    mask = torch.zeros((batch_size, max_len), dtype=torch.bool, device=device)
+    atom_mask = torch.zeros((batch_size, max_len, 3), dtype=torch.bool, device=device)
+    seq = torch.full((batch_size, max_len), PAD_INDEX, dtype=torch.long, device=device)
+    nan_mask = torch.zeros((batch_size, max_len), dtype=torch.bool, device=device)
+    node_scalars = torch.zeros((batch_size, max_len, 6), dtype=dtype, device=device)
+    node_vectors = torch.zeros((batch_size, max_len, 3, 3), dtype=dtype, device=device)
+    backbone_vectors = torch.zeros((batch_size, max_len, 6, 3), dtype=dtype, device=device)
+    torsion_angles = torch.zeros((batch_size, max_len, 3), dtype=dtype, device=device)
+
+    lengths = torch.zeros((batch_size,), dtype=torch.long, device=device)
+
+    edge_indices: List[Tensor] = []
+    edge_scalars: List[Tensor] = []
+    edge_vectors: List[Tensor] = []
+    edge_frames: List[Tensor] = []
+    edge_batch = []
+    node_batch = []
+
+    node_offset = 0
+    metadata: List[Dict[str, object]] = []
+    sequences: List[str] = []
+    rotations = torch.zeros((batch_size, 3, 3), dtype=dtype, device=device)
+    translations = torch.zeros((batch_size, 3), dtype=dtype, device=device)
+
+    for i, item in enumerate(batch):
+        length = item["coords"].shape[0]  # type: ignore[index]
+        lengths[i] = length
+
+        coords[i, :length] = item["coords"]  # type: ignore[index]
+        mask[i, :length] = item["mask"]  # type: ignore[index]
+        atom_mask[i, :length] = item["atom_mask"]  # type: ignore[index]
+        seq[i, :length] = item["seq"]  # type: ignore[index]
+        nan_mask[i, :length] = item["nan_mask"]  # type: ignore[index]
+        node_scalars[i, :length] = item["node_scalars"]  # type: ignore[index]
+        node_vectors[i, :length] = item["node_vectors"]  # type: ignore[index]
+        backbone_vectors[i, :length] = item["backbone_vectors"]  # type: ignore[index]
+        torsion_angles[i, :length] = item["torsion_angles"]  # type: ignore[index]
+
+        edge_idx = item["edge_index"]  # type: ignore[index]
+        edge_indices.append(edge_idx + node_offset)
+        edge_scalars.append(item["edge_scalars"])  # type: ignore[index]
+        edge_vectors.append(item["edge_vectors"])  # type: ignore[index]
+        edge_frames.append(item["edge_frames"])  # type: ignore[index]
+        edge_batch.append(torch.full((edge_idx.shape[1],), i, dtype=torch.long, device=device))
+
+        node_batch.append(torch.full((length,), i, dtype=torch.long, device=device))
+
+        pose = item["pose"]  # type: ignore[index]
+        rotations[i] = pose["rotation"]  # type: ignore[index]
+        translations[i] = pose["translation"]  # type: ignore[index]
+
+        metadata.append(item["metadata"])  # type: ignore[index]
+        sequences.append(item["seq_str"])  # type: ignore[index]
+
+        node_offset += length
+
+    edge_index = torch.cat(edge_indices, dim=1) if edge_indices else torch.empty((2, 0), dtype=torch.long, device=device)
+    edge_scalars_tensor = torch.cat(edge_scalars, dim=0) if edge_scalars else torch.empty((0, 8), dtype=dtype, device=device)
+    edge_vectors_tensor = torch.cat(edge_vectors, dim=0) if edge_vectors else torch.empty((0, 3), dtype=dtype, device=device)
+    edge_frames_tensor = torch.cat(edge_frames, dim=0) if edge_frames else torch.empty((0, 3, 3), dtype=dtype, device=device)
+    edge_batch_tensor = torch.cat(edge_batch, dim=0) if edge_batch else torch.empty((0,), dtype=torch.long, device=device)
+    node_batch_tensor = torch.cat(node_batch, dim=0) if node_batch else torch.empty((0,), dtype=torch.long, device=device)
+
+    return {
+        "coords": coords,
+        "mask": mask,
+        "atom_mask": atom_mask,
+        "seq": seq,
+        "nan_mask": nan_mask,
+        "node_scalars": node_scalars,
+        "node_vectors": node_vectors,
+        "backbone_vectors": backbone_vectors,
+        "torsion_angles": torsion_angles,
+        "edge_index": edge_index,
+        "edge_scalars": edge_scalars_tensor,
+        "edge_vectors": edge_vectors_tensor,
+        "edge_frames": edge_frames_tensor,
+        "edge_batch": edge_batch_tensor,
+        "node_batch": node_batch_tensor,
+        "lengths": lengths,
+        "rotations": rotations,
+        "translations": translations,
+        "metadata": metadata,
+        "sequences": sequences,
+    }
+
+
+__all__ = ["BackboneDataset", "collate_backbones"]

--- a/src/gcpvqvae/data/featurize.py
+++ b/src/gcpvqvae/data/featurize.py
@@ -2,12 +2,267 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Dict, Tuple
 
-def build_node_features(backbone):
-    """Produce scalar/vector node features from a backbone (stub)."""
-    raise NotImplementedError("build_node_features is not yet implemented")
+import torch
+
+from gcpvqvae.geometry.frames import build_local_frames
+from gcpvqvae.geometry.torsion import backbone_torsions
+
+from .mmcif import BackboneRecord
+
+Tensor = torch.Tensor
+
+RBF_CENTRES = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0])
+RBF_SIGMA = 2.0
 
 
-def build_edge_features(backbone):
-    """Produce scalar/vector edge features (stub)."""
-    raise NotImplementedError("build_edge_features is not yet implemented")
+def _safe_normalise(vec: Tensor, eps: float = 1e-8) -> Tensor:
+    norm = torch.linalg.norm(vec, dim=-1, keepdim=True)
+    norm = torch.clamp(norm, min=eps)
+    return vec / norm
+
+
+def _rbf(distances: Tensor, centres: Tensor, sigma: float) -> Tensor:
+    diff = distances.unsqueeze(-1) - centres
+    return torch.exp(-0.5 * (diff / sigma) ** 2)
+
+
+@dataclass
+class NodeFeatures:
+    scalars: Tensor  # (L, 6)
+    vectors: Tensor  # (L, 3, 3)
+    backbone_vectors: Tensor  # (L, 6, 3)
+    torsions: Tensor  # (L, 3)
+
+
+@dataclass
+class EdgeFeatures:
+    edge_index: Tensor  # (2, E)
+    scalars: Tensor  # (E, 8)
+    vectors: Tensor  # (E, 3)
+    frames: Tensor  # (E, 3, 3)
+
+
+def _backbone_vectors(coords: Tensor, mask: Tensor) -> Tuple[Tensor, Tensor]:
+    n = coords[:, 0, :]
+    ca = coords[:, 1, :]
+    c = coords[:, 2, :]
+
+    L = coords.shape[0]
+    device = coords.device
+    dtype = coords.dtype
+
+    valid = mask.to(torch.bool)
+
+    v1 = torch.zeros((L, 3), device=device, dtype=dtype)
+    v2 = torch.zeros_like(v1)
+    v3 = torch.zeros_like(v1)
+
+    valid_v1 = valid
+    valid_v2 = valid
+    valid_v3 = torch.zeros_like(valid)
+    valid_v3[:-1] = valid[:-1] & valid[1:]
+
+    if valid_v1.any():
+        v1[valid_v1] = ca[valid_v1] - n[valid_v1]
+        v1[valid_v1] = _safe_normalise(v1[valid_v1])
+    if valid_v2.any():
+        v2[valid_v2] = c[valid_v2] - ca[valid_v2]
+        v2[valid_v2] = _safe_normalise(v2[valid_v2])
+    if valid_v3.any():
+        v3[:-1][valid_v3[:-1]] = n[1:][valid_v3[:-1]] - c[:-1][valid_v3[:-1]]
+        v3[:-1][valid_v3[:-1]] = _safe_normalise(v3[:-1][valid_v3[:-1]])
+
+    v4 = torch.zeros_like(v1)
+    v5 = torch.zeros_like(v1)
+    v6 = torch.zeros_like(v1)
+
+    valid_cross = valid_v1 & valid_v2
+    if valid_cross.any():
+        v4[valid_cross] = -torch.cross(v1[valid_cross], v2[valid_cross], dim=-1)
+        v4[valid_cross] = _safe_normalise(v4[valid_cross])
+
+    valid_v5 = valid_v3 & valid_v1
+    if valid_v5.any():
+        v5[valid_v5] = torch.cross(v3[valid_v5], v1[valid_v5], dim=-1)
+        v5[valid_v5] = _safe_normalise(v5[valid_v5])
+
+    valid_v6 = valid_v2 & valid_v3
+    if valid_v6.any():
+        v6[valid_v6] = torch.cross(v2[valid_v6], v3[valid_v6], dim=-1)
+        v6[valid_v6] = _safe_normalise(v6[valid_v6])
+
+    stack = torch.stack((v1, v2, v3, v4, v5, v6), dim=1)
+    node_vectors = torch.stack((v1, v2, v4), dim=1)
+    return stack, node_vectors
+
+
+def build_node_features(backbone: BackboneRecord) -> NodeFeatures:
+    coords = backbone.coords
+    mask = backbone.mask
+
+    torsion_dict = backbone_torsions(coords)
+    phi = torsion_dict["phi"]
+    psi = torsion_dict["psi"]
+    omega = torsion_dict["omega"]
+
+    L = coords.shape[0]
+    dtype = coords.dtype
+    device = coords.device
+
+    sin_phi = torch.zeros((L,), dtype=dtype, device=device)
+    cos_phi = torch.zeros_like(sin_phi)
+    sin_psi = torch.zeros_like(sin_phi)
+    cos_psi = torch.zeros_like(sin_phi)
+    sin_omega = torch.zeros_like(sin_phi)
+    cos_omega = torch.zeros_like(sin_phi)
+
+    valid_phi = torch.zeros((L,), dtype=torch.bool, device=device)
+    valid_phi[1:] = mask[:-1] & mask[1:]
+
+    valid_psi = torch.zeros_like(valid_phi)
+    valid_psi[:-1] = mask[:-1] & mask[1:]
+
+    valid_omega = valid_psi.clone()
+
+    sin_phi[valid_phi] = torch.sin(phi[valid_phi])
+    cos_phi[valid_phi] = torch.cos(phi[valid_phi])
+    sin_psi[valid_psi] = torch.sin(psi[valid_psi])
+    cos_psi[valid_psi] = torch.cos(psi[valid_psi])
+    sin_omega[valid_omega] = torch.sin(omega[valid_omega])
+    cos_omega[valid_omega] = torch.cos(omega[valid_omega])
+
+    scalars = torch.stack(
+        (sin_phi, cos_phi, sin_psi, cos_psi, sin_omega, cos_omega),
+        dim=-1,
+    )
+
+    backbone_vectors, node_vectors = _backbone_vectors(coords, mask)
+    torsions = torch.stack((phi, psi, omega), dim=-1)
+
+    return NodeFeatures(
+        scalars=scalars,
+        vectors=node_vectors,
+        backbone_vectors=backbone_vectors,
+        torsions=torsions,
+    )
+
+
+def _sequence_edges(mask: Tensor) -> Tensor:
+    if mask.numel() < 2:
+        return torch.empty((2, 0), dtype=torch.long)
+
+    valid = mask.to(torch.bool)
+    src = torch.arange(mask.numel() - 1, dtype=torch.long)
+    dst = src + 1
+    valid_pairs = valid[:-1] & valid[1:]
+    src = src[valid_pairs]
+    dst = dst[valid_pairs]
+
+    edges = torch.stack((src, dst), dim=0)
+    rev = torch.stack((dst, src), dim=0)
+    if edges.numel() == 0:
+        return torch.empty((2, 0), dtype=torch.long)
+    return torch.cat((edges, rev), dim=1)
+
+
+def _knn_edges(ca: Tensor, mask: Tensor, k: int) -> Tensor:
+    valid_idx = torch.nonzero(mask, as_tuple=False).squeeze(-1)
+    if valid_idx.numel() <= 1:
+        return torch.empty((2, 0), dtype=torch.long, device=ca.device)
+
+    positions = ca[valid_idx]
+    distances = torch.cdist(positions, positions, p=2)
+
+    k = min(k, max(positions.shape[0] - 1, 0))
+    if k == 0:
+        return torch.empty((2, 0), dtype=torch.long, device=ca.device)
+
+    topk = torch.topk(-distances, k=k + 1, dim=-1).indices
+
+    src_list = []
+    dst_list = []
+    for row, idx in enumerate(valid_idx):
+        neighbours = topk[row]
+        neighbours = neighbours[neighbours != row][:k]
+        if neighbours.numel() == 0:
+            continue
+        src_nodes = idx.repeat(neighbours.numel())
+        dst_nodes = valid_idx[neighbours]
+        src_list.append(src_nodes)
+        dst_list.append(dst_nodes)
+
+    if not src_list:
+        return torch.empty((2, 0), dtype=torch.long, device=ca.device)
+
+    src = torch.cat(src_list, dim=0)
+    dst = torch.cat(dst_list, dim=0)
+    edges = torch.stack((src, dst), dim=0)
+    rev = torch.stack((dst, src), dim=0)
+    return torch.cat((edges, rev), dim=1)
+
+
+def build_edge_features(
+    backbone: BackboneRecord,
+    *,
+    k: int = 16,
+) -> EdgeFeatures:
+    ca = backbone.coords[:, 1, :]
+    mask = backbone.atom_mask[:, 1]
+
+    knn = _knn_edges(ca, mask, k)
+    seq_edges = _sequence_edges(mask)
+
+    edge_index = torch.cat((knn, seq_edges), dim=1) if knn.numel() else seq_edges
+    if edge_index.numel():
+        edge_index = edge_index.unique(dim=1)
+
+    if edge_index.numel() == 0:
+        return EdgeFeatures(
+            edge_index=edge_index,
+            scalars=torch.empty((0, 8), dtype=ca.dtype),
+            vectors=torch.empty((0, 3), dtype=ca.dtype),
+            frames=torch.empty((0, 3, 3), dtype=ca.dtype),
+        )
+
+    src, dst = edge_index
+    disp = ca[dst] - ca[src]
+    distances = torch.linalg.norm(disp, dim=-1)
+    centres = RBF_CENTRES.to(device=ca.device, dtype=ca.dtype)
+    scalars = _rbf(distances, centres, RBF_SIGMA)
+    vectors = disp
+    frames = build_local_frames(ca, edge_index, mask=mask)
+
+    return EdgeFeatures(
+        edge_index=edge_index,
+        scalars=scalars,
+        vectors=vectors,
+        frames=frames,
+    )
+
+
+def featurize_backbone(backbone: BackboneRecord, *, k: int = 16) -> Dict[str, Tensor]:
+    node = build_node_features(backbone)
+    edge = build_edge_features(backbone, k=k)
+
+    return {
+        "node_scalars": node.scalars,
+        "node_vectors": node.vectors,
+        "backbone_vectors": node.backbone_vectors,
+        "torsion_angles": node.torsions,
+        "edge_index": edge.edge_index,
+        "edge_scalars": edge.scalars,
+        "edge_vectors": edge.vectors,
+        "edge_frames": edge.frames,
+    }
+
+
+__all__ = [
+    "NodeFeatures",
+    "EdgeFeatures",
+    "build_node_features",
+    "build_edge_features",
+    "featurize_backbone",
+]

--- a/src/gcpvqvae/data/mmcif.py
+++ b/src/gcpvqvae/data/mmcif.py
@@ -1,13 +1,373 @@
-"""Utilities for reading and writing mmCIF structures."""
+"""Utilities for reading and writing mmCIF structures.
+
+This module provides a small, Torch-friendly representation of protein
+backbone chains together with helpers to read mmCIF files.  Only the atoms
+required by the GCP-VQVAE model (backbone N, CA and C) are extracted; all
+other data are ignored.  The reader prefers :mod:`gemmi` but falls back to
+Biopython when the former is unavailable.
+"""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
-def load_mmcif(path: str):
-    """Load an mmCIF file into an intermediate representation (stub)."""
-    raise NotImplementedError("load_mmcif is not yet implemented")
+import torch
+
+Tensor = torch.Tensor
+
+try:  # pragma: no cover - exercised in integration tests
+    import gemmi
+except Exception:  # pragma: no cover - gemmi is an optional dependency
+    gemmi = None
+
+try:  # pragma: no cover - exercised in integration tests
+    from Bio.PDB.MMCIFParser import MMCIFParser  # type: ignore
+except Exception:  # pragma: no cover - Biopython is optional
+    MMCIFParser = None
 
 
-def write_mmcif(data, path: str) -> None:
-    """Write an intermediate representation back to mmCIF (stub)."""
-    raise NotImplementedError("write_mmcif is not yet implemented")
+AA_ALPHABET = "ACDEFGHIKLMNPQRSTVWY"
+AA_TO_INDEX: Dict[str, int] = {aa: i for i, aa in enumerate(AA_ALPHABET)}
+AA_TO_INDEX["X"] = len(AA_TO_INDEX)
+PAD_INDEX = len(AA_TO_INDEX)
+
+THREE_TO_ONE: Dict[str, str] = {
+    "ALA": "A",
+    "ARG": "R",
+    "ASN": "N",
+    "ASP": "D",
+    "CYS": "C",
+    "GLN": "Q",
+    "GLU": "E",
+    "GLY": "G",
+    "HIS": "H",
+    "ILE": "I",
+    "LEU": "L",
+    "LYS": "K",
+    "MET": "M",
+    "PHE": "F",
+    "PRO": "P",
+    "SER": "S",
+    "THR": "T",
+    "TRP": "W",
+    "TYR": "Y",
+    "VAL": "V",
+}
+
+ONE_TO_THREE: Dict[str, str] = {v: k for k, v in THREE_TO_ONE.items()}
+ONE_TO_THREE["X"] = "UNK"
+
+
+@dataclass
+class BackboneRecord:
+    """Container holding the minimal backbone information for a chain."""
+
+    path: str
+    chain_id: str
+    coords: Tensor  # (L, 3, 3)
+    mask: Tensor  # (L,)
+    atom_mask: Tensor  # (L, 3)
+    seq: Tensor  # (L,)
+    seq_string: str
+    residue_names: List[str]
+    residue_ids: List[Tuple[int, str]]
+    rotation: Tensor  # (3, 3)
+    translation: Tensor  # (3,)
+    nan_mask: Tensor  # (L,)
+
+    @property
+    def length(self) -> int:
+        return int(self.coords.shape[0])
+
+
+def _normalise_coords(coords: Tensor, mask: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    """Centralise the coordinates and return the applied rigid transform."""
+
+    ca_mask = mask.to(torch.bool)
+    ca_positions = coords[:, 1, :]
+    if ca_mask.any():
+        centroid = ca_positions[ca_mask].mean(dim=0)
+    else:
+        centroid = ca_positions.mean(dim=0)
+    coords = coords - centroid.view(1, 1, 3)
+    rotation = torch.eye(3, dtype=coords.dtype, device=coords.device)
+    return coords, rotation, centroid
+
+
+def _load_with_gemmi(path: Path, *, length_cap: int, chain_id: Optional[str]) -> List[BackboneRecord]:
+    if gemmi is None:
+        return []
+
+    doc = gemmi.cif.read_file(str(path))
+    block = doc.sole_block()
+    structure = gemmi.make_structure_from_block(block)
+    structure.setup_entities()
+    records: List[BackboneRecord] = []
+
+    for model in structure:
+        for chain in model:
+            if chain_id is not None and chain.name != chain_id:
+                continue
+            coords_list: List[List[float]] = []
+            mask_list: List[bool] = []
+            atom_mask_list: List[List[bool]] = []
+            seq_indices: List[int] = []
+            seq_chars: List[str] = []
+            residue_names: List[str] = []
+            residue_ids: List[Tuple[int, str]] = []
+
+            residues = list(chain.get_polymer())
+            if not residues:
+                continue
+
+            if length_cap and len(residues) > length_cap:
+                residues = residues[:length_cap]
+
+            for residue in residues:
+                three_letter = residue.name.upper()
+                one_letter = THREE_TO_ONE.get(three_letter, "X")
+                seq_chars.append(one_letter)
+                seq_indices.append(AA_TO_INDEX.get(one_letter, AA_TO_INDEX["X"]))
+                residue_names.append(three_letter)
+                residue_ids.append((residue.seqid.num, residue.seqid.icode))
+
+                atom_coords = {
+                    "N": (None, -float("inf")),
+                    "CA": (None, -float("inf")),
+                    "C": (None, -float("inf")),
+                }
+
+                for atom in residue:
+                    name = atom.name.strip()
+                    if name not in atom_coords:
+                        continue
+                    occupancy = atom.occ
+                    if occupancy < atom_coords[name][1]:
+                        continue
+                    atom_coords[name] = ((atom.pos.x, atom.pos.y, atom.pos.z), occupancy)
+
+                coords_row: List[List[float]] = []
+                atom_mask = []
+                for atom_name in ("N", "CA", "C"):
+                    pos, occ = atom_coords[atom_name]
+                    if pos is None:
+                        coords_row.append([0.0, 0.0, 0.0])
+                        atom_mask.append(False)
+                    else:
+                        coords_row.append(list(pos))
+                        atom_mask.append(True)
+
+                coords_list.append(coords_row)
+                atom_mask_list.append(atom_mask)
+                mask_list.append(all(atom_mask))
+
+            coords = torch.tensor(coords_list, dtype=torch.float32)
+            mask = torch.tensor(mask_list, dtype=torch.bool)
+            atom_mask = torch.tensor(atom_mask_list, dtype=torch.bool)
+            seq = torch.tensor(seq_indices, dtype=torch.long)
+            nan_mask = torch.zeros((coords.shape[0],), dtype=torch.bool)
+
+            coords, rotation, translation = _normalise_coords(coords, atom_mask[:, 1])
+
+            record = BackboneRecord(
+                path=str(path),
+                chain_id=chain.name,
+                coords=coords,
+                mask=mask,
+                atom_mask=atom_mask,
+                seq=seq,
+                seq_string="".join(seq_chars),
+                residue_names=residue_names,
+                residue_ids=residue_ids,
+                rotation=rotation,
+                translation=translation,
+                nan_mask=nan_mask,
+            )
+            records.append(record)
+
+        if records:
+            break
+
+    if chain_id is not None:
+        records = [record for record in records if record.chain_id == chain_id]
+    return records
+
+
+def _load_with_biopython(path: Path, *, length_cap: int, chain_id: Optional[str]) -> List[BackboneRecord]:
+    if MMCIFParser is None:
+        return []
+
+    parser = MMCIFParser(QUIET=True)
+    structure = parser.get_structure("structure", str(path))
+    records: List[BackboneRecord] = []
+
+    for model in structure:
+        for chain in model:
+            if chain_id is not None and chain.id != chain_id:
+                continue
+
+            residues = [res for res in chain if res.id[0] == " "]
+            if not residues:
+                continue
+
+            if length_cap and len(residues) > length_cap:
+                residues = residues[:length_cap]
+
+            coords_list: List[List[float]] = []
+            mask_list: List[bool] = []
+            atom_mask_list: List[List[bool]] = []
+            seq_indices: List[int] = []
+            seq_chars: List[str] = []
+            residue_names: List[str] = []
+            residue_ids: List[Tuple[int, str]] = []
+
+            for residue in residues:
+                three_letter = residue.resname.upper()
+                one_letter = THREE_TO_ONE.get(three_letter, "X")
+                seq_chars.append(one_letter)
+                seq_indices.append(AA_TO_INDEX.get(one_letter, AA_TO_INDEX["X"]))
+                residue_names.append(three_letter)
+                residue_ids.append((residue.id[1], residue.id[2].strip()))
+
+                coords_row: List[List[float]] = []
+                atom_mask = []
+                for atom_name in ("N", "CA", "C"):
+                    atom = residue.child_dict.get(atom_name)
+                    if atom is None:
+                        coords_row.append([0.0, 0.0, 0.0])
+                        atom_mask.append(False)
+                    else:
+                        coords_row.append(atom.coord.tolist())
+                        atom_mask.append(True)
+
+                coords_list.append(coords_row)
+                atom_mask_list.append(atom_mask)
+                mask_list.append(all(atom_mask))
+
+            coords = torch.tensor(coords_list, dtype=torch.float32)
+            mask = torch.tensor(mask_list, dtype=torch.bool)
+            atom_mask = torch.tensor(atom_mask_list, dtype=torch.bool)
+            seq = torch.tensor(seq_indices, dtype=torch.long)
+            nan_mask = torch.zeros((coords.shape[0],), dtype=torch.bool)
+
+            coords, rotation, translation = _normalise_coords(coords, atom_mask[:, 1])
+
+            record = BackboneRecord(
+                path=str(path),
+                chain_id=chain.id,
+                coords=coords,
+                mask=mask,
+                atom_mask=atom_mask,
+                seq=seq,
+                seq_string="".join(seq_chars),
+                residue_names=residue_names,
+                residue_ids=residue_ids,
+                rotation=rotation,
+                translation=translation,
+                nan_mask=nan_mask,
+            )
+            records.append(record)
+
+        if records:
+            break
+
+    if chain_id is not None:
+        records = [record for record in records if record.chain_id == chain_id]
+    return records
+
+
+def load_mmcif(
+    path: str,
+    *,
+    chain_id: Optional[str] = None,
+    length_cap: int = 2048,
+) -> List[BackboneRecord]:
+    """Load backbone coordinates for all qualifying chains in ``path``.
+
+    Parameters
+    ----------
+    path:
+        File system path to an mmCIF file.
+    chain_id:
+        Optional chain identifier.  When provided the returned list only
+        contains the corresponding chain.
+    length_cap:
+        Maximum number of residues to keep.  Chains longer than ``length_cap``
+        are truncated to that length.
+    """
+
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise FileNotFoundError(path)
+
+    records = _load_with_gemmi(path_obj, length_cap=length_cap, chain_id=chain_id)
+    if not records:
+        records = _load_with_biopython(path_obj, length_cap=length_cap, chain_id=chain_id)
+
+    if chain_id is not None and not records:
+        raise KeyError(f"Chain {chain_id!r} not found in {path}")
+
+    return records
+
+
+def write_mmcif(record: BackboneRecord, path: str) -> None:
+    """Serialise a :class:`BackboneRecord` back to an mmCIF file."""
+
+    if gemmi is None:
+        raise RuntimeError("Writing mmCIF files requires the gemmi package")
+
+    coords = record.coords
+    rotation = record.rotation
+    translation = record.translation
+
+    transformed = coords @ rotation.T + translation.view(1, 1, 3)
+
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(10.0, 10.0, 10.0, 90.0, 90.0, 90.0)
+    model = gemmi.Model("0")
+    chain = gemmi.Chain(record.chain_id or "A")
+
+    for idx in range(record.length):
+        if not record.mask[idx] or (record.nan_mask[idx] if record.nan_mask.numel() else False):
+            continue
+        residue = gemmi.Residue()
+        residue.name = record.residue_names[idx] if idx < len(record.residue_names) else "UNK"
+        seqid = gemmi.SeqId()
+        seqid.num, seqid.icode = record.residue_ids[idx] if idx < len(record.residue_ids) else (idx + 1, "")
+        residue.seqid = seqid
+        residue.het_flag = " "
+
+        for atom_name, atom_idx in zip(("N", "CA", "C"), range(3)):
+            if idx < record.atom_mask.shape[0] and not record.atom_mask[idx, atom_idx]:
+                continue
+            atom = gemmi.Atom()
+            atom.name = atom_name
+            atom.pos = gemmi.Position(*transformed[idx, atom_idx].tolist())
+            atom.occ = 1.0
+            atom.b_iso = 0.0
+            residue.add_atom(atom)
+
+        if residue:
+            chain.add_residue(residue)
+
+    if not chain:
+        raise ValueError("Cannot write empty chain")
+
+    model.add_chain(chain)
+    structure.add_model(model)
+    structure.setup_entities()
+
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+
+__all__ = [
+    "AA_ALPHABET",
+    "AA_TO_INDEX",
+    "PAD_INDEX",
+    "BackboneRecord",
+    "load_mmcif",
+    "write_mmcif",
+]

--- a/src/gcpvqvae/geometry/frames.py
+++ b/src/gcpvqvae/geometry/frames.py
@@ -1,13 +1,228 @@
-"""Local frame utilities and alignment helpers."""
+"""Local frame utilities and alignment helpers.
+
+This module purposefully contains only lightweight tensor operations so that it
+can be reused by both the data pipeline (to build per-edge frames) and the loss
+functions (for alignment aware reconstruction losses).  The functions operate on
+PyTorch tensors because the rest of the project is implemented in PyTorch and
+automatic differentiation through some of the primitives – most notably the
+Kabsch alignment routine – is occasionally useful when computing auxiliary
+metrics during training.
+"""
 
 from __future__ import annotations
 
+from typing import Optional, Tuple
 
-def build_local_frames(backbone):
-    """Construct residue-centered local frames (stub)."""
-    raise NotImplementedError("build_local_frames is not yet implemented")
+import torch
+
+Tensor = torch.Tensor
 
 
-def kabsch_align(src, dst):
-    """Run the Kabsch algorithm for optimal rotation (stub)."""
-    raise NotImplementedError("kabsch_align is not yet implemented")
+def _normalize(vec: Tensor, eps: float = 1e-8) -> Tensor:
+    """Return a safely normalised version of ``vec``.
+
+    ``vec`` is assumed to be a floating point tensor whose final dimension
+    contains the vector components.  Norms that would underflow are clamped so
+    that zero-vectors are mapped to themselves.
+    """
+
+    norm = torch.linalg.norm(vec, dim=-1, keepdim=True)
+    norm = torch.clamp(norm, min=eps)
+    return vec / norm
+
+
+def _orthonormal_vector(vec: Tensor) -> Tensor:
+    """Return an arbitrary vector orthogonal to ``vec``.
+
+    The implementation mirrors the strategy commonly used in graphics: select
+    the axis with the smallest magnitude component and subtract the projection
+    of the corresponding basis vector.  The function is fully vectorised and can
+    operate on batches of vectors.
+    """
+
+    batch_shape = vec.shape[:-1]
+    out = torch.zeros_like(vec)
+    abs_vec = torch.abs(vec)
+    # Choose the axis with the smallest absolute value to avoid degeneracy.
+    indices = torch.argmin(abs_vec, dim=-1, keepdim=True)
+    out.scatter_(-1, indices, 1.0)
+    out = out - (out * vec).sum(dim=-1, keepdim=True) * vec
+    return _normalize(out)
+
+
+def build_local_frames(
+    ca_positions: Tensor,
+    edge_index: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+    eps: float = 1e-6,
+) -> Tensor:
+    """Construct a right-handed orthonormal frame for each directed edge.
+
+    Parameters
+    ----------
+    ca_positions:
+        Tensor of shape ``(L, 3)`` containing Cα coordinates for a single
+        protein chain.
+    edge_index:
+        Long tensor of shape ``(2, E)`` specifying the directed edges.  The
+        convention follows PyTorch Geometric where ``edge_index[0]`` are source
+        indices and ``edge_index[1]`` the corresponding destinations.
+    mask:
+        Optional boolean mask of shape ``(L,)`` marking valid residues.  Frames
+        touching masked residues are set to the identity matrix so they can be
+        ignored by downstream modules.
+    eps:
+        Numerical stability constant.
+
+    Returns
+    -------
+    Tensor of shape ``(E, 3, 3)`` where each slice is a rotation matrix whose
+    first column is the unit edge direction, the second column captures the
+    locally-biased normal (projected into the edge-orthogonal plane) and the
+    third column completes the right-handed triad via a cross product.
+    """
+
+    if ca_positions.ndim != 2 or ca_positions.size(-1) != 3:
+        raise ValueError("ca_positions must be of shape (L, 3)")
+    if edge_index.ndim != 2 or edge_index.size(0) != 2:
+        raise ValueError("edge_index must have shape (2, E)")
+
+    src, dst = edge_index
+    if src.numel() == 0:
+        return torch.empty((0, 3, 3), device=ca_positions.device, dtype=ca_positions.dtype)
+
+    edge_vec = ca_positions[dst] - ca_positions[src]
+    tangent = _normalize(edge_vec, eps)
+
+    # Compute neighbourhood averages for bias vectors.
+    num_nodes = ca_positions.shape[0]
+    device = ca_positions.device
+    dtype = ca_positions.dtype
+
+    neighbour_sum = torch.zeros((num_nodes, 3), device=device, dtype=dtype)
+    neighbour_count = torch.zeros((num_nodes, 1), device=device, dtype=dtype)
+    neighbour_unit = tangent
+    neighbour_sum.index_add_(0, src, neighbour_unit)
+    neighbour_count.index_add_(0, src, torch.ones_like(neighbour_count[src]))
+
+    # Prepare fallback axes once to avoid repeated allocations in the loop.
+    fallback_axis = torch.tensor([0.0, 0.0, 1.0], device=device, dtype=dtype)
+    fallback_alt_axis = torch.tensor([1.0, 0.0, 0.0], device=device, dtype=dtype)
+
+    bias_vectors = neighbour_sum[src] - neighbour_unit
+    denom = torch.clamp(neighbour_count[src] - 1.0, min=1.0)
+    bias_vectors = bias_vectors / denom
+
+    # Project the bias into the plane orthogonal to the tangent.
+    proj = bias_vectors - (bias_vectors * tangent).sum(dim=-1, keepdim=True) * tangent
+
+    needs_fallback = torch.linalg.norm(proj, dim=-1, keepdim=True) <= eps
+    if needs_fallback.any():
+        fallback = fallback_axis.expand_as(proj)
+        fallback = fallback - (fallback * tangent).sum(dim=-1, keepdim=True) * tangent
+        still_degenerate = torch.linalg.norm(fallback, dim=-1, keepdim=True) <= eps
+        if still_degenerate.any():
+            fallback2 = fallback_alt_axis.expand_as(proj)
+            fallback2 = fallback2 - (fallback2 * tangent).sum(dim=-1, keepdim=True) * tangent
+            fallback = torch.where(still_degenerate, fallback2, fallback)
+        proj = torch.where(needs_fallback, fallback, proj)
+
+    normal = _normalize(proj, eps)
+    binormal = _normalize(torch.cross(tangent, normal, dim=-1), eps)
+
+    normal = _normalize(torch.cross(binormal, tangent, dim=-1), eps)
+    binormal = torch.cross(tangent, normal, dim=-1)
+
+    frames = torch.stack((tangent, normal, binormal), dim=-1)
+
+    if mask is not None:
+        mask = mask.to(torch.bool)
+        valid = mask[src] & mask[dst]
+        identity = torch.eye(3, device=device, dtype=dtype).expand_as(frames)
+        frames = torch.where(valid.view(-1, 1, 1), frames, identity)
+
+    return frames
+
+
+def kabsch_align(
+    src: Tensor,
+    dst: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+    allow_reflections: bool = False,
+    return_aligned: bool = False,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """Compute the optimal rigid transform aligning ``src`` onto ``dst``.
+
+    Parameters
+    ----------
+    src, dst:
+        Tensors of shape ``(N, 3)`` describing two point clouds.  The function
+        accepts any floating point dtype supported by :mod:`torch`.
+    mask:
+        Optional boolean tensor of shape ``(N,)`` marking valid correspondences.
+    allow_reflections:
+        If ``False`` (default) the returned rotation always has determinant +1;
+        in the rare event that the optimal transform contains a reflection we
+        flip the last singular vector as described in the original Kabsch
+        publication.
+    return_aligned:
+        When ``True`` the aligned source coordinates are returned as the third
+        element of the tuple.
+
+    Returns
+    -------
+    rotation, translation[, aligned]
+        ``rotation`` has shape ``(3, 3)`` and ``translation`` has shape ``(3,)``.
+        If ``return_aligned`` is ``True`` the third element is the aligned source
+        coordinates of shape ``(N, 3)``.
+    """
+
+    if src.shape != dst.shape:
+        raise ValueError("src and dst must have the same shape")
+    if src.ndim != 2 or src.size(-1) != 3:
+        raise ValueError("src and dst must be of shape (N, 3)")
+
+    if mask is not None:
+        if mask.shape != src.shape[:1]:
+            raise ValueError("mask must have shape (N,)")
+        mask = mask.to(torch.bool)
+        if mask.sum() < 3:
+            raise ValueError("At least three points are required for alignment")
+        src_sel = src[mask]
+        dst_sel = dst[mask]
+    else:
+        src_sel = src
+        dst_sel = dst
+
+    src_mean = src_sel.mean(dim=0)
+    dst_mean = dst_sel.mean(dim=0)
+
+    src_centered = src_sel - src_mean
+    dst_centered = dst_sel - dst_mean
+
+    cov = src_centered.transpose(0, 1) @ dst_centered
+
+    u, _, vh = torch.linalg.svd(cov, full_matrices=False)
+    rotation = u @ vh
+
+    if not allow_reflections:
+        det = torch.linalg.det(rotation)
+        if det < 0:
+            vh = vh.clone()
+            vh[-1, :] *= -1
+            rotation = u @ vh
+
+    translation = dst_mean - src_mean @ rotation
+
+    aligned: Optional[Tensor]
+    if return_aligned:
+        aligned = (src @ rotation) + translation
+    else:
+        aligned = None
+
+    return rotation, translation, aligned
+
+
+__all__ = ["build_local_frames", "kabsch_align"]

--- a/src/gcpvqvae/geometry/metrics.py
+++ b/src/gcpvqvae/geometry/metrics.py
@@ -2,12 +2,88 @@
 
 from __future__ import annotations
 
+from typing import Optional
 
-def rmsd(coords_a, coords_b):
-    """Compute backbone RMSD (stub)."""
-    raise NotImplementedError("rmsd is not yet implemented")
+import torch
+
+Tensor = torch.Tensor
 
 
-def tm_score(coords_a, coords_b):
-    """Approximate TM-score for backbones (stub)."""
-    raise NotImplementedError("tm_score is not yet implemented")
+def rmsd(coords_a: Tensor, coords_b: Tensor, *, mask: Optional[Tensor] = None) -> Tensor:
+    """Compute the root-mean-square deviation between two coordinate sets.
+
+    Parameters
+    ----------
+    coords_a, coords_b:
+        Tensors containing matching coordinates.  The tensors can either be of
+        shape ``(..., 3)`` or ``(..., 3, 3)`` (for three backbone atoms).  The
+        function operates element-wise on the leading dimensions.
+    mask:
+        Optional boolean mask whose ``True`` entries mark valid residues.  The
+        mask is broadcast against the leading dimensions of the coordinate
+        tensors.
+    """
+
+    if coords_a.shape != coords_b.shape:
+        raise ValueError("coords_a and coords_b must have identical shapes")
+
+    diff = coords_a - coords_b
+    if diff.size(-2) == 3 and diff.ndim >= 3:
+        # Flatten atom dimension.
+        diff = diff.reshape(*diff.shape[:-2], -1)
+    else:
+        diff = diff.reshape(*diff.shape[:-1], -1)
+
+    if mask is not None:
+        mask = mask.to(diff.dtype)
+        mask = mask.reshape(*mask.shape, *([1] * (diff.ndim - mask.ndim)))
+        diff = diff * mask
+        valid = mask.sum()
+        denom = torch.clamp(valid * diff.shape[-1], min=1.0)
+    else:
+        denom = float(diff.numel())
+
+    mse = (diff**2).sum() / denom
+    return torch.sqrt(mse)
+
+
+def tm_score(
+    coords_a: Tensor,
+    coords_b: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+    length_scale: Optional[float] = None,
+) -> Tensor:
+    """Compute an approximate TM-score between two aligned structures.
+
+    The implementation follows the standard TM-score formulation operating on
+    the per-residue Cα coordinates.  The caller is expected to align the
+    structures beforehand (for example via :func:`gcpvqvae.geometry.frames.kabsch_align`).
+    """
+
+    if coords_a.shape != coords_b.shape:
+        raise ValueError("coords_a and coords_b must have identical shapes")
+    if coords_a.size(-2) != 3:
+        raise ValueError("Inputs must contain backbone atoms with shape (..., 3, 3)")
+
+    ca_a = coords_a[..., 1, :]
+    ca_b = coords_b[..., 1, :]
+    diff = torch.linalg.norm(ca_a - ca_b, dim=-1)
+
+    if mask is not None:
+        mask = mask.to(torch.bool)
+        diff = diff[mask]
+
+    L = diff.numel()
+    if L == 0:
+        return torch.tensor(0.0, dtype=coords_a.dtype, device=coords_a.device)
+
+    if length_scale is None:
+        length_scale = 1.24 * (L - 15) ** (1 / 3) - 1.8
+        length_scale = float(torch.clamp(torch.tensor(length_scale, dtype=coords_a.dtype), min=0.5))
+
+    score = (1.0 / L) * torch.sum(1.0 / (1.0 + (diff / length_scale) ** 2))
+    return score
+
+
+__all__ = ["rmsd", "tm_score"]

--- a/src/gcpvqvae/geometry/torsion.py
+++ b/src/gcpvqvae/geometry/torsion.py
@@ -2,7 +2,64 @@
 
 from __future__ import annotations
 
+from typing import Dict
 
-def backbone_torsions(backbone):
-    """Compute φ/ψ/ω torsions (stub)."""
-    raise NotImplementedError("backbone_torsions is not yet implemented")
+import torch
+
+Tensor = torch.Tensor
+
+
+def _dihedral(p0: Tensor, p1: Tensor, p2: Tensor, p3: Tensor) -> Tensor:
+    """Return the signed dihedral angle for four sets of points."""
+
+    b0 = p1 - p0
+    b1 = p2 - p1
+    b2 = p3 - p2
+
+    b1_norm = torch.linalg.norm(b1, dim=-1, keepdim=True)
+    b1_norm = torch.clamp(b1_norm, min=1e-8)
+    b1_unit = b1 / b1_norm
+
+    v = b0 - (b0 * b1_unit).sum(dim=-1, keepdim=True) * b1_unit
+    w = b2 - (b2 * b1_unit).sum(dim=-1, keepdim=True) * b1_unit
+
+    x = (v * w).sum(dim=-1)
+    y = (torch.cross(b1_unit, v, dim=-1) * w).sum(dim=-1)
+
+    angle = torch.atan2(y, x)
+    return angle
+
+
+def backbone_torsions(backbone: Tensor) -> Dict[str, Tensor]:
+    """Compute φ, ψ and ω torsions for an ``(L, 3, 3)`` backbone tensor.
+
+    Missing angles (because the required atoms are unavailable) are filled with
+    zeros which keeps the function convenient to use when creating feature
+    tensors.  The caller can always infer validity by checking which residues are
+    interior to the chain.
+    """
+
+    if backbone.ndim != 3 or backbone.shape[1:] != (3, 3):
+        raise ValueError("backbone must have shape (L, 3, 3)")
+
+    n = backbone[:, 0, :]
+    ca = backbone[:, 1, :]
+    c = backbone[:, 2, :]
+
+    L = backbone.shape[0]
+    dtype = backbone.dtype
+    device = backbone.device
+
+    phi = torch.zeros((L,), dtype=dtype, device=device)
+    psi = torch.zeros((L,), dtype=dtype, device=device)
+    omega = torch.zeros((L,), dtype=dtype, device=device)
+
+    if L >= 2:
+        phi[1:] = _dihedral(c[:-1], n[1:], ca[1:], c[1:])
+        psi[:-1] = _dihedral(n[:-1], ca[:-1], c[:-1], n[1:])
+        omega[:-1] = _dihedral(ca[:-1], c[:-1], n[1:], ca[1:])
+
+    return {"phi": phi, "psi": psi, "omega": omega}
+
+
+__all__ = ["backbone_torsions"]

--- a/src/gcpvqvae/models/decoder.py
+++ b/src/gcpvqvae/models/decoder.py
@@ -2,16 +2,139 @@
 
 from __future__ import annotations
 
+from typing import Optional, Tuple
+
 import torch
-from torch import nn
+from torch import Tensor, nn
+
+
+def _normalize(vec: Tensor, eps: float = 1e-8) -> Tensor:
+    norm = torch.linalg.norm(vec, dim=-1, keepdim=True)
+    return vec / torch.clamp(norm, min=eps)
 
 
 class RotationDecoder(nn.Module):
-    """Placeholder 6D rotation decoder head."""
+    """6D rotation decoder head operating on transformer outputs.
 
-    def __init__(self) -> None:
+    The module implements the rigid-body update described in Algorithm 1 of the
+    GCP-VQVAE manuscript.  Given a stream of latent vectors it predicts per-step
+    rotation and translation updates which are accumulated to reconstruct the
+    backbone coordinates from an idealised local template.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        *,
+        translation_scale: float = 1.0,
+        template: Optional[Tensor] = None,
+    ) -> None:
         super().__init__()
-        raise NotImplementedError("RotationDecoder needs implementation")
 
-    def forward(self, *args, **kwargs):
-        raise NotImplementedError
+        self.in_dim = in_dim
+        self.translation_scale = translation_scale
+        self.proj = nn.Linear(in_dim, 9, bias=True)
+
+        if template is None:
+            # Idealised backbone geometry (Å).  The coordinates are centred so
+            # that the Cα atom sits at the origin which improves numerical
+            # stability when composing transforms.
+            template = torch.tensor(
+                [
+                    [-0.525, 0.000, 0.000],  # N
+                    [0.000, 0.000, 0.000],   # Cα
+                    [0.626, 0.000, 0.000],   # C
+                ]
+            )
+        self.register_buffer("template", template, persistent=False)
+
+    def forward(
+        self,
+        latents: Tensor,
+        *,
+        mask: Optional[Tensor] = None,
+        init_pose: Optional[Tuple[Tensor, Tensor]] = None,
+    ) -> Tuple[Tensor, Tuple[Tensor, Tensor]]:
+        """Decode latent representations into backbone coordinates.
+
+        Parameters
+        ----------
+        latents:
+            Tensor of shape ``(batch, length, in_dim)``.
+        mask:
+            Optional boolean mask of shape ``(batch, length)``.  Masked positions
+            are ignored and their coordinates are filled with zeros.
+        init_pose:
+            Optional tuple ``(R, t)`` providing the initial rigid transform for
+            each sequence in the batch.  ``R`` has shape ``(batch, 3, 3)`` and
+            ``t`` has shape ``(batch, 3)``.
+        """
+
+        if latents.ndim != 3:
+            raise ValueError("latents must have shape (batch, length, dim)")
+
+        batch, length, _ = latents.shape
+        device = latents.device
+        dtype = latents.dtype
+
+        if mask is None:
+            mask = torch.ones((batch, length), dtype=torch.bool, device=device)
+        else:
+            mask = mask.to(torch.bool)
+
+        if init_pose is None:
+            R = torch.eye(3, device=device, dtype=dtype).expand(batch, 3, 3).clone()
+            t = torch.zeros((batch, 3), device=device, dtype=dtype)
+        else:
+            R, t = init_pose
+            if R.shape != (batch, 3, 3) or t.shape != (batch, 3):
+                raise ValueError("Initial pose must match batch dimensions")
+            R = R.clone()
+            t = t.clone()
+
+        out_coords = []
+
+        projected = self.proj(latents)
+        translation, vec_a, vec_b = torch.split(projected, 3, dim=-1)
+
+        for idx in range(length):
+            active = mask[:, idx].view(batch, 1)
+            if not active.any():
+                out_coords.append(torch.zeros((batch, 3, 3), device=device, dtype=dtype))
+                continue
+
+            a = _normalize(vec_a[:, idx, :], eps=1e-6)
+            b_raw = vec_b[:, idx, :]
+            b = b_raw - (a * b_raw).sum(dim=-1, keepdim=True) * a
+            needs_fallback = torch.linalg.norm(b, dim=-1, keepdim=True) < 1e-6
+            if needs_fallback.any():
+                fallback = torch.zeros((batch, 3), device=device, dtype=dtype)
+                fallback[:, 1] = 1.0
+                fallback = fallback - (fallback * a).sum(dim=-1, keepdim=True) * a
+                b = torch.where(needs_fallback, fallback, b)
+            b = _normalize(b, eps=1e-6)
+            c = torch.cross(a, b, dim=-1)
+            c = _normalize(c, eps=1e-6)
+            b = torch.cross(c, a, dim=-1)
+
+            R_local = torch.stack((a, b, c), dim=-1)  # (batch, 3, 3)
+
+            t_local = self.translation_scale * translation[:, idx, :]
+
+            R_candidate = R @ R_local
+            t_candidate = (R @ t_local.unsqueeze(-1)).squeeze(-1) + t
+
+            coords = torch.einsum("bij,aj->bai", R_candidate, self.template) + t_candidate.unsqueeze(-2)
+
+            R = torch.where(active.view(batch, 1, 1), R_candidate, R)
+            t = torch.where(active, t_candidate, t)
+            coords = torch.where(active.view(batch, 1, 1), coords, torch.zeros_like(coords))
+            out_coords.append(coords)
+
+        stacked = torch.stack(out_coords, dim=1)
+        final_pose = (R, t)
+
+        return stacked, final_pose
+
+
+__all__ = ["RotationDecoder"]

--- a/src/gcpvqvae/models/gcpcore.py
+++ b/src/gcpvqvae/models/gcpcore.py
@@ -1,8 +1,75 @@
-"""Shared equivariant utility functions for GCP layers."""
+"""Shared SE(3)-equivariant helper utilities used by the models."""
 
 from __future__ import annotations
 
+from typing import Iterable
 
-def gated_update(*args, **kwargs):
-    """Apply scalar/vector gating (stub)."""
-    raise NotImplementedError("gated_update is not yet implemented")
+import torch
+from torch import Tensor
+
+
+def safe_norm(vec: Tensor, *, dim: int = -1, keepdim: bool = False, eps: float = 1e-8) -> Tensor:
+    """Return the L2 norm of ``vec`` clamped away from zero.
+
+    Parameters
+    ----------
+    vec:
+        Tensor containing vectors along dimension ``dim``.
+    dim:
+        Dimension containing the vector components.
+    keepdim:
+        Whether to retain ``dim`` in the returned tensor.
+    eps:
+        Minimum norm used for clamping.  This avoids divisions by zero when
+        normalising vectors in downstream modules.
+    """
+
+    norm = torch.linalg.norm(vec, dim=dim, keepdim=keepdim)
+    return torch.clamp(norm, min=eps)
+
+
+def unit(vec: Tensor, *, dim: int = -1, eps: float = 1e-8) -> Tensor:
+    """Return a safely normalised copy of ``vec``."""
+
+    return vec / safe_norm(vec, dim=dim, keepdim=True, eps=eps)
+
+
+def vector_linear(vectors: Tensor, weight: Tensor) -> Tensor:
+    """Apply a linear map over vector channels while preserving equivariance.
+
+    The function expects ``vectors`` to have shape ``(..., C_in, 3)`` and applies
+    the ``(C_out, C_in)`` matrix ``weight`` across the channel dimension without
+    mixing spatial components.  The return tensor has shape ``(..., C_out, 3)``.
+    """
+
+    if vectors.size(-1) != 3:
+        raise ValueError("vectors must store 3D components in the last dimension")
+    if weight.ndim != 2:
+        raise ValueError("weight must be a 2D matrix")
+    if vectors.size(-2) != weight.size(1):
+        raise ValueError(
+            f"Mismatched channel dimensions: expected {weight.size(1)}, "
+            f"got {vectors.size(-2)}"
+        )
+
+    return torch.einsum("oi,...ic->...oc", weight, vectors)
+
+
+def apply_gating(update: Tensor, gate: Tensor) -> Tensor:
+    """Apply row-wise gates to vector features."""
+
+    if gate.ndim != update.ndim - 1:
+        raise ValueError("Gate dimensionality must match update tensor")
+
+    expanded_gate = gate.unsqueeze(-1)
+    return update * expanded_gate
+
+
+def broadcast_param(param: Tensor, target_dims: Iterable[int]) -> Tensor:
+    """Broadcast ``param`` across ``target_dims`` trailing dimensions."""
+
+    shape = [1] * target_dims
+    return param.view(*shape, -1)
+
+
+__all__ = ["safe_norm", "unit", "vector_linear", "apply_gating", "broadcast_param"]

--- a/src/gcpvqvae/models/gcpnet.py
+++ b/src/gcpvqvae/models/gcpnet.py
@@ -1,28 +1,308 @@
-"""Graph Convolutional Point (GCP) network building blocks."""
+"""Graph Convolutional Point (GCP) encoder used by GCP-VQVAE."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Dict, Optional
+
 import torch
-from torch import nn
+from torch import Tensor, nn
+
+from .gcpcore import apply_gating, safe_norm, vector_linear
+
+
+class VectorLayerNorm(nn.Module):
+    """LayerNorm-style normalisation for vector features."""
+
+    def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(num_channels))
+
+    def forward(self, vectors: Tensor) -> Tensor:
+        if vectors.size(-1) != 3:
+            raise ValueError("VectorLayerNorm expects (..., C, 3) tensors")
+
+        norms = torch.linalg.norm(vectors, dim=-1, keepdim=True)
+        mean = norms.mean(dim=-2, keepdim=True)
+        scaled = vectors / torch.clamp(mean, min=self.eps)
+
+        shape = [1] * (scaled.ndim - 2) + [-1, 1]
+        return scaled * self.weight.view(*shape)
+
+
+def _gather_edge_vectors(
+    node_vectors: Tensor,
+    edge_index: Tensor,
+    edge_vectors: Tensor,
+    *,
+    edge_vector_channels: int,
+) -> Tensor:
+    src, _ = edge_index
+
+    node_vec = node_vectors.index_select(0, src)
+    if edge_vector_channels > 0:
+        if edge_vectors.numel() == 0:
+            edge_vec = torch.zeros(
+                (src.numel(), edge_vector_channels, 3),
+                dtype=node_vectors.dtype,
+                device=node_vectors.device,
+            )
+        else:
+            if edge_vectors.ndim == 2:
+                edge_vec = edge_vectors.unsqueeze(1)
+            else:
+                edge_vec = edge_vectors
+            if edge_vec.size(1) != edge_vector_channels:
+                raise ValueError("edge_vectors has incompatible channel dimension")
+    else:
+        edge_vec = torch.zeros(
+            (src.numel(), 0, 3),
+            dtype=node_vectors.dtype,
+            device=node_vectors.device,
+        )
+
+    combined_vectors = torch.cat((node_vec, edge_vec), dim=1)
+    return combined_vectors
 
 
 class GCPConv(nn.Module):
-    """Placeholder for the GCP convolution layer."""
+    """Single GCP convolution layer implementing Algorithm 1 from GCPNet."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        scalar_dim: int,
+        vector_dim: int,
+        *,
+        edge_scalar_dim: int,
+        edge_vector_channels: int,
+        hidden_scalar_dim: int,
+        hidden_vector_channels: int,
+        dropout: float = 0.0,
+    ) -> None:
         super().__init__()
-        raise NotImplementedError("GCPConv needs implementation")
 
-    def forward(self, *args, **kwargs):
-        raise NotImplementedError
+        self.scalar_dim = scalar_dim
+        self.vector_dim = vector_dim
+        self.edge_scalar_dim = edge_scalar_dim
+        self.edge_vector_channels = edge_vector_channels
+        self.hidden_vector_channels = hidden_vector_channels
+
+        combined_vector_dim = vector_dim + edge_vector_channels
+
+        self.scalar_norm = nn.LayerNorm(scalar_dim)
+        self.vector_norm = VectorLayerNorm(vector_dim)
+
+        self.vec_down = nn.Parameter(torch.randn(hidden_vector_channels, combined_vector_dim) * 0.02)
+        self.vec_signature = nn.Parameter(torch.randn(3, combined_vector_dim) * 0.02)
+        self.vec_up = nn.Parameter(torch.randn(vector_dim, hidden_vector_channels) * 0.02)
+
+        scalar_in_dim = scalar_dim + 9 + hidden_vector_channels + edge_scalar_dim
+
+        self.scalar_mlp = nn.Sequential(
+            nn.Linear(scalar_in_dim, hidden_scalar_dim, bias=False),
+            nn.SiLU(),
+            nn.Linear(hidden_scalar_dim, scalar_dim, bias=False),
+        )
+
+        self.gate_mlp = nn.Sequential(
+            nn.Linear(scalar_in_dim, hidden_scalar_dim, bias=False),
+            nn.SiLU(),
+            nn.Linear(hidden_scalar_dim, vector_dim, bias=False),
+        )
+
+        self.dropout = nn.Dropout(dropout)
+        self.vector_dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        node_scalars: Tensor,
+        node_vectors: Tensor,
+        edge_index: Tensor,
+        edge_scalars: Tensor,
+        edge_vectors: Tensor,
+        edge_frames: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        if node_scalars.shape[0] != node_vectors.shape[0]:
+            raise ValueError("Scalar and vector node features must align")
+
+        src, dst = edge_index
+        num_nodes = node_scalars.shape[0]
+        dtype = node_scalars.dtype
+        device = node_scalars.device
+
+        if src.numel() == 0:
+            agg_vectors = torch.zeros(
+                (num_nodes, self.hidden_vector_channels, 3), dtype=node_vectors.dtype, device=device
+            )
+            agg_q = torch.zeros((num_nodes, 9), dtype=dtype, device=device)
+            agg_norm = torch.zeros((num_nodes, self.hidden_vector_channels), dtype=dtype, device=device)
+            agg_edge = torch.zeros((num_nodes, self.edge_scalar_dim), dtype=dtype, device=device)
+            counts = torch.ones((num_nodes, 1), dtype=dtype, device=device)
+        else:
+            norm_scalars = self.scalar_norm(node_scalars)
+            norm_vectors = self.vector_norm(node_vectors)
+
+            combined_vectors = _gather_edge_vectors(
+                norm_vectors, edge_index, edge_vectors, edge_vector_channels=self.edge_vector_channels
+            )
+
+            down = vector_linear(combined_vectors, self.vec_down)
+            down_norm = safe_norm(down, dim=-1)
+
+            signature_vectors = vector_linear(combined_vectors, self.vec_signature)
+            orient = torch.einsum("eac,ebc->eab", signature_vectors, edge_frames).reshape(-1, 9)
+
+            counts = torch.zeros((num_nodes, 1), dtype=dtype, device=device)
+            counts.index_add_(0, dst, torch.ones((dst.numel(), 1), dtype=dtype, device=device))
+            counts = torch.clamp(counts, min=1.0)
+
+            agg_vectors = torch.zeros(
+                (num_nodes, self.hidden_vector_channels, 3), dtype=node_vectors.dtype, device=device
+            )
+            agg_vectors.index_add_(0, dst, down)
+            agg_vectors = agg_vectors / counts.unsqueeze(-1)
+
+            agg_q = torch.zeros((num_nodes, 9), dtype=dtype, device=device)
+            agg_q.index_add_(0, dst, orient)
+            agg_q = agg_q / counts
+
+            agg_norm = torch.zeros((num_nodes, self.hidden_vector_channels), dtype=dtype, device=device)
+            agg_norm.index_add_(0, dst, down_norm)
+            agg_norm = agg_norm / counts
+
+            if self.edge_scalar_dim > 0:
+                if edge_scalars.numel() == 0:
+                    agg_edge = torch.zeros((num_nodes, self.edge_scalar_dim), dtype=dtype, device=device)
+                else:
+                    agg_edge = torch.zeros((num_nodes, self.edge_scalar_dim), dtype=dtype, device=device)
+                    agg_edge.index_add_(0, dst, edge_scalars)
+                    agg_edge = agg_edge / counts
+            else:
+                agg_edge = torch.zeros((num_nodes, 0), dtype=dtype, device=device)
+
+            norm_scalars = norm_scalars  # retained for residual below
+
+        if src.numel() == 0:
+            norm_scalars = self.scalar_norm(node_scalars)
+
+        scalar_input = torch.cat((norm_scalars, agg_q, agg_norm, agg_edge), dim=-1)
+        scalar_update = self.scalar_mlp(scalar_input)
+        scalars_out = node_scalars + self.dropout(scalar_update)
+
+        vector_update = vector_linear(agg_vectors, self.vec_up)
+        gate = torch.sigmoid(self.gate_mlp(scalar_input))
+        gated = apply_gating(vector_update, gate)
+        vectors_out = node_vectors + self.vector_dropout(gated)
+
+        return scalars_out, vectors_out
+
+
+@dataclass
+class GCPNetConfig:
+    node_scalar_dim: int = 6
+    node_vector_dim: int = 3
+    edge_scalar_dim: int = 8
+    edge_vector_dim: int = 1
+    hidden_scalar_dim: int = 128
+    hidden_vector_dim: int = 16
+    latent_dim: int = 256
+    layers: int = 6
+    dropout: float = 0.0
+    displacement_head: bool = False
 
 
 class GCPNetEncoder(nn.Module):
-    """Placeholder for the GCPNet encoder stack."""
+    """Stack of GCP convolutional layers with scalar/vector read-out."""
 
-    def __init__(self) -> None:
+    def __init__(self, config: Optional[GCPNetConfig] = None) -> None:
         super().__init__()
-        raise NotImplementedError("GCPNetEncoder needs implementation")
 
-    def forward(self, *args, **kwargs):
-        raise NotImplementedError
+        self.config = config or GCPNetConfig()
+
+        self.scalar_proj = nn.Linear(self.config.node_scalar_dim, self.config.hidden_scalar_dim, bias=False)
+        self.vector_proj = nn.Parameter(
+            torch.randn(self.config.hidden_vector_dim, self.config.node_vector_dim) * 0.02
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                GCPConv(
+                    self.config.hidden_scalar_dim,
+                    self.config.hidden_vector_dim,
+                    edge_scalar_dim=self.config.edge_scalar_dim,
+                    edge_vector_channels=self.config.edge_vector_dim,
+                    hidden_scalar_dim=self.config.hidden_scalar_dim * 2,
+                    hidden_vector_channels=self.config.hidden_vector_dim,
+                    dropout=self.config.dropout,
+                )
+                for _ in range(self.config.layers)
+            ]
+        )
+
+        readout_dim = self.config.hidden_scalar_dim + self.config.hidden_vector_dim
+        self.readout = nn.Sequential(
+            nn.LayerNorm(readout_dim),
+            nn.Linear(readout_dim, self.config.latent_dim, bias=False),
+        )
+
+        if self.config.displacement_head:
+            self.displacement_head = nn.Sequential(
+                nn.LayerNorm(self.config.hidden_scalar_dim),
+                nn.Linear(self.config.hidden_scalar_dim, self.config.hidden_scalar_dim, bias=False),
+                nn.SiLU(),
+                nn.Linear(self.config.hidden_scalar_dim, 3, bias=False),
+            )
+        else:
+            self.displacement_head = None
+
+    def forward(
+        self,
+        node_scalars: Tensor,
+        node_vectors: Tensor,
+        edge_index: Tensor,
+        edge_scalars: Tensor,
+        edge_vectors: Tensor,
+        edge_frames: Tensor,
+        *,
+        mask: Optional[Tensor] = None,
+    ) -> Dict[str, Tensor]:
+        if node_scalars.ndim != 2:
+            raise ValueError("node_scalars must have shape (N, F)")
+        if node_vectors.ndim != 3:
+            raise ValueError("node_vectors must have shape (N, C, 3)")
+
+        scalars = self.scalar_proj(node_scalars)
+        vectors = vector_linear(node_vectors, self.vector_proj)
+
+        if mask is not None:
+            mask = mask.to(torch.bool)
+            scalars = scalars * mask.unsqueeze(-1)
+            vectors = vectors * mask.unsqueeze(-1).unsqueeze(-1)
+
+        for layer in self.layers:
+            scalars, vectors = layer(scalars, vectors, edge_index, edge_scalars, edge_vectors, edge_frames)
+            if mask is not None:
+                scalars = scalars * mask.unsqueeze(-1)
+                vectors = vectors * mask.unsqueeze(-1).unsqueeze(-1)
+
+        vec_norms = safe_norm(vectors, dim=-1)
+        readout_input = torch.cat((scalars, vec_norms), dim=-1)
+        embeddings = self.readout(readout_input)
+
+        output: Dict[str, Tensor] = {
+            "embeddings": embeddings,
+            "node_scalars": scalars,
+            "node_vectors": vectors,
+        }
+
+        if self.displacement_head is not None:
+            displacement = self.displacement_head(scalars)
+            if mask is not None:
+                displacement = displacement * mask.unsqueeze(-1)
+            output["displacement"] = displacement
+
+        return output
+
+
+__all__ = ["GCPNetEncoder", "GCPNetConfig", "GCPConv", "VectorLayerNorm"]

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -1,0 +1,425 @@
+"""High-level end-to-end module for the GCP-VQVAE architecture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor, nn
+
+from gcpvqvae.data.featurize import featurize_backbone
+from gcpvqvae.data.mmcif import PAD_INDEX, BackboneRecord, load_mmcif
+from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.gcpnet import GCPNetConfig, GCPNetEncoder
+from gcpvqvae.models.losses import reconstruction_loss
+from gcpvqvae.models.transformer import GCPTokensTransformer, TransformerConfig
+from gcpvqvae.models.vq import VectorQuantizer
+
+
+@dataclass
+class DataPipelineConfig:
+    """Configuration governing single-chain preprocessing."""
+
+    length_cap: int = 2048
+    knn: int = 16
+
+
+@dataclass
+class VectorQuantizerConfig:
+    """Configuration for the latent codebook."""
+
+    num_codes: int = 4096
+    dim: int = 256
+    beta: float = 0.25
+    decay: float = 0.99
+    epsilon: float = 1e-5
+    kmeans_iters: int = 10
+    rotation_trick: bool = True
+    orthogonal_reg_weight: float = 0.0
+    orthogonal_reg_max_codes: int = 512
+
+
+@dataclass
+class RotationHeadConfig:
+    """Parameters for the rigid 6D rotation decoder head."""
+
+    input_dim: Optional[int] = None
+    translation_scale: float = 1.0
+    template: Optional[Tensor] = None
+
+
+@dataclass
+class GCPVQVAEConfig:
+    """Top-level configuration for the full GCP-VQVAE model."""
+
+    gcp: GCPNetConfig = field(default_factory=GCPNetConfig)
+    encoder: TransformerConfig = field(
+        default_factory=lambda: TransformerConfig(input_dim=256, output_dim=256)
+    )
+    decoder: TransformerConfig = field(
+        default_factory=lambda: TransformerConfig(
+            input_dim=256, num_layers=16, num_heads=16, num_kv_heads=1
+        )
+    )
+    vq: VectorQuantizerConfig = field(default_factory=VectorQuantizerConfig)
+    rotation: RotationHeadConfig = field(default_factory=RotationHeadConfig)
+    data: DataPipelineConfig = field(default_factory=DataPipelineConfig)
+
+    def __post_init__(self) -> None:
+        # Ensure dimensional consistency between the sub-modules.
+        self.encoder.input_dim = self.gcp.latent_dim
+        self.encoder.output_dim = self.vq.dim
+        self.decoder.input_dim = self.vq.dim
+        if self.decoder.output_dim is None:
+            # The rotation head consumes the decoder's model dimension when the
+            # output projection is omitted.
+            decoder_out = self.decoder.model_dim
+        else:
+            decoder_out = self.decoder.output_dim
+        if self.rotation.input_dim is None:
+            self.rotation.input_dim = decoder_out
+
+
+class GCPVQVAE(nn.Module):
+    """High-level module exposing encode/decode utilities and training forward."""
+
+    def __init__(self, config: Optional[GCPVQVAEConfig] = None) -> None:
+        super().__init__()
+        self.config = config or GCPVQVAEConfig()
+
+        self.encoder_gcp = GCPNetEncoder(self.config.gcp)
+        self.encoder_transformer = GCPTokensTransformer(self.config.encoder)
+        self.vq = VectorQuantizer(
+            self.config.vq.num_codes,
+            self.config.vq.dim,
+            beta=self.config.vq.beta,
+            decay=self.config.vq.decay,
+            epsilon=self.config.vq.epsilon,
+            kmeans_iters=self.config.vq.kmeans_iters,
+            rotation_trick=self.config.vq.rotation_trick,
+            orthogonal_reg_weight=self.config.vq.orthogonal_reg_weight,
+            orthogonal_reg_max_codes=self.config.vq.orthogonal_reg_max_codes,
+        )
+        self.decoder_transformer = GCPTokensTransformer(self.config.decoder)
+        self.rotation_decoder = RotationDecoder(
+            self.config.rotation.input_dim,
+            translation_scale=self.config.rotation.translation_scale,
+            template=self.config.rotation.template,
+        )
+
+    # ------------------------------------------------------------------ utils
+    def _device(self) -> torch.device:
+        return next(self.parameters()).device
+
+    def _dtype(self) -> torch.dtype:
+        return next(self.parameters()).dtype
+
+    def _flatten_batch(self, tensor: Tensor) -> Tensor:
+        if tensor.ndim < 2:
+            raise ValueError("Expected tensor with batch and length dimensions")
+        batch, length = tensor.shape[:2]
+        return tensor.reshape(batch * length, *tensor.shape[2:])
+
+    def _reshape_batch(self, tensor: Tensor, batch: int, length: int) -> Tensor:
+        return tensor.reshape(batch, length, *tensor.shape[1:])
+
+    # ----------------------------------------------------------------- forward
+    def forward(self, batch: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        device = self._device()
+        dtype = self._dtype()
+
+        mask = batch["mask"].to(torch.bool).to(device)
+        if "nan_mask" in batch:
+            mask = mask & ~batch["nan_mask"].to(torch.bool).to(device)
+
+        coords = batch["coords"].to(device=device, dtype=dtype)
+        node_scalars = batch["node_scalars"].to(device=device, dtype=dtype)
+        node_vectors = batch["node_vectors"].to(device=device, dtype=dtype)
+        edge_index = batch["edge_index"].to(device=device)
+        edge_scalars = batch["edge_scalars"].to(device=device, dtype=dtype)
+        edge_vectors = batch["edge_vectors"].to(device=device, dtype=dtype)
+        edge_frames = batch["edge_frames"].to(device=device, dtype=dtype)
+
+        batch_size, max_len, _ = node_scalars.shape
+        flat_scalars = self._flatten_batch(node_scalars)
+        flat_vectors = self._flatten_batch(node_vectors)
+        flat_mask = mask.reshape(-1)
+
+        gcp_out = self.encoder_gcp(
+            flat_scalars,
+            flat_vectors,
+            edge_index,
+            edge_scalars,
+            edge_vectors,
+            edge_frames,
+            mask=flat_mask,
+        )
+        embeddings = gcp_out["embeddings"].reshape(batch_size, max_len, -1)
+
+        enc_hidden = self.encoder_transformer(embeddings, mask=mask)
+        quantized, indices, vq_losses = self.vq(enc_hidden, mask=mask)
+
+        dec_hidden = self.decoder_transformer(quantized, mask=mask)
+        recon_coords, final_pose = self.rotation_decoder(dec_hidden, mask=mask)
+
+        rec_loss, rec_components = reconstruction_loss(
+            recon_coords,
+            coords,
+            mask=mask,
+            return_components=True,
+        )
+
+        total_loss = rec_loss
+        total_loss = total_loss + vq_losses["commitment"]
+        total_loss = total_loss + vq_losses["codebook"]
+        total_loss = total_loss + vq_losses["orthogonality"]
+
+        return {
+            "gcp_embeddings": embeddings,
+            "encoder_hidden": enc_hidden,
+            "quantized": quantized,
+            "indices": indices,
+            "decoded": recon_coords,
+            "mask": mask,
+            "pose": final_pose,
+            "vq_losses": vq_losses,
+            "reconstruction": rec_loss,
+            "reconstruction_components": rec_components,
+            "total_loss": total_loss,
+        }
+
+    # ----------------------------------------------------------- encode helper
+    def _build_metadata(self, record: BackboneRecord) -> Dict[str, Any]:
+        return {
+            "path": record.path,
+            "chain_id": record.chain_id,
+            "sequence": record.seq_string,
+            "seq_indices": record.seq.clone().cpu(),
+            "residue_ids": list(record.residue_ids),
+            "residue_names": list(record.residue_names),
+        }
+
+    def _run_encoder(
+        self,
+        node_scalars: Tensor,
+        node_vectors: Tensor,
+        edge_index: Tensor,
+        edge_scalars: Tensor,
+        edge_vectors: Tensor,
+        edge_frames: Tensor,
+        mask: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor, Dict[str, Tensor]]:
+        device = self._device()
+        dtype = self._dtype()
+
+        node_scalars = node_scalars.to(device=device, dtype=dtype)
+        node_vectors = node_vectors.to(device=device, dtype=dtype)
+        edge_index = edge_index.to(device=device)
+        edge_scalars = edge_scalars.to(device=device, dtype=dtype)
+        edge_vectors = edge_vectors.to(device=device, dtype=dtype)
+        edge_frames = edge_frames.to(device=device, dtype=dtype)
+        mask = mask.to(device=device, dtype=torch.bool)
+
+        gcp_out = self.encoder_gcp(
+            node_scalars,
+            node_vectors,
+            edge_index,
+            edge_scalars,
+            edge_vectors,
+            edge_frames,
+            mask=mask,
+        )
+        embeddings = gcp_out["embeddings"].unsqueeze(0)
+        enc_hidden = self.encoder_transformer(embeddings, mask=mask.unsqueeze(0))
+        quantized, indices, vq_losses = self.vq(enc_hidden, mask=mask.unsqueeze(0))
+        return embeddings, enc_hidden, quantized, {"indices": indices, "vq": vq_losses}
+
+    # ------------------------------------------------------------------- encode
+    @torch.no_grad()
+    def encode(
+        self,
+        mmcif_path: str,
+        *,
+        chain_id: Optional[str] = None,
+        length_cap: Optional[int] = None,
+        k: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        was_training = self.training
+        self.eval()
+        try:
+            records = load_mmcif(
+                mmcif_path,
+                chain_id=chain_id,
+                length_cap=length_cap or self.config.data.length_cap,
+            )
+            if not records:
+                raise ValueError(f"No suitable chains found in {mmcif_path}")
+            record = records[0]
+            features = featurize_backbone(record, k=k or self.config.data.knn)
+
+            mask = record.mask.clone()
+            if record.nan_mask.numel():
+                mask = mask & ~record.nan_mask
+
+            embeddings, enc_hidden, quantized, extras = self._run_encoder(
+                features["node_scalars"],
+                features["node_vectors"],
+                features["edge_index"],
+                features["edge_scalars"],
+                features["edge_vectors"],
+                features["edge_frames"],
+                mask,
+            )
+
+            indices = extras["indices"].squeeze(0).cpu()
+            vq_losses = extras["vq"]
+
+            result = {
+                "tokens": indices.clone(),
+                "length": int(record.length),
+                "mask": mask.clone().cpu(),
+                "pose_header": (
+                    record.rotation.clone().cpu(),
+                    record.translation.clone().cpu(),
+                ),
+                "gcp_embeddings": embeddings.squeeze(0).cpu(),
+                "encoder_embeddings": enc_hidden.squeeze(0).cpu(),
+                "quantized": quantized.squeeze(0).cpu(),
+                "vq_losses": {k: v.detach().cpu() for k, v in vq_losses.items()},
+                "metadata": self._build_metadata(record),
+            }
+            return result
+        finally:
+            self.train(was_training)
+
+    # ------------------------------------------------------------------- decode
+    @torch.no_grad()
+    def decode(
+        self,
+        tokens: Iterable[int] | np.ndarray | Tensor,
+        *,
+        pose_header: Optional[Tuple[Tensor | np.ndarray, Tensor | np.ndarray]] = None,
+        mask: Optional[Iterable[bool] | Tensor | np.ndarray] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        was_training = self.training
+        self.eval()
+        try:
+            device = self._device()
+            dtype = self._dtype()
+
+            tokens_tensor = torch.as_tensor(tokens, dtype=torch.long, device=device)
+            if tokens_tensor.ndim == 1:
+                tokens_tensor = tokens_tensor.unsqueeze(0)
+            batch, length = tokens_tensor.shape
+
+            if mask is None:
+                mask_tensor = tokens_tensor >= 0
+            else:
+                mask_tensor = torch.as_tensor(mask, dtype=torch.bool, device=device)
+                if mask_tensor.ndim == 1:
+                    mask_tensor = mask_tensor.unsqueeze(0)
+
+            latent_dim = self.config.vq.dim
+            dequant = torch.zeros((batch, length, latent_dim), device=device, dtype=dtype)
+            valid = mask_tensor & (tokens_tensor >= 0)
+            if valid.any():
+                flat_indices = tokens_tensor[valid]
+                dequant[valid] = self.vq.embedding.index_select(0, flat_indices).to(dtype)
+
+            dec_hidden = self.decoder_transformer(dequant, mask=mask_tensor)
+            coords_central, final_pose = self.rotation_decoder(
+                dec_hidden, mask=mask_tensor
+            )
+
+            if pose_header is not None:
+                rot, trans = pose_header
+                rot_t = torch.as_tensor(rot, dtype=dtype, device=device)
+                trans_t = torch.as_tensor(trans, dtype=dtype, device=device)
+                if rot_t.ndim == 2:
+                    rot_t = rot_t.unsqueeze(0)
+                if trans_t.ndim == 1:
+                    trans_t = trans_t.unsqueeze(0)
+            else:
+                rot_t = torch.eye(3, device=device, dtype=dtype).expand(batch, 3, 3)
+                trans_t = torch.zeros((batch, 3), device=device, dtype=dtype)
+
+            coords_global = coords_central @ rot_t.transpose(-1, -2)
+            coords_global = coords_global + trans_t.unsqueeze(1).unsqueeze(2)
+
+            mask_cpu = mask_tensor.clone().cpu()
+
+            records_out: Optional[Any]
+            if metadata is not None:
+                seq_indices = metadata.get("seq_indices")
+                if isinstance(seq_indices, Tensor):
+                    seq_tensor = seq_indices.clone()
+                elif seq_indices is not None:
+                    seq_tensor = torch.tensor(seq_indices, dtype=torch.long)
+                else:
+                    seq_tensor = torch.full((length,), PAD_INDEX, dtype=torch.long)
+                if seq_tensor.ndim == 1:
+                    seq_tensor = seq_tensor.unsqueeze(0)
+                if seq_tensor.shape[0] != batch:
+                    seq_tensor = seq_tensor.expand(batch, -1)
+
+                records = []
+                for b in range(batch):
+                    b_mask = mask_cpu[b]
+                    valid_len = int(b_mask.sum().item())
+                    seq_slice = seq_tensor[b, :valid_len]
+                    seq_chars = metadata.get("sequence", "X" * valid_len)
+                    if isinstance(seq_chars, str):
+                        seq_chars_b = seq_chars[:valid_len]
+                    else:
+                        seq_chars_b = "".join(seq_chars)[:valid_len]
+
+                    residue_ids = metadata.get("residue_ids", [(i + 1, "") for i in range(valid_len)])
+                    residue_names = metadata.get("residue_names", ["UNK"] * valid_len)
+
+                    record = BackboneRecord(
+                        path=str(metadata.get("path", "")),
+                        chain_id=str(metadata.get("chain_id", "A")),
+                        coords=coords_central[b, :valid_len].cpu(),
+                        mask=b_mask[:valid_len].cpu(),
+                        atom_mask=torch.ones((valid_len, 3), dtype=torch.bool),
+                        seq=seq_slice.cpu(),
+                        seq_string=seq_chars_b,
+                        residue_names=list(residue_names)[:valid_len],
+                        residue_ids=list(residue_ids)[:valid_len],
+                        rotation=rot_t[b].cpu(),
+                        translation=trans_t[b].cpu(),
+                        nan_mask=~b_mask[:valid_len].cpu(),
+                    )
+                    records.append(record)
+                if batch == 1:
+                    records_out = records[0]
+                else:
+                    records_out = records
+            else:
+                records_out = None
+
+            result = {
+                "coords": coords_global.squeeze(0).cpu() if batch == 1 else coords_global.cpu(),
+                "coords_central": coords_central.squeeze(0).cpu()
+                if batch == 1
+                else coords_central.cpu(),
+                "mask": mask_cpu.squeeze(0) if batch == 1 else mask_cpu,
+                "pose": (final_pose[0].cpu(), final_pose[1].cpu()),
+                "pose_header": (rot_t.cpu(), trans_t.cpu()),
+                "records": records_out,
+            }
+            return result
+        finally:
+            self.train(was_training)
+
+
+__all__ = [
+    "GCPVQVAE",
+    "GCPVQVAEConfig",
+    "VectorQuantizerConfig",
+    "RotationHeadConfig",
+    "DataPipelineConfig",
+]

--- a/src/gcpvqvae/models/losses.py
+++ b/src/gcpvqvae/models/losses.py
@@ -1,8 +1,202 @@
-"""Loss functions for geometry-consistent training."""
+"""Geometry-aware reconstruction losses used by GCP-VQVAE."""
 
 from __future__ import annotations
 
+from typing import Dict, Optional, Tuple
 
-def reconstruction_loss(pred, target):
-    """Compute weighted reconstruction losses (stub)."""
-    raise NotImplementedError("reconstruction_loss is not yet implemented")
+import torch
+from torch import Tensor
+
+from gcpvqvae.geometry.frames import kabsch_align
+
+
+def _flatten_backbone(coords: Tensor) -> Tensor:
+    if coords.ndim != 4 or coords.size(-2) != 3 or coords.size(-1) != 3:
+        raise ValueError("Backbone tensors must have shape (B, L, 3, 3)")
+    return coords.view(coords.size(0), coords.size(1) * 3, 3)
+
+
+def _broadcast_mask(mask: Optional[Tensor], length: int) -> Optional[Tensor]:
+    if mask is None:
+        return None
+    if mask.ndim != 2:
+        raise ValueError("Mask must have shape (B, L)")
+    return mask.unsqueeze(-1).expand(-1, -1, 3).reshape(mask.shape[0], length * 3)
+
+
+def aligned_mse(
+    pred: Tensor,
+    target: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+) -> Tensor:
+    """Compute the aligned MSE between predicted and target backbones."""
+
+    pred_flat = _flatten_backbone(pred)
+    target_flat = _flatten_backbone(target)
+
+    mask_flat = _broadcast_mask(mask, pred.size(1))
+
+    losses = []
+    for i in range(pred_flat.size(0)):
+        mask_i: Optional[Tensor]
+        if mask_flat is not None:
+            mask_i = mask_flat[i]
+            valid = mask_i.to(torch.bool)
+            if valid.sum() < 3:
+                losses.append(torch.zeros((), device=pred.device, dtype=pred.dtype))
+                continue
+        else:
+            mask_i = None
+
+        try:
+            rotation, translation, _ = kabsch_align(
+                pred_flat[i],
+                target_flat[i],
+                mask=mask_i,
+                allow_reflections=False,
+                return_aligned=False,
+            )
+        except ValueError:
+            rotation = torch.eye(3, device=pred.device, dtype=pred.dtype)
+            translation = torch.zeros(3, device=pred.device, dtype=pred.dtype)
+
+        aligned = pred_flat[i] @ rotation + translation
+        diff = aligned - target_flat[i]
+        if mask_i is not None:
+            diff = diff * mask_i.unsqueeze(-1)
+            denom = torch.clamp(mask_i.sum(), min=1.0) * 1.0
+        else:
+            denom = diff.shape[0]
+        losses.append((diff.square().sum(dim=-1).sum()) / denom)
+
+    return torch.stack(losses).mean()
+
+
+def distance_matrix_loss(
+    pred: Tensor,
+    target: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+    clamp_distance: float = 5.0,
+) -> Tensor:
+    """Pairwise distance loss on flattened residue representations."""
+
+    pred_flat = pred.view(pred.size(0), pred.size(1), -1)
+    target_flat = target.view(target.size(0), target.size(1), -1)
+
+    losses = []
+    for i in range(pred_flat.size(0)):
+        if mask is not None:
+            valid = mask[i].to(torch.bool)
+            pred_i = pred_flat[i, valid]
+            target_i = target_flat[i, valid]
+        else:
+            pred_i = pred_flat[i]
+            target_i = target_flat[i]
+
+        if pred_i.size(0) < 2:
+            losses.append(torch.zeros((), device=pred.device, dtype=pred.dtype))
+            continue
+
+        pred_dist = torch.cdist(pred_i, pred_i)
+        target_dist = torch.cdist(target_i, target_i)
+
+        pred_dist = torch.clamp(pred_dist, max=clamp_distance)
+        target_dist = torch.clamp(target_dist, max=clamp_distance)
+
+        losses.append((pred_dist - target_dist).pow(2).mean())
+
+    return torch.stack(losses).mean()
+
+
+def _backbone_vectors(coords: Tensor) -> Tensor:
+    n = coords[:, :, 0, :]
+    ca = coords[:, :, 1, :]
+    c = coords[:, :, 2, :]
+
+    v1 = ca - n
+    v2 = c - ca
+    v3 = torch.zeros_like(v1)
+    v3[:, :-1] = n[:, 1:] - c[:, :-1]
+
+    def _normalise(vec: Tensor) -> Tensor:
+        norm = torch.linalg.norm(vec, dim=-1, keepdim=True)
+        return vec / torch.clamp(norm, min=1e-8)
+
+    v1 = _normalise(v1)
+    v2 = _normalise(v2)
+    v3 = _normalise(v3)
+    v4 = _normalise(-torch.cross(v1, v2, dim=-1))
+    v5 = _normalise(torch.cross(v3, v1, dim=-1))
+    v6 = _normalise(torch.cross(v2, v3, dim=-1))
+
+    return torch.stack((v1, v2, v3, v4, v5, v6), dim=2)
+
+
+def direction_loss(
+    pred: Tensor,
+    target: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+) -> Tensor:
+    """Loss on backbone direction signatures."""
+
+    pred_vectors = _backbone_vectors(pred)
+    target_vectors = _backbone_vectors(target)
+
+    losses = []
+    for i in range(pred_vectors.size(0)):
+        if mask is not None:
+            valid = mask[i].to(torch.bool)
+            pv = pred_vectors[i, valid]
+            tv = target_vectors[i, valid]
+        else:
+            pv = pred_vectors[i]
+            tv = target_vectors[i]
+
+        if pv.size(0) < 2:
+            losses.append(torch.zeros((), device=pred.device, dtype=pred.dtype))
+            continue
+
+        pred_dot = torch.einsum("icd,jcd->ijc", pv, pv)
+        target_dot = torch.einsum("icd,jcd->ijc", tv, tv)
+        losses.append((pred_dot - target_dot).pow(2).mean())
+
+    return torch.stack(losses).mean()
+
+
+def reconstruction_loss(
+    pred: Tensor,
+    target: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+    weights: Tuple[float, float, float] = (5e-3, 1e-2, 5e-2),
+    return_components: bool = False,
+) -> Tuple[Tensor, Dict[str, Tensor]] | Tensor:
+    """Compute the weighted reconstruction loss following Algorithm 2."""
+
+    l_mse = aligned_mse(pred, target, mask=mask)
+    l_dist = distance_matrix_loss(pred, target, mask=mask)
+    l_dir = direction_loss(pred, target, mask=mask)
+
+    total = weights[0] * l_mse + weights[1] * l_dist + weights[2] * l_dir
+
+    if return_components:
+        components = {
+            "aligned_mse": l_mse,
+            "distance": l_dist,
+            "direction": l_dir,
+            "total": total,
+        }
+        return total, components
+
+    return total
+
+
+__all__ = [
+    "aligned_mse",
+    "distance_matrix_loss",
+    "direction_loss",
+    "reconstruction_loss",
+]

--- a/src/gcpvqvae/models/transformer.py
+++ b/src/gcpvqvae/models/transformer.py
@@ -1,17 +1,232 @@
-"""Transformer backbone with rotary embeddings and grouped query attention."""
+"""Transformer backbone with rotary embeddings and grouped-query attention."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
 import torch
-from torch import nn
+from torch import Tensor, nn
+
+
+def _split_heads(x: Tensor, num_heads: int) -> Tensor:
+    batch, length, dim = x.shape
+    head_dim = dim // num_heads
+    return x.view(batch, length, num_heads, head_dim).transpose(1, 2)
+
+
+def _merge_heads(x: Tensor) -> Tensor:
+    batch, heads, length, head_dim = x.shape
+    return x.transpose(1, 2).reshape(batch, length, heads * head_dim)
+
+
+def _rotate_half(x: Tensor) -> Tensor:
+    x1, x2 = x[..., ::2], x[..., 1::2]
+    return torch.stack((-x2, x1), dim=-1).reshape_as(x)
+
+
+class RotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, base: float = 10_000.0) -> None:
+        super().__init__()
+        if dim % 2 != 0:
+            raise ValueError("Rotary embeddings require an even head dimension")
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seq_len: int, *, device: torch.device, dtype: torch.dtype) -> Tuple[Tensor, Tensor]:
+        positions = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+        freqs = torch.einsum("i,j->ij", positions, self.inv_freq)
+        cos = torch.cos(freqs).to(dtype)
+        sin = torch.sin(freqs).to(dtype)
+        cos = torch.repeat_interleave(cos, repeats=2, dim=-1)
+        sin = torch.repeat_interleave(sin, repeats=2, dim=-1)
+        return cos, sin
+
+
+def apply_rotary(q: Tensor, k: Tensor, cos: Tensor, sin: Tensor) -> Tuple[Tensor, Tensor]:
+    cos = cos.unsqueeze(0).unsqueeze(0)
+    sin = sin.unsqueeze(0).unsqueeze(0)
+    q_rot = (q * cos) + (_rotate_half(q) * sin)
+    k_rot = (k * cos) + (_rotate_half(k) * sin)
+    return q_rot, k_rot
+
+
+class MultiHeadAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        *,
+        dropout: float = 0.0,
+        rope: Optional[RotaryEmbedding] = None,
+    ) -> None:
+        super().__init__()
+
+        if dim % num_heads != 0:
+            raise ValueError("dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be a multiple of num_kv_heads")
+
+        self.dim = dim
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim ** -0.5
+        self.groups = num_heads // num_kv_heads
+
+        self.q_proj = nn.Linear(dim, dim, bias=False)
+        self.k_proj = nn.Linear(dim, num_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, num_kv_heads * self.head_dim, bias=False)
+        self.out_proj = nn.Linear(dim, dim, bias=False)
+
+        self.attn_dropout = nn.Dropout(dropout)
+        self.proj_dropout = nn.Dropout(dropout)
+        self.rope = rope
+
+    def _repeat_kv(self, tensor: Tensor) -> Tensor:
+        if self.groups == 1:
+            return tensor
+        return tensor.unsqueeze(2).repeat(1, 1, self.groups, 1, 1).reshape(
+            tensor.size(0), self.num_heads, tensor.size(-2), self.head_dim
+        )
+
+    def forward(self, x: Tensor, *, attn_mask: Optional[Tensor] = None) -> Tensor:
+        batch, length, _ = x.shape
+
+        q = _split_heads(self.q_proj(x), self.num_heads)
+        k = _split_heads(self.k_proj(x), self.num_kv_heads)
+        v = _split_heads(self.v_proj(x), self.num_kv_heads)
+
+        if self.rope is not None:
+            cos, sin = self.rope(length, device=x.device, dtype=x.dtype)
+            q, k = apply_rotary(q, k, cos, sin)
+
+        q = q / torch.clamp(torch.linalg.norm(q, dim=-1, keepdim=True), min=1e-6)
+        k = k / torch.clamp(torch.linalg.norm(k, dim=-1, keepdim=True), min=1e-6)
+
+        k_full = self._repeat_kv(k)
+        v_full = self._repeat_kv(v)
+
+        scores = torch.matmul(q, k_full.transpose(-2, -1)) * self.scale
+
+        if attn_mask is not None:
+            scores = scores.masked_fill(attn_mask, float("-inf"))
+
+        attn = torch.softmax(scores, dim=-1)
+        attn = self.attn_dropout(attn)
+
+        output = torch.matmul(attn, v_full)
+        output = _merge_heads(output)
+        return self.proj_dropout(self.out_proj(output))
+
+
+class FeedForward(nn.Module):
+    def __init__(self, dim: int, expansion: int, dropout: float) -> None:
+        super().__init__()
+        hidden = int(dim * expansion)
+        self.net = nn.Sequential(
+            nn.Linear(dim, hidden, bias=False),
+            nn.GELU(),
+            nn.Linear(hidden, dim, bias=False),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.net(x)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        *,
+        dropout: float,
+        ffn_multiplier: float,
+        rope: Optional[RotaryEmbedding],
+    ) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = MultiHeadAttention(
+            dim,
+            num_heads,
+            num_kv_heads,
+            dropout=dropout,
+            rope=rope,
+        )
+        self.norm2 = nn.LayerNorm(dim)
+        self.ffn = FeedForward(dim, ffn_multiplier, dropout)
+
+    def forward(self, x: Tensor, *, attn_mask: Optional[Tensor]) -> Tensor:
+        x = x + self.attn(self.norm1(x), attn_mask=attn_mask)
+        x = x + self.ffn(self.norm2(x))
+        return x
+
+
+@dataclass
+class TransformerConfig:
+    input_dim: int
+    model_dim: int = 1024
+    output_dim: Optional[int] = None
+    num_layers: int = 12
+    num_heads: int = 12
+    num_kv_heads: int = 3
+    dropout: float = 0.0
+    ffn_multiplier: float = 4.0
+    use_rope: bool = True
 
 
 class GCPTokensTransformer(nn.Module):
-    """Placeholder transformer operating on latent tokens."""
+    """Pre-LN Transformer stack tailored to the GCP-VQVAE architecture."""
 
-    def __init__(self) -> None:
+    def __init__(self, config: TransformerConfig) -> None:
         super().__init__()
-        raise NotImplementedError("GCPTokensTransformer needs implementation")
 
-    def forward(self, *args, **kwargs):
-        raise NotImplementedError
+        self.config = config
+        self.input_proj = nn.Linear(config.input_dim, config.model_dim, bias=False)
+        self.output_proj = nn.Linear(
+            config.model_dim, config.output_dim or config.model_dim, bias=False
+        )
+
+        rope = RotaryEmbedding(config.model_dim // config.num_heads) if config.use_rope else None
+
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    config.model_dim,
+                    config.num_heads,
+                    config.num_kv_heads,
+                    dropout=config.dropout,
+                    ffn_multiplier=config.ffn_multiplier,
+                    rope=rope,
+                )
+                for _ in range(config.num_layers)
+            ]
+        )
+
+        self.dropout = nn.Dropout(config.dropout)
+        self.final_norm = nn.LayerNorm(config.model_dim)
+
+    def forward(self, x: Tensor, *, mask: Optional[Tensor] = None) -> Tensor:
+        if x.ndim != 3:
+            raise ValueError("Inputs must have shape (batch, length, features)")
+
+        attn_mask: Optional[Tensor]
+        if mask is None:
+            attn_mask = None
+        else:
+            mask = mask.to(torch.bool)
+            attn_mask = (~mask).unsqueeze(1).unsqueeze(2)
+
+        hidden = self.input_proj(x)
+        for block in self.blocks:
+            hidden = block(hidden, attn_mask=attn_mask)
+
+        hidden = self.final_norm(hidden)
+        hidden = self.dropout(hidden)
+        return self.output_proj(hidden)
+
+
+__all__ = ["GCPTokensTransformer", "TransformerConfig"]

--- a/src/gcpvqvae/models/vq.py
+++ b/src/gcpvqvae/models/vq.py
@@ -2,16 +2,263 @@
 
 from __future__ import annotations
 
+from typing import Dict, Optional, Tuple
+
 import torch
-from torch import nn
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+
+def _safe_normalize(vec: Tensor, eps: float = 1e-8) -> Tensor:
+    norm = torch.linalg.norm(vec, dim=-1, keepdim=True)
+    return vec / torch.clamp(norm, min=eps)
+
+
+def _orthogonal_basis(vec: Tensor) -> Tensor:
+    """Return vectors orthogonal to ``vec`` (batched)."""
+
+    if vec.ndim != 2:
+        raise ValueError("vec must be of shape (N, D)")
+    n, d = vec.shape
+    if n == 0:
+        return vec
+    basis = torch.zeros_like(vec)
+    # Select the axis with smallest magnitude to avoid degeneracy.
+    indices = torch.argmin(torch.abs(vec), dim=-1)
+    basis[torch.arange(n, device=vec.device), indices] = 1.0
+    basis = basis - (basis * vec).sum(dim=-1, keepdim=True) * vec
+    return _safe_normalize(basis)
+
+
+def _rotation_trick_gradient(grad: Tensor, inputs: Tensor, codes: Tensor, eps: float) -> Tensor:
+    """Apply the rotation-trick Jacobian to ``grad``.
+
+    The operation is vectorised over the leading dimension of the tensors and
+    works for arbitrary latent dimensionality.  For degenerate inputs (e.g.
+    zero-norm latents) the fallback reduces to simple rescaling which matches
+    the behaviour of the straight-through estimator.
+    """
+
+    if grad.numel() == 0:
+        return grad
+
+    z_norm = torch.linalg.norm(inputs, dim=-1, keepdim=True)
+    c_norm = torch.linalg.norm(codes, dim=-1, keepdim=True)
+
+    scale = c_norm / torch.clamp(z_norm, min=eps)
+
+    a_hat = torch.where(z_norm > eps, inputs / torch.clamp(z_norm, min=eps), _orthogonal_basis(codes))
+    b_hat = torch.where(c_norm > eps, codes / torch.clamp(c_norm, min=eps), _orthogonal_basis(inputs))
+
+    cos_theta = torch.clamp((a_hat * b_hat).sum(dim=-1, keepdim=True), -1.0, 1.0)
+    proj = b_hat - cos_theta * a_hat
+    sin_theta = torch.linalg.norm(proj, dim=-1, keepdim=True)
+
+    u = torch.where(sin_theta > eps, proj / torch.clamp(sin_theta, min=eps), _orthogonal_basis(a_hat))
+
+    dot_ga = (grad * a_hat).sum(dim=-1, keepdim=True)
+    dot_gu = (grad * u).sum(dim=-1, keepdim=True)
+
+    term1 = sin_theta * (dot_gu * a_hat - dot_ga * u)
+    term2 = (cos_theta - 1.0) * (dot_ga * a_hat + dot_gu * u)
+
+    rotated_grad = grad + term1 + term2
+    return scale * rotated_grad
+
+
+class _RotateTrickPass(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, inputs: Tensor, quantized: Tensor, mask: Tensor, eps: float) -> Tensor:
+        ctx.save_for_backward(inputs, quantized, mask)
+        ctx.eps = eps
+        return quantized
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor) -> Tuple[Tensor, None, None, None]:
+        inputs, quantized, mask = ctx.saved_tensors
+        mask = mask.to(torch.bool)
+
+        grad_inputs = torch.zeros_like(inputs)
+        if mask.any():
+            grad = grad_output[mask]
+            inp = inputs[mask]
+            codes = quantized[mask]
+            grad_inputs[mask] = _rotation_trick_gradient(grad, inp, codes, ctx.eps)
+
+        return grad_inputs, None, None, None
 
 
 class VectorQuantizer(nn.Module):
-    """Placeholder VQ module with EMA updates."""
+    """Vector quantisation module with EMA codebook updates."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        num_codes: int,
+        dim: int,
+        *,
+        beta: float = 0.25,
+        decay: float = 0.99,
+        epsilon: float = 1e-5,
+        kmeans_iters: int = 0,
+        rotation_trick: bool = True,
+        orthogonal_reg_weight: float = 0.0,
+        orthogonal_reg_max_codes: int = 512,
+    ) -> None:
         super().__init__()
-        raise NotImplementedError("VectorQuantizer needs implementation")
 
-    def forward(self, *args, **kwargs):
-        raise NotImplementedError
+        if num_codes <= 0:
+            raise ValueError("num_codes must be positive")
+        if dim <= 0:
+            raise ValueError("dim must be positive")
+
+        self.num_codes = num_codes
+        self.dim = dim
+        self.beta = beta
+        self.decay = decay
+        self.eps = epsilon
+        self.kmeans_iters = kmeans_iters
+        self.rotation_trick = rotation_trick
+        self.orthogonal_reg_weight = orthogonal_reg_weight
+        self.orthogonal_reg_max_codes = orthogonal_reg_max_codes
+
+        self.embedding = nn.Parameter(torch.randn(num_codes, dim))
+
+        self.register_buffer("ema_cluster_size", torch.zeros(num_codes))
+        self.register_buffer("ema_codebook", torch.zeros(num_codes, dim))
+        self.register_buffer("usage", torch.zeros(num_codes))
+
+        self._initialised = False
+
+    def _initialise_codebook(self, samples: Tensor) -> None:
+        if self._initialised or samples.numel() == 0:
+            return
+
+        num_samples = samples.shape[0]
+        if num_samples < self.num_codes:
+            repeats = (self.num_codes + num_samples - 1) // num_samples
+            samples = samples.repeat(repeats, 1)
+        centroids = samples[: self.num_codes].clone()
+
+        for _ in range(self.kmeans_iters):
+            distances = (
+                torch.sum(samples**2, dim=1, keepdim=True)
+                + torch.sum(centroids**2, dim=1)
+                - 2.0 * samples @ centroids.t()
+            )
+            assignment = distances.argmin(dim=1)
+            for k in range(self.num_codes):
+                mask = assignment == k
+                if mask.any():
+                    centroids[k] = samples[mask].mean(dim=0)
+
+        with torch.no_grad():
+            self.embedding.copy_(centroids[: self.num_codes])
+        self._initialised = True
+
+    def forward(
+        self,
+        latents: Tensor,
+        *,
+        mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor, Dict[str, Tensor]]:
+        if latents.size(-1) != self.dim:
+            raise ValueError(f"Expected latent dim {self.dim}, got {latents.size(-1)}")
+
+        original_shape = latents.shape
+        flat_latents = latents.reshape(-1, self.dim)
+
+        if mask is not None:
+            mask = mask.to(torch.bool).reshape(-1)
+        else:
+            mask = torch.ones(flat_latents.shape[0], dtype=torch.bool, device=latents.device)
+
+        valid_latents = flat_latents[mask]
+
+        if self.training and self.kmeans_iters > 0 and not self._initialised:
+            self._initialise_codebook(valid_latents.detach())
+
+        if valid_latents.numel() == 0:
+            quantized = torch.zeros_like(flat_latents)
+            indices = torch.full((flat_latents.shape[0],), -1, dtype=torch.long, device=latents.device)
+            losses = {
+                "commitment": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
+                "codebook": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
+                "orthogonality": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
+                "perplexity": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
+            }
+            quantized = quantized.reshape(original_shape)
+            indices = indices.reshape(original_shape[:-1])
+            return quantized, indices, losses
+
+        distances = (
+            torch.sum(valid_latents**2, dim=1, keepdim=True)
+            + torch.sum(self.embedding**2, dim=1)
+            - 2.0 * valid_latents @ self.embedding.t()
+        )
+        assignment = distances.argmin(dim=1)
+        quantized_valid = self.embedding.index_select(0, assignment)
+
+        full_quantized = torch.zeros_like(flat_latents)
+        full_quantized[mask] = quantized_valid
+
+        indices = torch.full((flat_latents.shape[0],), -1, dtype=torch.long, device=latents.device)
+        indices[mask] = assignment
+
+        full_quantized = torch.where(mask.unsqueeze(-1), full_quantized, flat_latents)
+
+        diff = flat_latents - full_quantized.detach()
+        commitment = (diff[mask] ** 2).mean()
+        codebook_loss = ((flat_latents.detach() - full_quantized)[mask] ** 2).mean()
+
+        if self.orthogonal_reg_weight > 0:
+            num_codes = min(self.orthogonal_reg_max_codes, self.num_codes)
+            codes = self.embedding[:num_codes]
+            gram = codes @ codes.t()
+            identity = torch.eye(num_codes, device=latents.device, dtype=latents.dtype)
+            orth_loss = ((gram - identity) ** 2).mean()
+        else:
+            orth_loss = torch.tensor(0.0, device=latents.device, dtype=latents.dtype)
+
+        if self.training and self.decay < 1.0:
+            with torch.no_grad():
+                one_hot = F.one_hot(assignment, num_classes=self.num_codes).to(latents.dtype)
+                cluster_size = one_hot.sum(dim=0)
+                embed_sum = one_hot.t() @ valid_latents
+
+                self.ema_cluster_size.mul_(self.decay).add_(cluster_size, alpha=1.0 - self.decay)
+                self.ema_codebook.mul_(self.decay).add_(embed_sum, alpha=1.0 - self.decay)
+
+                cluster_size = self.ema_cluster_size + self.eps
+                n = cluster_size.sum()
+                cluster_size = cluster_size / (n + self.num_codes * self.eps) * n
+                updated = self.ema_codebook / cluster_size.unsqueeze(1)
+                self.embedding.copy_(updated)
+
+        one_hot = F.one_hot(assignment, num_classes=self.num_codes).to(latents.dtype)
+        avg_probs = one_hot.mean(dim=0)
+        nonzero = avg_probs > 0
+        if nonzero.any():
+            perplexity = torch.exp(-(avg_probs[nonzero] * torch.log(avg_probs[nonzero])).sum())
+        else:
+            perplexity = torch.tensor(0.0, device=latents.device, dtype=latents.dtype)
+        self.usage.copy_(avg_probs)
+
+        if self.rotation_trick:
+            full_quantized = _RotateTrickPass.apply(flat_latents, full_quantized, mask, self.eps)
+        else:
+            full_quantized = flat_latents + (full_quantized - flat_latents).detach()
+
+        quantized = full_quantized.reshape(original_shape)
+        indices = indices.reshape(original_shape[:-1])
+
+        losses = {
+            "commitment": self.beta * commitment,
+            "codebook": codebook_loss,
+            "orthogonality": self.orthogonal_reg_weight * orth_loss,
+            "perplexity": perplexity,
+        }
+
+        return quantized, indices, losses
+
+
+__all__ = ["VectorQuantizer"]

--- a/src/gcpvqvae/system/train.py
+++ b/src/gcpvqvae/system/train.py
@@ -1,8 +1,678 @@
-"""High level training loop orchestration."""
+"""High level training harness for the GCP-VQVAE model."""
 
 from __future__ import annotations
 
+import contextlib
+import dataclasses
+import math
+import random
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+from torch.nn.utils import clip_grad_norm_
+from torch.utils.data import DataLoader
+
+import yaml
+
+from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
+from gcpvqvae.data.mmcif import BackboneRecord, write_mmcif
+from gcpvqvae.geometry.metrics import rmsd
+from gcpvqvae.models.gcpvqvae import GCPVQVAE, GCPVQVAEConfig
+from gcpvqvae.utils.checkpoint import save_checkpoint
+from gcpvqvae.utils.logging import get_logger
+from gcpvqvae.utils.seed import seed_everything
+
+
+Tensor = torch.Tensor
+
+
+@dataclass
+class DataConfig:
+    root: str
+    chain_ids: Optional[Sequence[str]] = None
+    k: int = 16
+    num_workers: int = 0
+    cache: bool = True
+
+
+@dataclass
+class StageConfig:
+    name: str
+    length_cap: int
+    batch_size: int
+    base_lr: float
+    min_lr: float
+    warmup_steps: int
+    total_steps: Optional[int] = None
+    epochs: Optional[int] = None
+    accumulation_steps: int = 1
+    nan_mask_prob: float = 0.0
+    nan_mask_span: Tuple[int, int] = (1, 1)
+
+    def effective_total_steps(self, batches_per_epoch: int) -> int:
+        if self.total_steps is not None:
+            return self.total_steps
+        if self.epochs is None:
+            raise ValueError(f"Stage {self.name} requires either total_steps or epochs")
+        if batches_per_epoch == 0:
+            raise ValueError("Cannot compute steps with an empty dataset")
+        steps_per_epoch = math.ceil(batches_per_epoch / max(self.accumulation_steps, 1))
+        return self.epochs * max(steps_per_epoch, 1)
+
+
+@dataclass
+class ExportConfig:
+    enabled: bool = True
+    directory: Optional[str] = None
+    every_n_steps: Optional[int] = None
+    on_stage_end: bool = True
+    num_samples: int = 1
+
+
+@dataclass
+class TrainConfig:
+    seed: int = 42
+    device: Optional[str] = None
+    amp: bool = True
+    clip_grad: float = 1.0
+    random_rotation: bool = True
+    log_interval: int = 50
+    checkpoint_interval: Optional[int] = None
+    output_dir: str = "runs"
+    export: ExportConfig = field(default_factory=ExportConfig)
+    stages: List[StageConfig] = field(default_factory=list)
+
+
+class MetricTracker:
+    """Utility tracking running averages for logging."""
+
+    def __init__(self) -> None:
+        self.total = 0.0
+        self.count = 0.0
+
+    def update(self, value: float, weight: float = 1.0) -> None:
+        self.total += value * weight
+        self.count += weight
+
+    def reset(self) -> None:
+        self.total = 0.0
+        self.count = 0.0
+
+    @property
+    def average(self) -> float:
+        if self.count == 0:
+            return 0.0
+        return self.total / self.count
+
+
+class WarmupCosineScheduler:
+    """Cosine learning-rate schedule with linear warmup."""
+
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        *,
+        warmup_steps: int,
+        total_steps: int,
+        base_lr: float,
+        min_lr: float,
+    ) -> None:
+        self.optimizer = optimizer
+        self.warmup_steps = max(warmup_steps, 0)
+        self.total_steps = max(total_steps, 1)
+        self.base_lr = base_lr
+        self.min_lr = min_lr
+        self._step = 0
+        self.update(0)
+
+    def _lr_at(self, step: int) -> float:
+        step = min(max(step, 0), self.total_steps)
+        if self.total_steps <= 0:
+            return self.min_lr
+        if self.warmup_steps > 0 and step <= self.warmup_steps:
+            progress = step / max(self.warmup_steps, 1)
+            return self.min_lr + (self.base_lr - self.min_lr) * progress
+        if self.total_steps == self.warmup_steps:
+            return self.base_lr
+        progress = (step - self.warmup_steps) / max(self.total_steps - self.warmup_steps, 1)
+        progress = min(max(progress, 0.0), 1.0)
+        cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
+        return self.min_lr + (self.base_lr - self.min_lr) * cosine
+
+    def update(self, step: int) -> None:
+        lr = self._lr_at(step)
+        for group in self.optimizer.param_groups:
+            group["lr"] = lr
+        self._step = step
+
+    def step(self) -> None:
+        self.update(self._step + 1)
+
+
+def _update_dataclass(instance: Any, updates: Dict[str, Any]) -> Any:
+    if not dataclasses.is_dataclass(instance) or not isinstance(updates, dict):
+        return instance
+    for key, value in updates.items():
+        if not hasattr(instance, key):
+            continue
+        current = getattr(instance, key)
+        if dataclasses.is_dataclass(current):
+            setattr(instance, key, _update_dataclass(current, value))
+        else:
+            setattr(instance, key, value)
+    return instance
+
+
+def _build_model_config(raw: Optional[Dict[str, Any]]) -> GCPVQVAEConfig:
+    config = GCPVQVAEConfig()
+    if raw:
+        for key, value in raw.items():
+            if not hasattr(config, key):
+                continue
+            current = getattr(config, key)
+            if dataclasses.is_dataclass(current):
+                setattr(config, key, _update_dataclass(current, value))
+            else:
+                setattr(config, key, value)
+        config.rotation.input_dim = None
+        config.__post_init__()
+    return config
+
+
+def _random_rotation(device: torch.device, dtype: torch.dtype) -> Tensor:
+    mat = torch.randn((3, 3), device=device, dtype=dtype)
+    q, r = torch.linalg.qr(mat)
+    diag = torch.diagonal(r)
+    signs = torch.sign(diag + (diag == 0).to(dtype))
+    q = q * signs
+    if torch.linalg.det(q) < 0:
+        q[:, 0] = -q[:, 0]
+    return q
+
+
+def _apply_random_rotation(batch: Dict[str, Tensor]) -> None:
+    coords = batch.get("coords")
+    node_vectors = batch.get("node_vectors")
+    edge_vectors = batch.get("edge_vectors")
+    edge_frames = batch.get("edge_frames")
+    edge_batch = batch.get("edge_batch")
+    backbone_vectors = batch.get("backbone_vectors")
+
+    if coords is None or node_vectors is None:
+        return
+
+    batch_size = coords.shape[0]
+    device = coords.device
+    dtype = coords.dtype
+
+    for b in range(batch_size):
+        rot = _random_rotation(device, dtype)
+        coords[b] = coords[b] @ rot.T
+        node_vectors[b] = node_vectors[b] @ rot.T
+        if backbone_vectors is not None:
+            backbone_vectors[b] = backbone_vectors[b] @ rot.T
+        if edge_batch is not None and edge_vectors is not None and edge_vectors.numel():
+            mask = edge_batch == b
+            if mask.any():
+                edge_vectors[mask] = edge_vectors[mask] @ rot.T
+        if edge_batch is not None and edge_frames is not None and edge_frames.numel():
+            mask = edge_batch == b
+            if mask.any():
+                edge_frames[mask] = edge_frames[mask] @ rot.T
+
+
+def _apply_nan_mask(batch: Dict[str, Tensor], prob: float, span: Tuple[int, int]) -> None:
+    if prob <= 0.0:
+        return
+    nan_mask = batch.get("nan_mask")
+    lengths = batch.get("lengths")
+    if nan_mask is None or lengths is None:
+        return
+    min_span, max_span = span
+    for i in range(nan_mask.shape[0]):
+        if random.random() >= prob:
+            continue
+        length = int(lengths[i].item())
+        if length <= 0:
+            continue
+        span_length = random.randint(min_span, min(max_span, length))
+        if span_length <= 0:
+            continue
+        start = random.randint(0, max(length - span_length, 0))
+        end = min(start + span_length, length)
+        nan_mask[i, start:end] = True
+
+
+def _prepare_stage_config(data: Dict[str, Any]) -> StageConfig:
+    span = data.get("nan_mask_span", (1, 1))
+    if isinstance(span, Sequence):
+        span_tuple = (int(span[0]), int(span[1]))
+    else:
+        span_tuple = (1, 1)
+    total_steps = data.get("total_steps")
+    epochs = data.get("epochs")
+    return StageConfig(
+        name=str(data.get("name", "stage")),
+        length_cap=int(data.get("length_cap", 512)),
+        batch_size=int(data.get("batch_size", 1)),
+        base_lr=float(data.get("base_lr", 1e-4)),
+        min_lr=float(data.get("min_lr", 1e-6)),
+        warmup_steps=int(data.get("warmup_steps", 0)),
+        total_steps=int(total_steps) if total_steps is not None else None,
+        epochs=int(epochs) if epochs is not None else None,
+        accumulation_steps=int(data.get("accumulation_steps", 1)),
+        nan_mask_prob=float(data.get("nan_mask_prob", 0.0)),
+        nan_mask_span=span_tuple,
+    )
+
+
+def _prepare_train_config(raw: Dict[str, Any]) -> TrainConfig:
+    export_cfg = raw.get("export", {})
+    every_n = export_cfg.get("every_n_steps")
+    export = ExportConfig(
+        enabled=bool(export_cfg.get("enabled", True)),
+        directory=export_cfg.get("directory"),
+        every_n_steps=int(every_n) if every_n is not None else None,
+        on_stage_end=bool(export_cfg.get("on_stage_end", True)),
+        num_samples=int(export_cfg.get("num_samples", 1)),
+    )
+    stages = [_prepare_stage_config(stage) for stage in raw.get("stages", [])]
+    if not stages:
+        raise ValueError("Training configuration must specify at least one stage")
+    checkpoint = raw.get("checkpoint_interval")
+    return TrainConfig(
+        seed=int(raw.get("seed", 42)),
+        device=raw.get("device"),
+        amp=bool(raw.get("amp", True)),
+        clip_grad=float(raw.get("clip_grad", 1.0)),
+        random_rotation=bool(raw.get("random_rotation", True)),
+        log_interval=int(raw.get("log_interval", 50)),
+        checkpoint_interval=int(checkpoint) if checkpoint is not None else None,
+        output_dir=str(raw.get("output_dir", "runs")),
+        export=export,
+        stages=stages,
+    )
+
+
+def _prepare_data_config(raw: Dict[str, Any]) -> DataConfig:
+    root = raw.get("root")
+    if root is None:
+        raise ValueError("Data configuration requires a 'root' path")
+    return DataConfig(
+        root=str(root),
+        chain_ids=raw.get("chain_ids"),
+        k=int(raw.get("k", 16)),
+        num_workers=int(raw.get("num_workers", 0)),
+        cache=bool(raw.get("cache", True)),
+    )
+
+
+def _load_config(path: str | Path) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle)
+    if not isinstance(config, dict):
+        raise ValueError("Configuration file must define a dictionary")
+    return config
+
+
+def _codebook_statistics(vq: nn.Module) -> Tuple[float, float]:
+    if not hasattr(vq, "usage"):
+        return 0.0, 0.0
+    usage = getattr(vq, "usage").detach().float()
+    if usage.numel() == 0:
+        return 0.0, 0.0
+    active = float((usage > 0).sum().item()) / float(usage.numel())
+    total = usage.sum()
+    if total <= 0:
+        return active, 0.0
+    probs = usage / total
+    mask = probs > 0
+    if mask.any():
+        uniform = math.log(1.0 / probs.numel())
+        kl = float((probs[mask] * (torch.log(probs[mask]) - uniform)).sum().item())
+    else:
+        kl = 0.0
+    return active, kl
+
+
+def _export_samples(
+    model: GCPVQVAE,
+    dataset: BackboneDataset,
+    export_cfg: ExportConfig,
+    stage_name: str,
+    global_step: int,
+    output_dir: Path,
+    logger,
+) -> None:
+    if not export_cfg.enabled:
+        return
+    if not hasattr(dataset, "_keys") or not dataset._keys:  # type: ignore[attr-defined]
+        return
+    base_dir = Path(export_cfg.directory) if export_cfg.directory else output_dir / "exports"
+    target_dir = base_dir / f"{stage_name}_step{global_step:06d}"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    was_training = model.training
+    model.eval()
+    try:
+        keys: List[Tuple[str, str]] = dataset._keys  # type: ignore[attr-defined]
+        for key in keys[: export_cfg.num_samples]:
+            path, chain_id = key
+            try:
+                encoded = model.encode(path, chain_id=chain_id)
+            except Exception as exc:  # pragma: no cover - encoding errors are logged
+                logger.warning("Failed to encode %s chain %s: %s", path, chain_id, exc)
+                continue
+
+            tokens = encoded["tokens"].cpu().numpy().astype(np.int32)
+            mask = encoded["mask"].cpu().numpy().astype(np.bool_)
+            rotation, translation = encoded["pose_header"]
+            np.savez(
+                target_dir / f"{Path(path).stem}_{chain_id}.npz",
+                tokens=tokens,
+                mask=mask,
+                length=np.int32(encoded["length"]),
+                rotation=rotation.cpu().numpy(),
+                translation=translation.cpu().numpy(),
+            )
+
+            try:
+                decoded = model.decode(
+                    tokens,
+                    pose_header=(rotation, translation),
+                    mask=mask,
+                    metadata=encoded.get("metadata"),
+                )
+            except Exception as exc:  # pragma: no cover - decoding errors are logged
+                logger.warning("Failed to decode tokens for %s chain %s: %s", path, chain_id, exc)
+                continue
+
+            records = decoded.get("records")
+            record: Optional[BackboneRecord]
+            if isinstance(records, BackboneRecord):
+                record = records
+            elif isinstance(records, list) and records:
+                record = records[0]
+            else:
+                record = None
+
+            if record is None:
+                continue
+
+            cif_path = target_dir / f"{Path(path).stem}_{chain_id}_recon.cif"
+            try:
+                write_mmcif(record, str(cif_path))
+            except Exception as exc:  # pragma: no cover - gemmi may be unavailable
+                logger.warning("Failed to write mmCIF for %s chain %s: %s", path, chain_id, exc)
+    finally:
+        model.train(was_training)
+
+
+class Trainer:
+    def __init__(self, config_path: str | Path) -> None:
+        raw = _load_config(config_path)
+        self.data_cfg = _prepare_data_config(raw.get("data", {}))
+        self.train_cfg = _prepare_train_config(raw.get("train", {}))
+        self.model_cfg = _build_model_config(raw.get("model"))
+        self.logger = get_logger()
+
+        seed_everything(self.train_cfg.seed)
+
+        self.device = torch.device(
+            self.train_cfg.device
+            if self.train_cfg.device is not None
+            else ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+
+        self.model = GCPVQVAE(self.model_cfg).to(self.device)
+        self.optimizer = torch.optim.AdamW(
+            self.model.parameters(),
+            lr=self.train_cfg.stages[0].base_lr,
+            betas=(0.9, 0.98),
+            eps=1e-7,
+            weight_decay=1e-3,
+        )
+
+        self.global_step = 0
+        self.output_dir = Path(self.train_cfg.output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        self.amp_enabled = self.train_cfg.amp and self.device.type == "cuda"
+
+    def _log_stage_progress(
+        self,
+        stage: StageConfig,
+        stage_step: int,
+        total_steps: int,
+        trackers: Dict[str, MetricTracker],
+        samples: int,
+        residues: int,
+        elapsed: float,
+    ) -> None:
+        loss_avg = trackers["loss"].average
+        rec_avg = trackers["recon"].average
+        rmsd_avg = trackers["rmsd"].average
+        perplexity_avg = trackers["perplexity"].average
+        trackers["loss"].reset()
+        trackers["recon"].reset()
+        trackers["rmsd"].reset()
+        trackers["perplexity"].reset()
+
+        util, kl = _codebook_statistics(self.model.vq)
+        lr = self.optimizer.param_groups[0]["lr"]
+        denom = max(elapsed, 1e-6)
+        ex_speed = samples / denom
+        res_speed = residues / denom
+
+        self.logger.info(
+            "[%s] step %d/%d | loss %.4f | rec %.4f | rmsd %.3f Å | perp %.2f | util %.2f%% | KL %.4f | lr %.2e | %.2f seq/s %.2f res/s",
+            stage.name,
+            stage_step,
+            total_steps,
+            loss_avg,
+            rec_avg,
+            rmsd_avg,
+            perplexity_avg,
+            util * 100.0,
+            kl,
+            lr,
+            ex_speed,
+            res_speed,
+        )
+
+    def _save_checkpoint(self, stage: StageConfig) -> None:
+        ckpt_dir = self.output_dir / "checkpoints"
+        ckpt_path = ckpt_dir / f"{stage.name}_step{self.global_step:06d}.pt"
+        save_checkpoint(
+            {
+                "model": self.model.state_dict(),
+                "optimizer": self.optimizer.state_dict(),
+                "stage": stage.name,
+                "global_step": self.global_step,
+                "config": dataclasses.asdict(self.model_cfg),
+            },
+            ckpt_path,
+        )
+
+    def _build_dataloader(self, stage: StageConfig) -> DataLoader:
+        dataset = BackboneDataset(
+            self.data_cfg.root,
+            chain_ids=self.data_cfg.chain_ids,
+            length_cap=stage.length_cap,
+            k=self.data_cfg.k,
+            cache=self.data_cfg.cache,
+        )
+        loader = DataLoader(
+            dataset,
+            batch_size=stage.batch_size,
+            shuffle=True,
+            num_workers=self.data_cfg.num_workers,
+            pin_memory=self.device.type == "cuda",
+            collate_fn=collate_backbones,
+            drop_last=False,
+        )
+        return loader
+
+    def run(self) -> None:
+        for stage_idx, stage in enumerate(self.train_cfg.stages):
+            self.logger.info("Starting stage %d: %s", stage_idx + 1, stage.name)
+
+            dataloader = self._build_dataloader(stage)
+            batches_per_epoch = len(dataloader)
+            total_updates = stage.effective_total_steps(batches_per_epoch)
+            scheduler = WarmupCosineScheduler(
+                self.optimizer,
+                warmup_steps=stage.warmup_steps,
+                total_steps=total_updates,
+                base_lr=stage.base_lr,
+                min_lr=stage.min_lr,
+            )
+
+            trackers = {
+                "loss": MetricTracker(),
+                "recon": MetricTracker(),
+                "rmsd": MetricTracker(),
+                "perplexity": MetricTracker(),
+            }
+
+            samples_since_log = 0
+            residues_since_log = 0
+            last_log_time = time.perf_counter()
+
+            stage_step = 0
+            accum_counter = 0
+
+            autocast_context = (
+                torch.cuda.amp.autocast if self.amp_enabled else contextlib.nullcontext
+            )
+            autocast_kwargs = {"dtype": torch.bfloat16} if self.amp_enabled else {}
+
+            self.optimizer.zero_grad(set_to_none=True)
+
+            while stage_step < total_updates:
+                for batch in dataloader:
+                    if self.train_cfg.random_rotation:
+                        _apply_random_rotation(batch)
+                    if stage.nan_mask_prob > 0.0:
+                        _apply_nan_mask(batch, stage.nan_mask_prob, stage.nan_mask_span)
+
+                    with autocast_context(**autocast_kwargs):
+                        outputs = self.model(batch)
+                        loss = outputs["total_loss"] / max(stage.accumulation_steps, 1)
+
+                    loss.backward()
+                    accum_counter += 1
+
+                    batch_mask = batch["mask"]
+                    batch_size = int(batch_mask.shape[0])
+                    residue_count = int(batch_mask.sum().item())
+
+                    trackers["loss"].update(float(outputs["total_loss"].detach().item()), batch_size)
+                    trackers["recon"].update(float(outputs["reconstruction"].detach().item()), batch_size)
+                    with torch.no_grad():
+                        target_coords = batch["coords"].to(
+                            device=self.device, dtype=outputs["decoded"].dtype
+                        )
+                        rmsd_val = rmsd(outputs["decoded"].detach(), target_coords, mask=outputs["mask"]).item()
+                        trackers["rmsd"].update(rmsd_val, batch_size)
+                        trackers["perplexity"].update(
+                            float(outputs["vq_losses"]["perplexity"].detach().item())
+                        )
+
+                    samples_since_log += batch_size
+                    residues_since_log += residue_count
+
+                    if accum_counter >= stage.accumulation_steps:
+                        if self.train_cfg.clip_grad > 0:
+                            clip_grad_norm_(self.model.parameters(), self.train_cfg.clip_grad)
+                        self.optimizer.step()
+                        self.optimizer.zero_grad(set_to_none=True)
+                        scheduler.step()
+                        accum_counter = 0
+
+                        stage_step += 1
+                        self.global_step += 1
+
+                        if (
+                            self.train_cfg.checkpoint_interval
+                            and self.global_step % int(self.train_cfg.checkpoint_interval) == 0
+                        ):
+                            self._save_checkpoint(stage)
+
+                        if (
+                            self.train_cfg.export.enabled
+                            and self.train_cfg.export.every_n_steps
+                            and self.global_step % int(self.train_cfg.export.every_n_steps) == 0
+                        ):
+                            dataset = dataloader.dataset  # type: ignore[assignment]
+                            _export_samples(
+                                self.model,
+                                dataset,
+                                self.train_cfg.export,
+                                stage.name,
+                                self.global_step,
+                                self.output_dir,
+                                self.logger,
+                            )
+
+                        if self.train_cfg.log_interval and stage_step % self.train_cfg.log_interval == 0:
+                            now = time.perf_counter()
+                            self._log_stage_progress(
+                                stage,
+                                stage_step,
+                                total_updates,
+                                trackers,
+                                samples_since_log,
+                                residues_since_log,
+                                now - last_log_time,
+                            )
+                            samples_since_log = 0
+                            residues_since_log = 0
+                            last_log_time = now
+
+                        if stage_step >= total_updates:
+                            break
+
+                if stage_step >= total_updates:
+                    break
+
+            # Flush any remaining gradients (unlikely when accumulation divides batches).
+            if accum_counter > 0 and stage_step < total_updates:
+                if self.train_cfg.clip_grad > 0:
+                    clip_grad_norm_(self.model.parameters(), self.train_cfg.clip_grad)
+                self.optimizer.step()
+                self.optimizer.zero_grad(set_to_none=True)
+                scheduler.step()
+                stage_step += 1
+                self.global_step += 1
+
+            self._save_checkpoint(stage)
+
+            if self.train_cfg.export.enabled and self.train_cfg.export.on_stage_end:
+                dataset = dataloader.dataset  # type: ignore[assignment]
+                _export_samples(
+                    self.model,
+                    dataset,
+                    self.train_cfg.export,
+                    stage.name,
+                    self.global_step,
+                    self.output_dir,
+                    self.logger,
+                )
+
+            self.logger.info("Completed stage %s", stage.name)
+
 
 def train(config_path: str) -> None:
-    """Run training with a configuration file (stub)."""
-    raise NotImplementedError("train is not yet implemented")
+    """Entry point mirroring the public API."""
+
+    Trainer(config_path).run()
+
+
+__all__ = ["train", "Trainer"]
+

--- a/src/gcpvqvae/utils/checkpoint.py
+++ b/src/gcpvqvae/utils/checkpoint.py
@@ -1,13 +1,25 @@
-"""Checkpoint loading and saving utilities."""
+"""Checkpoint helpers wrapping :func:`torch.save` and :func:`torch.load`."""
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any, Optional
 
-def save_checkpoint(state, path: str) -> None:
-    """Persist training state to disk (stub)."""
-    raise NotImplementedError("save_checkpoint is not yet implemented")
+import torch
 
 
-def load_checkpoint(path: str):
-    """Restore training state from disk (stub)."""
-    raise NotImplementedError("load_checkpoint is not yet implemented")
+def save_checkpoint(state: dict[str, Any], path: str | Path) -> None:
+    """Persist ``state`` to ``path`` creating parent directories as needed."""
+
+    path_obj = Path(path)
+    path_obj.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(state, path_obj)
+
+
+def load_checkpoint(path: str | Path, *, map_location: Optional[str | torch.device] = None) -> dict[str, Any]:
+    """Load and return a previously saved training state."""
+
+    return torch.load(Path(path), map_location=map_location)
+
+
+__all__ = ["save_checkpoint", "load_checkpoint"]

--- a/src/gcpvqvae/utils/logging.py
+++ b/src/gcpvqvae/utils/logging.py
@@ -1,8 +1,29 @@
-"""Logging utilities integrating tqdm and TensorBoard (stub)."""
+"""Minimal logging helpers used by the training harness."""
 
 from __future__ import annotations
 
+import logging
 
-def get_logger(name: str = "gcpvqvae"):
-    """Return an application logger (stub)."""
-    raise NotImplementedError("get_logger is not yet implemented")
+
+def get_logger(name: str = "gcpvqvae", level: int = logging.INFO) -> logging.Logger:
+    """Return a configured :class:`logging.Logger` instance.
+
+    The helper ensures that multiple invocations do not attach duplicate
+    handlers which would otherwise result in repeated log lines when modules
+    import the utility from different places.  The default configuration keeps
+    the output compact and console friendly which suits both interactive runs
+    and automated tests.
+    """
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler: logging.Handler = logging.StreamHandler()
+        formatter = logging.Formatter("[%(asctime)s] %(levelname)s - %(message)s", "%H:%M:%S")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    logger.propagate = False
+    return logger
+
+
+__all__ = ["get_logger"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration ensuring the source tree is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,0 +1,150 @@
+"""Tests for the data ingestion and featurisation pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import gemmi
+import torch
+
+from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
+from gcpvqvae.data.featurize import featurize_backbone
+from gcpvqvae.data.mmcif import PAD_INDEX, load_mmcif
+
+
+def _add_atom(residue: gemmi.Residue, name: str, position, *, occ: float = 1.0, altloc: str = "") -> None:
+    atom = gemmi.Atom()
+    atom.name = name
+    atom.pos = gemmi.Position(*position)
+    atom.occ = occ
+    if altloc:
+        atom.altloc = altloc
+    atom.b_iso = 10.0
+    residue.add_atom(atom)
+
+
+def _build_test_structure(path: Path) -> dict[str, torch.Tensor]:
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(30.0, 30.0, 30.0, 90.0, 90.0, 90.0)
+
+    info: dict[str, torch.Tensor] = {}
+
+    model = gemmi.Model("0")
+    chain_a = gemmi.Chain("A")
+    ca_positions_a = []
+    residue_names_a = ["ALA", "GLY", "SER"]
+    for idx, name in enumerate(residue_names_a, start=1):
+        residue = gemmi.Residue()
+        residue.name = name
+        residue.het_flag = " "
+        residue.seqid = gemmi.SeqId(str(idx))
+        base = 3.8 * (idx - 1)
+        _add_atom(residue, "N", (base, 0.5, 0.0))
+        _add_atom(residue, "CA", (base + 1.2, 1.0, (-1) ** idx * 0.3), occ=0.2, altloc="A")
+        _add_atom(residue, "CA", (base + 1.0, 1.2, (-1) ** idx * 0.4), occ=0.8, altloc="B")
+        _add_atom(residue, "C", (base + 2.4, 0.7, 0.5))
+        chain_a.add_residue(residue)
+        ca_positions_a.append([base + 1.0, 1.2, (-1) ** idx * 0.4])
+
+    model.add_chain(chain_a)
+    info["A"] = torch.tensor(ca_positions_a, dtype=torch.float32)
+
+    chain_b = gemmi.Chain("B")
+    ca_positions_b = []
+    residue_names_b = ["VAL", "TYR"]
+    for idx, name in enumerate(residue_names_b, start=1):
+        residue = gemmi.Residue()
+        residue.name = name
+        residue.het_flag = " "
+        residue.seqid = gemmi.SeqId(str(idx))
+        base = 4.0 * (idx - 1)
+        _add_atom(residue, "N", (0.2, base, 1.0))
+        _add_atom(residue, "CA", (0.4, base + 1.1, 1.2))
+        if idx == 1:
+            _add_atom(residue, "C", (0.6, base + 2.0, 1.1))
+        # omit C for the second residue to test masking behaviour
+        chain_b.add_residue(residue)
+        ca_positions_b.append([0.4, base + 1.1, 1.2])
+
+    model.add_chain(chain_b)
+    info["B"] = torch.tensor(ca_positions_b, dtype=torch.float32)
+
+    structure.add_model(model)
+    structure.setup_entities()
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+    return info
+
+
+def test_load_mmcif_parses_backbone(tmp_path):
+    path = tmp_path / "test.cif"
+    info = _build_test_structure(path)
+
+    records = load_mmcif(str(path))
+    assert {record.chain_id for record in records} == {"A", "B"}
+
+    record_a = next(record for record in records if record.chain_id == "A")
+    assert record_a.coords.shape == (3, 3, 3)
+    assert torch.all(record_a.mask)
+    assert torch.all(record_a.atom_mask)
+
+    expected_centroid = info["A"].mean(dim=0)
+    assert torch.allclose(record_a.translation, expected_centroid, atol=1e-5)
+    assert torch.allclose(record_a.coords[:, 1, :].mean(dim=0), torch.zeros(3), atol=1e-5)
+    assert record_a.seq_string == "AGS"
+
+    record_b = next(record for record in records if record.chain_id == "B")
+    assert record_b.coords.shape == (2, 3, 3)
+    assert record_b.mask.tolist() == [True, False]
+    assert record_b.atom_mask[1].tolist() == [True, True, False]
+
+
+def test_featurize_backbone_produces_expected_shapes(tmp_path):
+    path = tmp_path / "test.cif"
+    _build_test_structure(path)
+
+    record = load_mmcif(str(path), chain_id="A")[0]
+    features = featurize_backbone(record, k=2)
+
+    assert features["node_scalars"].shape == (3, 6)
+    assert features["node_vectors"].shape == (3, 3, 3)
+    assert features["backbone_vectors"].shape == (3, 6, 3)
+    assert features["torsion_angles"].shape == (3, 3)
+
+    norms = torch.linalg.norm(features["node_vectors"], dim=-1)
+    valid = record.mask.unsqueeze(-1).expand_as(norms)
+    assert torch.allclose(norms[valid], torch.ones_like(norms[valid]), atol=1e-4)
+
+    edge_index = features["edge_index"]
+    assert edge_index.shape[0] == 2
+    assert edge_index.shape[1] > 0
+    frames = features["edge_frames"]
+    if frames.numel():
+        identity = torch.eye(3, dtype=frames.dtype)
+        orthogonality = frames.transpose(-1, -2) @ frames
+        assert torch.allclose(orthogonality, identity.expand_as(orthogonality), atol=1e-4)
+
+
+def test_dataset_and_collate(tmp_path):
+    path = tmp_path / "test.cif"
+    _build_test_structure(path)
+
+    dataset = BackboneDataset(path, k=2)
+    assert len(dataset) == 2
+
+    sample = dataset[0]
+    assert sample["coords"].ndim == 3
+    assert sample["node_scalars"].shape[-1] == 6
+    assert "metadata" in sample
+
+    batch = collate_backbones([dataset[0], dataset[1]])
+    assert batch["coords"].shape[0] == 2
+    assert batch["coords"].shape[1] >= sample["coords"].shape[0]
+    assert torch.all(batch["seq"][0, batch["lengths"][0] : ] == PAD_INDEX)
+
+    total_nodes = int(batch["lengths"].sum())
+    assert batch["node_batch"].shape[0] == total_nodes
+    assert batch["edge_vectors"].shape[0] == batch["edge_index"].shape[1]
+    assert len(batch["metadata"]) == 2
+    assert len(batch["sequences"]) == 2

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,6 +1,69 @@
-"""Unit tests for the rotation decoder (stub)."""
+"""Unit tests for the rotation decoder."""
+
+from __future__ import annotations
+
+import torch
+
+from gcpvqvae.models.decoder import RotationDecoder
 
 
-def test_rotation_decoder_stub():
-    """Placeholder test."""
-    assert True
+def _identity_decoder(in_dim: int) -> RotationDecoder:
+    decoder = RotationDecoder(in_dim, translation_scale=1.0)
+    with torch.no_grad():
+        decoder.proj.weight.zero_()
+        decoder.proj.bias.zero_()
+        decoder.proj.weight.copy_(torch.eye(9, in_dim))
+    return decoder
+
+
+def test_rotation_decoder_identity_frame() -> None:
+    decoder = _identity_decoder(9)
+    latents = torch.tensor([[[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]]])
+    coords, (R, t) = decoder(latents)
+
+    template = decoder.template
+    assert torch.allclose(coords[0, 0], template, atol=1e-6)
+    assert torch.allclose(R, torch.eye(3))
+    assert torch.allclose(t, torch.zeros(3))
+
+
+def test_rotation_decoder_accumulates_translations() -> None:
+    decoder = _identity_decoder(9)
+    latents = torch.tensor(
+        [
+            [
+                [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+
+    coords, (R, t) = decoder(latents)
+
+    ca_positions = coords[0, :, 1, :]
+    assert torch.allclose(ca_positions[0], torch.tensor([1.0, 0.0, 0.0]))
+    assert torch.allclose(ca_positions[1], torch.tensor([1.0, 1.0, 0.0]))
+    assert torch.allclose(t, torch.tensor([1.0, 1.0, 0.0]))
+    assert torch.allclose(R, torch.eye(3))
+
+
+def test_rotation_decoder_respects_mask() -> None:
+    decoder = _identity_decoder(9)
+    latents = torch.tensor(
+        [
+            [
+                [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+    mask = torch.tensor([[True, False]])
+
+    coords, (R, t) = decoder(latents, mask=mask)
+
+    ca_positions = coords[0, :, 1, :]
+    assert torch.allclose(ca_positions[0], torch.tensor([1.0, 0.0, 0.0]))
+    assert torch.allclose(ca_positions[1], torch.zeros(3))
+    assert torch.allclose(t, torch.tensor([1.0, 0.0, 0.0]))

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,6 +1,24 @@
-"""End-to-end integration smoke test (stub)."""
+"""End-to-end integration smoke tests."""
+
+from __future__ import annotations
+
+import torch
+
+from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.vq import VectorQuantizer
 
 
-def test_end_to_end_stub():
-    """Placeholder test."""
-    assert True
+def test_vq_decoder_pipeline_runs() -> None:
+    batch, length, dim = 2, 4, 3
+    vq = VectorQuantizer(num_codes=4, dim=dim, beta=0.1, decay=0.9, rotation_trick=True)
+    decoder = RotationDecoder(dim, translation_scale=0.5)
+
+    latents = torch.randn(batch, length, dim, requires_grad=True)
+    quantized, indices, losses = vq(latents)
+    coords, _ = decoder(quantized)
+
+    assert coords.shape == (batch, length, 3, 3)
+    assert indices.shape == (batch, length)
+    total_loss = losses["commitment"] + losses["codebook"]
+    total_loss.backward()
+    assert torch.isfinite(latents.grad).all()

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -1,6 +1,69 @@
-"""Unit tests for frame construction (stub)."""
+"""Unit tests for local frame construction and alignment helpers."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from gcpvqvae.geometry.frames import build_local_frames, kabsch_align
 
 
-def test_build_local_frames_stub():
-    """Placeholder test."""
-    assert True
+def _random_rotation(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    axis = torch.randn(3, device=device, dtype=dtype)
+    axis = axis / torch.linalg.norm(axis)
+    angle = torch.rand(1, device=device, dtype=dtype) * 2 * math.pi
+    K = torch.tensor(
+        [
+            [0.0, -axis[2].item(), axis[1].item()],
+            [axis[2].item(), 0.0, -axis[0].item()],
+            [-axis[1].item(), axis[0].item(), 0.0],
+        ],
+        device=device,
+        dtype=dtype,
+    )
+    R = torch.eye(3, device=device, dtype=dtype) + torch.sin(angle) * K + (1 - torch.cos(angle)) * (K @ K)
+    return R
+
+
+def test_build_local_frames_right_handed() -> None:
+    coords = torch.tensor(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.2, 0.0],
+            [2.1, 0.3, 0.5],
+            [3.1, 0.1, 0.8],
+        ],
+        dtype=torch.float32,
+    )
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+    frames = build_local_frames(coords, edge_index)
+
+    assert frames.shape == (3, 3, 3)
+    tangent = frames[:, :, 0]
+    diff = coords[edge_index[1]] - coords[edge_index[0]]
+    diff = diff / torch.linalg.norm(diff, dim=-1, keepdim=True)
+    assert torch.allclose(tangent, diff, atol=1e-5)
+
+    orthogonality = torch.matmul(frames.transpose(-1, -2), frames)
+    identity = torch.eye(3).expand_as(orthogonality)
+    assert torch.allclose(orthogonality, identity, atol=1e-5)
+
+    det = torch.linalg.det(frames)
+    assert torch.all(det > 0.99)
+
+
+def test_kabsch_align_recovers_transform() -> None:
+    device = torch.device("cpu")
+    dtype = torch.float64
+    points = torch.randn(10, 3, device=device, dtype=dtype)
+    rotation = _random_rotation(device, dtype)
+    translation = torch.tensor([0.4, -1.2, 0.7], device=device, dtype=dtype)
+
+    transformed = (points @ rotation) + translation
+
+    R, t, aligned = kabsch_align(points, transformed, return_aligned=True)
+
+    assert torch.allclose(R, rotation, atol=1e-6)
+    assert torch.allclose(t, translation, atol=1e-6)
+    assert aligned is not None and torch.allclose(aligned, transformed, atol=1e-6)

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import gemmi
+import torch
+
+from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
+from gcpvqvae.data.mmcif import BackboneRecord
+from gcpvqvae.models.gcpnet import GCPNetConfig
+from gcpvqvae.models.gcpvqvae import (
+    DataPipelineConfig,
+    GCPVQVAE,
+    GCPVQVAEConfig,
+    RotationHeadConfig,
+    VectorQuantizerConfig,
+)
+from gcpvqvae.models.transformer import TransformerConfig
+
+
+def _add_atom(residue: gemmi.Residue, name: str, position, *, occ: float = 1.0, altloc: str = "") -> None:
+    atom = gemmi.Atom()
+    atom.name = name
+    atom.pos = gemmi.Position(*position)
+    atom.occ = occ
+    if altloc:
+        atom.altloc = altloc
+    atom.b_iso = 10.0
+    residue.add_atom(atom)
+
+
+def _build_test_structure(path: Path) -> None:
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(30.0, 30.0, 30.0, 90.0, 90.0, 90.0)
+
+    model = gemmi.Model("0")
+    chain_a = gemmi.Chain("A")
+    for idx, name in enumerate(["ALA", "GLY", "SER"], start=1):
+        residue = gemmi.Residue()
+        residue.name = name
+        residue.het_flag = " "
+        residue.seqid = gemmi.SeqId(str(idx))
+        base = 3.8 * (idx - 1)
+        _add_atom(residue, "N", (base, 0.5, 0.0))
+        _add_atom(residue, "CA", (base + 1.2, 1.0, (-1) ** idx * 0.3), occ=0.2, altloc="A")
+        _add_atom(residue, "CA", (base + 1.0, 1.2, (-1) ** idx * 0.4), occ=0.8, altloc="B")
+        _add_atom(residue, "C", (base + 2.4, 0.7, 0.5))
+        chain_a.add_residue(residue)
+
+    chain_b = gemmi.Chain("B")
+    for idx, name in enumerate(["VAL", "TYR"], start=1):
+        residue = gemmi.Residue()
+        residue.name = name
+        residue.het_flag = " "
+        residue.seqid = gemmi.SeqId(str(idx))
+        base = 4.0 * (idx - 1)
+        _add_atom(residue, "N", (0.2, base, 1.0))
+        _add_atom(residue, "CA", (0.4, base + 1.1, 1.2))
+        if idx == 1:
+            _add_atom(residue, "C", (0.6, base + 2.0, 1.1))
+        chain_b.add_residue(residue)
+
+    model.add_chain(chain_a)
+    model.add_chain(chain_b)
+    structure.add_model(model)
+    structure.setup_entities()
+
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+
+def _make_config() -> GCPVQVAEConfig:
+    gcp_cfg = GCPNetConfig(
+        hidden_scalar_dim=64,
+        hidden_vector_dim=8,
+        latent_dim=32,
+        layers=2,
+    )
+    vq_cfg = VectorQuantizerConfig(num_codes=32, dim=24, beta=0.25, decay=0.9, kmeans_iters=1)
+    enc_cfg = TransformerConfig(
+        input_dim=gcp_cfg.latent_dim,
+        model_dim=48,
+        output_dim=vq_cfg.dim,
+        num_layers=2,
+        num_heads=4,
+        num_kv_heads=2,
+        dropout=0.0,
+    )
+    dec_cfg = TransformerConfig(
+        input_dim=vq_cfg.dim,
+        model_dim=48,
+        num_layers=2,
+        num_heads=4,
+        num_kv_heads=1,
+        dropout=0.0,
+    )
+    rot_cfg = RotationHeadConfig(input_dim=48, translation_scale=1.0)
+    data_cfg = DataPipelineConfig(length_cap=512, knn=4)
+    return GCPVQVAEConfig(
+        gcp=gcp_cfg,
+        encoder=enc_cfg,
+        decoder=dec_cfg,
+        vq=vq_cfg,
+        rotation=rot_cfg,
+        data=data_cfg,
+    )
+
+
+def test_model_forward_runs(tmp_path) -> None:
+    cif_path = Path(tmp_path) / "toy.cif"
+    _build_test_structure(cif_path)
+
+    dataset = BackboneDataset(cif_path, k=2)
+    batch = collate_backbones([dataset[0]])
+
+    model = GCPVQVAE(_make_config())
+    output = model(batch)
+
+    assert "total_loss" in output
+    loss = output["total_loss"]
+    loss.backward()
+    assert torch.isfinite(loss)
+    grads = [p.grad for p in model.parameters() if p.requires_grad and p.grad is not None]
+    assert grads, "expected gradients to flow"
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+def test_encode_decode_roundtrip(tmp_path) -> None:
+    cif_path = Path(tmp_path) / "toy.cif"
+    _build_test_structure(cif_path)
+
+    model = GCPVQVAE(_make_config())
+
+    encoded = model.encode(str(cif_path), chain_id="A", k=2)
+    tokens = encoded["tokens"]
+    mask = encoded["mask"]
+
+    assert tokens.shape[0] == encoded["length"]
+    assert mask.shape[0] == encoded["length"]
+
+    decoded = model.decode(
+        tokens,
+        pose_header=encoded["pose_header"],
+        mask=mask,
+        metadata=encoded["metadata"],
+    )
+
+    coords = decoded["coords"]
+    assert coords.shape[0] == encoded["length"]
+    assert decoded["mask"].shape == mask.shape
+
+    record = decoded["records"]
+    assert isinstance(record, BackboneRecord)
+    assert record.coords.shape[0] == int(mask.sum().item())

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,119 @@
+import gemmi
+import yaml
+
+from gcpvqvae.system.train import train
+
+
+def _build_toy_structure(path):
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(30.0, 30.0, 30.0, 90.0, 90.0, 90.0)
+
+    model = gemmi.Model("0")
+    chain = gemmi.Chain("A")
+    for idx, offset in enumerate((0.0, 3.8, 7.6), start=1):
+        residue = gemmi.Residue()
+        residue.name = "GLY"
+        residue.het_flag = " "
+        residue.seqid = gemmi.SeqId(str(idx))
+
+        atom_n = gemmi.Atom()
+        atom_n.name = "N"
+        atom_n.pos = gemmi.Position(offset, 0.0, 0.0)
+        atom_n.occ = 1.0
+        residue.add_atom(atom_n)
+
+        atom_ca = gemmi.Atom()
+        atom_ca.name = "CA"
+        atom_ca.pos = gemmi.Position(offset + 1.2, 0.5, (-1) ** idx * 0.3)
+        atom_ca.occ = 1.0
+        residue.add_atom(atom_ca)
+
+        atom_c = gemmi.Atom()
+        atom_c.name = "C"
+        atom_c.pos = gemmi.Position(offset + 2.4, 0.1, 0.6)
+        atom_c.occ = 1.0
+        residue.add_atom(atom_c)
+
+        chain.add_residue(residue)
+
+    model.add_chain(chain)
+    structure.add_model(model)
+    structure.setup_entities()
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+
+def test_training_harness_runs_single_stage(tmp_path):
+    data_path = tmp_path / "toy.cif"
+    _build_toy_structure(data_path)
+
+    output_dir = tmp_path / "runs"
+    config = {
+        "data": {
+            "root": str(data_path),
+            "k": 4,
+            "num_workers": 0,
+            "cache": True,
+        },
+        "model": {
+            "gcp": {
+                "hidden_scalar_dim": 32,
+                "hidden_vector_dim": 4,
+                "edge_scalar_dim": 8,
+                "edge_vector_dim": 1,
+                "latent_dim": 64,
+                "layers": 2,
+            },
+            "vq": {
+                "num_codes": 64,
+                "dim": 64,
+                "beta": 0.25,
+                "decay": 0.99,
+                "kmeans_iters": 1,
+            },
+            "encoder": {
+                "model_dim": 128,
+                "num_layers": 2,
+                "num_heads": 4,
+                "num_kv_heads": 2,
+            },
+            "decoder": {
+                "model_dim": 128,
+                "num_layers": 2,
+                "num_heads": 4,
+                "num_kv_heads": 1,
+            },
+        },
+        "train": {
+            "seed": 123,
+            "amp": False,
+            "clip_grad": 1.0,
+            "random_rotation": False,
+            "log_interval": 1,
+            "checkpoint_interval": 1,
+            "output_dir": str(output_dir),
+            "export": {"enabled": False},
+            "stages": [
+                {
+                    "name": "test",
+                    "length_cap": 512,
+                    "batch_size": 1,
+                    "base_lr": 0.001,
+                    "min_lr": 1e-5,
+                    "warmup_steps": 1,
+                    "epochs": 1,
+                    "accumulation_steps": 1,
+                    "nan_mask_prob": 0.0,
+                }
+            ],
+        },
+    }
+
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(config, handle)
+
+    train(str(config_path))
+
+    checkpoints = list((output_dir / "checkpoints").glob("*.pt"))
+    assert checkpoints, "training did not produce checkpoints"

--- a/tests/test_vq.py
+++ b/tests/test_vq.py
@@ -1,6 +1,64 @@
-"""Unit tests for vector quantization components (stub)."""
+"""Unit tests for vector quantisation components."""
+
+from __future__ import annotations
+
+import torch
+
+from gcpvqvae.models.vq import VectorQuantizer
 
 
-def test_vector_quantizer_stub():
-    """Placeholder test."""
-    assert True
+def test_vector_quantizer_assigns_nearest_codes() -> None:
+    vq = VectorQuantizer(num_codes=3, dim=3, beta=0.25, decay=1.0, rotation_trick=True)
+    with torch.no_grad():
+        vq.embedding.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+        )
+
+    latents = torch.tensor(
+        [
+            [0.9, 0.1, 0.0],
+            [0.0, 0.8, 0.2],
+            [0.0, 0.2, 0.7],
+        ],
+        requires_grad=True,
+        dtype=torch.float32,
+    )
+
+    quantized, indices, losses = vq(latents)
+
+    assert indices.tolist() == [0, 1, 2]
+    expected = torch.tensor(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    assert torch.allclose(quantized, expected)
+    assert {"commitment", "codebook", "orthogonality", "perplexity"} <= set(losses.keys())
+
+    loss = quantized.sum() + losses["commitment"] + losses["codebook"]
+    loss.backward()
+    assert latents.grad is not None
+    assert torch.isfinite(latents.grad).all()
+
+
+def test_vector_quantizer_supports_masks() -> None:
+    vq = VectorQuantizer(num_codes=2, dim=2, beta=0.25, decay=1.0, rotation_trick=False)
+    with torch.no_grad():
+        vq.embedding.copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
+
+    latents = torch.tensor([[0.9, 0.1], [0.0, 1.2]], requires_grad=True)
+    mask = torch.tensor([True, False])
+
+    quantized, indices, _ = vq(latents, mask=mask)
+
+    assert indices.tolist() == [0, -1]
+    assert torch.allclose(quantized[0], torch.tensor([1.0, 0.0]))
+    assert torch.allclose(quantized[1], latents[1])  # straight-through when masked


### PR DESCRIPTION
## Summary
- implement the full GCP-VQVAE training harness with staged schedules, augmentation, logging, checkpointing, and optional export helpers
- provide base and pilot YAML configurations aligned with the manuscript hyperparameters, plus concrete logging and checkpoint utilities that the harness relies on
- add an integration test that exercises a single-stage training run on a toy mmCIF to ensure the loop and checkpointing behave end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1a0c20ba883238037ce00d4a8a289