### PR TITLE
Refactor CLI to use click command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,86 @@ Clean PyTorch implementation of the geometry-complete protein VQ-VAE (GCP-VQVAE)
 
 ## Features
 
-- GCPNet encoder with equivariant micro-steps and gating
+- GCPNet encoder with equivariant micro-steps and gating for protein backbones
 - Transformer context module with vector-quantized latent tokens
 - 6D rotation decoder with rigid reconstruction losses
-- CLI tooling for encoding, decoding, training, and evaluation
+- Click-powered CLI tooling for training, encoding, decoding, and evaluation workflows
 
 ## Installation
 
+We recommend working inside a fresh Python environment (3.9 or newer).
+
 ```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
 pip install -e .
+```
+
+## Command line interface
+
+Installing the package registers a single entry point named `gpcvq`. Run `gpcvq --help`
+for a full overview of the available subcommands and global options.
+
+```bash
+gpcvq --help
+```
+
+### Training models
+
+Use the `train` subcommand to launch an experiment from a YAML configuration file.
+The configuration is expected to follow the schema used by
+`gcpvqvae.system.train`, with top-level `data`, `model`, and `train` sections.
+Template files are available under `src/gcpvqvae/configs`.
+
+```bash
+# Train using a configuration file in the repository
+# (adjust the path to point at your desired template)
+gpcvq train src/gcpvqvae/configs/base.yaml
+```
+
+You can inspect the supported options with `gpcvq train --help`:
+
+```text
+Usage: gpcvq train [OPTIONS] CONFIG
+
+  Train a GCP-VQVAE model using the settings defined in CONFIG. The
+  configuration file should provide ``data``, ``model``, and ``train``
+  sections as described in :mod:`gcpvqvae.system.train`. Template files are
+  available under ``src/gcpvqvae/configs``.
+```
+
+### Evaluating checkpoints
+
+Once training has produced a checkpoint, the `eval` subcommand can be used to
+compute metrics defined in an evaluation configuration. The schema mirrors the
+training configuration.
+
+```bash
+gpcvq eval path/to/eval_config.yaml
+```
+
+If evaluation encounters an unimplemented feature, the command will exit with a
+human-friendly error explaining the limitation.
+
+### Encoding and decoding structures
+
+The CLI includes placeholders for future encoding and decoding workflows:
+
+```bash
+gpcvq encode structure.cif --output tokens.npz
+gpcvq decode tokens.npz --output rebuilt_structure.cif
+```
+
+At present these commands will raise an informative error directing you to use
+the Python API while the CLI implementations are finalized.
+
+## Development
+
+After cloning the repository you can run the test suite to verify your setup.
+
+```bash
+pytest
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
+    "click>=8.1",
     "torch>=2.3",
     "numpy",
     "einops",
@@ -26,10 +27,7 @@ dependencies = [
 viz = ["tensorboard"]
 
 [project.scripts]
-gcpvq.encode = "vqvae.cli:encode_cmd"
-gcpvq.decode = "vqvae.cli:decode_cmd"
-gcpvq.train = "vqvae.cli:train_cmd"
-gcpvq.eval = "vqvae.cli:eval_cmd"
+gpcvq = "gcpvqvae.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/gcpvqvae/cli.py
+++ b/src/gcpvqvae/cli.py
@@ -2,22 +2,160 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Optional
 
-def encode_cmd() -> None:
-    """Encode protein backbones to VQ tokens (stub)."""
-    raise NotImplementedError("encode_cmd is not yet implemented")
+import click
+
+try:  # Python 3.10+
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # pragma: no cover - fallback for very old Python
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
+
+_CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+try:
+    _PACKAGE_VERSION = version("vqvae")
+except PackageNotFoundError:
+    _PACKAGE_VERSION = "0.0.0"
 
 
-def decode_cmd() -> None:
-    """Decode VQ tokens to backbone coordinates (stub)."""
-    raise NotImplementedError("decode_cmd is not yet implemented")
+def _feature_unavailable(feature: str) -> None:
+    """Raise a friendly error for CLI features that are not yet implemented."""
+
+    raise click.ClickException(
+        f"{feature} is not yet available from the command line. "
+        "Use the Python API for now, or keep an eye on future releases."
+    )
 
 
-def train_cmd() -> None:
-    """Train the model (stub)."""
-    raise NotImplementedError("train_cmd is not yet implemented")
+@click.group(name="gpcvq", context_settings=_CONTEXT_SETTINGS)
+@click.version_option(_PACKAGE_VERSION, prog_name="gpcvq")
+def gpcvq() -> None:
+    """Geometry-complete protein VQ-VAE command line interface.
+
+    The CLI centralizes the major workflows for training, encoding, decoding, and
+    evaluating models.  Run ``gpcvq <command> --help`` for details on any command.
+    """
 
 
-def eval_cmd() -> None:
-    """Evaluate the model (stub)."""
-    raise NotImplementedError("eval_cmd is not yet implemented")
+@gpcvq.command(
+    name="train",
+    short_help="Train a model from a YAML configuration file.",
+    help=(
+        "Train a GCP-VQVAE model using the settings defined in CONFIG. "
+        "The configuration file should provide ``data``, ``model``, and ``train`` "
+        "sections as described in :mod:`gcpvqvae.system.train`.  Template files are "
+        "available under ``src/gcpvqvae/configs``."
+    ),
+)
+@click.argument(
+    "config",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    metavar="CONFIG",
+)
+def train_command(config: Path) -> None:
+    """Kick off model training with the provided configuration file."""
+
+    from gcpvqvae.system.train import train as run_train
+
+    run_train(str(config))
+
+
+@gpcvq.command(
+    name="encode",
+    short_help="Encode backbone structures into discrete tokens.",
+    help=(
+        "Encode protein backbone structures into the model's vector-quantized "
+        "token representation.  Provide either a single mmCIF/PDB file or a "
+        "directory containing structures.  Results are written to OUTPUT as a "
+        "NumPy archive containing the tokens and associated metadata. "
+        "\n\nNote: the public CLI for encoding is not yet implemented.  Invoke the "
+        "Python API (``GCPVQVAE.encode``) for the time being."
+    ),
+)
+@click.argument(
+    "input_path",
+    type=click.Path(dir_okay=True, path_type=Path),
+    metavar="INPUT",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Location to store the encoded tokens (defaults to INPUT with a .npz suffix).",
+)
+@click.option(
+    "--chain-id",
+    type=str,
+    help="Restrict encoding to a specific chain identifier (optional).",
+)
+def encode_command(
+    input_path: Path, output_path: Optional[Path], chain_id: Optional[str]
+) -> None:
+    """Placeholder implementation for the encode sub-command."""
+
+    _feature_unavailable("Encoding")
+
+
+@gpcvq.command(
+    name="decode",
+    short_help="Reconstruct coordinates from discrete tokens.",
+    help=(
+        "Decode previously generated VQ token sequences back into Cartesian backbone "
+        "coordinates.  TOKENS should reference a NumPy archive produced by the "
+        "encoder.  The decoded backbone will be written to OUTPUT in mmCIF format. "
+        "\n\nNote: CLI decoding is not yet available; please use the Python API "
+        "instead."
+    ),
+)
+@click.argument(
+    "tokens",
+    type=click.Path(dir_okay=False, path_type=Path),
+    metavar="TOKENS",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Destination mmCIF file for reconstructed coordinates.",
+)
+def decode_command(tokens: Path, output_path: Optional[Path]) -> None:
+    """Placeholder implementation for the decode sub-command."""
+
+    _feature_unavailable("Decoding")
+
+
+@gpcvq.command(
+    name="eval",
+    short_help="Evaluate a trained checkpoint.",
+    help=(
+        "Evaluate a trained model checkpoint using the experiment CONFIG file. "
+        "The configuration should describe the dataset split, checkpoint to load, "
+        "and metrics to compute."
+    ),
+)
+@click.argument(
+    "config",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    metavar="CONFIG",
+)
+def eval_command(config: Path) -> None:
+    """Run model evaluation for a specified configuration."""
+
+    from gcpvqvae.system.eval import evaluate
+
+    try:
+        evaluate(str(config))
+    except NotImplementedError as exc:  # pragma: no cover - pending implementation
+        raise click.ClickException(str(exc)) from exc
+
+
+def main() -> None:
+    """Entry-point used by setuptools console scripts."""
+
+    gpcvq()  # pylint: disable=no-value-for-parameter
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- replace the CLI stubs with a Click-powered `gpcvq` command group that exposes train, encode, decode, and eval subcommands with detailed help text
- delegate the train subcommand to the existing `gcpvqvae.system.train.train` entry point and surface friendly errors for features that are not yet implemented via the CLI
- register the consolidated console script and add Click to the project dependencies
- expand the README with CLI installation guidance and concrete usage examples for each subcommand

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1e0a03eac8323ad7694b14b93f410