### PR TITLE
Implement evaluation pipeline with structural metrics

### DIFF
--- a/src/gcpvqvae/geometry/metrics.py
+++ b/src/gcpvqvae/geometry/metrics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 
@@ -79,11 +79,54 @@ def tm_score(
         return torch.tensor(0.0, dtype=coords_a.dtype, device=coords_a.device)
 
     if length_scale is None:
-        length_scale = 1.24 * (L - 15) ** (1 / 3) - 1.8
-        length_scale = float(torch.clamp(torch.tensor(length_scale, dtype=coords_a.dtype), min=0.5))
+        effective_L = max(L, 19)
+        length_scale = 1.24 * (effective_L - 15) ** (1 / 3) - 1.8
+    length_scale = max(float(length_scale), 0.5)
+    length_scale_tensor = torch.tensor(length_scale, dtype=coords_a.dtype, device=coords_a.device)
 
-    score = (1.0 / L) * torch.sum(1.0 / (1.0 + (diff / length_scale) ** 2))
+    score = (1.0 / L) * torch.sum(1.0 / (1.0 + (diff / length_scale_tensor) ** 2))
     return score
 
 
-__all__ = ["rmsd", "tm_score"]
+def gdt_ts(
+    coords_a: Tensor,
+    coords_b: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+    thresholds: Sequence[float] = (1.0, 2.0, 4.0, 8.0),
+) -> Tensor:
+    """Compute the Global Distance Test Total Score (GDT-TS).
+
+    The metric measures the fraction of residues whose Cα atoms fall within the
+    specified distance thresholds after the structures have been aligned.
+    """
+
+    if coords_a.shape != coords_b.shape:
+        raise ValueError("coords_a and coords_b must have identical shapes")
+    if coords_a.size(-2) != 3:
+        raise ValueError("Inputs must contain backbone atoms with shape (..., 3, 3)")
+    if not thresholds:
+        raise ValueError("At least one distance threshold is required")
+
+    ca_a = coords_a[..., 1, :]
+    ca_b = coords_b[..., 1, :]
+    diff = torch.linalg.norm(ca_a - ca_b, dim=-1)
+
+    if mask is not None:
+        mask = mask.to(torch.bool)
+        diff = diff[mask]
+
+    L = diff.numel()
+    if L == 0:
+        return torch.tensor(0.0, dtype=coords_a.dtype, device=coords_a.device)
+
+    scores = []
+    for threshold in thresholds:
+        threshold = float(threshold)
+        within = (diff <= threshold).sum().to(coords_a.dtype)
+        scores.append(within / float(L))
+
+    return torch.mean(torch.stack(scores))
+
+
+__all__ = ["rmsd", "tm_score", "gdt_ts"]

--- a/src/gcpvqvae/system/eval.py
+++ b/src/gcpvqvae/system/eval.py
@@ -2,7 +2,454 @@
 
 from __future__ import annotations
 
+import dataclasses
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-def evaluate(config_path: str) -> None:
-    """Run evaluation with a configuration file (stub)."""
-    raise NotImplementedError("evaluate is not yet implemented")
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+import yaml
+
+from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
+from gcpvqvae.geometry.frames import kabsch_align
+from gcpvqvae.geometry.metrics import gdt_ts, tm_score
+from gcpvqvae.models.gcpvqvae import GCPVQVAE, GCPVQVAEConfig
+from gcpvqvae.utils.checkpoint import load_checkpoint
+from gcpvqvae.utils.logging import get_logger
+
+
+Tensor = torch.Tensor
+
+
+@dataclass
+class EvalDataConfig:
+    root: str
+    chain_ids: Optional[Sequence[str]] = None
+    length_cap: int = 2048
+    k: int = 16
+    num_workers: int = 0
+    cache: bool = True
+
+
+@dataclass
+class EvalRuntimeConfig:
+    batch_size: int = 1
+    device: Optional[str] = None
+    tm_score: bool = True
+    gdt_ts: bool = False
+    max_batches: Optional[int] = None
+    histogram_bins: int = 20
+    quantiles: Tuple[float, ...] = (0.05, 0.5, 0.95)
+
+
+@dataclass
+class EvalModelConfig:
+    checkpoint: str
+    config: Optional[Dict[str, Any]] = None
+
+
+def _load_config(path: str | Path) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+    if not isinstance(raw, dict):
+        raise ValueError("Configuration file must define a dictionary")
+    return raw
+
+
+def _prepare_data_config(raw: Dict[str, Any]) -> EvalDataConfig:
+    if not isinstance(raw, dict) or "root" not in raw:
+        raise ValueError("data.root must be provided in the evaluation config")
+
+    chain_ids = raw.get("chain_ids")
+    if chain_ids is not None and not isinstance(chain_ids, Sequence):
+        raise ValueError("data.chain_ids must be a sequence of chain identifiers")
+
+    return EvalDataConfig(
+        root=str(raw["root"]),
+        chain_ids=tuple(chain_ids) if chain_ids is not None else None,
+        length_cap=int(raw.get("length_cap", 2048)),
+        k=int(raw.get("k", 16)),
+        num_workers=int(raw.get("num_workers", 0)),
+        cache=bool(raw.get("cache", True)),
+    )
+
+
+def _prepare_runtime_config(raw: Dict[str, Any]) -> EvalRuntimeConfig:
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise ValueError("eval section must be a dictionary")
+
+    max_batches = raw.get("max_batches")
+    if max_batches is not None:
+        max_batches = int(max_batches)
+        if max_batches <= 0:
+            max_batches = None
+
+    quantiles_raw = raw.get("quantiles", (0.05, 0.5, 0.95))
+    if quantiles_raw is None:
+        quantiles = ()
+    else:
+        quantiles = []
+        for value in quantiles_raw:
+            q = float(value)
+            if 0.0 <= q <= 1.0:
+                quantiles.append(q)
+        quantiles = tuple(quantiles)
+
+    return EvalRuntimeConfig(
+        batch_size=int(raw.get("batch_size", 1)),
+        device=raw.get("device"),
+        tm_score=bool(raw.get("tm_score", True)),
+        gdt_ts=bool(raw.get("gdt_ts", False)),
+        max_batches=max_batches,
+        histogram_bins=max(int(raw.get("histogram_bins", 20)), 1),
+        quantiles=quantiles,
+    )
+
+
+def _prepare_model_config(raw: Dict[str, Any]) -> EvalModelConfig:
+    if not isinstance(raw, dict) or "checkpoint" not in raw:
+        raise ValueError("model.checkpoint must be provided in the evaluation config")
+
+    overrides = raw.get("config")
+    if overrides is not None and not isinstance(overrides, dict):
+        raise ValueError("model.config must be a dictionary when provided")
+
+    return EvalModelConfig(checkpoint=str(raw["checkpoint"]), config=overrides)
+
+
+def _update_dataclass(instance: Any, updates: Dict[str, Any]) -> Any:
+    if not dataclasses.is_dataclass(instance) or not isinstance(updates, dict):
+        return instance
+    for key, value in updates.items():
+        if not hasattr(instance, key):
+            continue
+        current = getattr(instance, key)
+        if dataclasses.is_dataclass(current):
+            setattr(instance, key, _update_dataclass(current, value))
+        else:
+            setattr(instance, key, value)
+    return instance
+
+
+def _build_model_config(raw: Optional[Dict[str, Any]]) -> GCPVQVAEConfig:
+    config = GCPVQVAEConfig()
+    if raw:
+        for key, value in raw.items():
+            if not hasattr(config, key):
+                continue
+            current = getattr(config, key)
+            if dataclasses.is_dataclass(current):
+                setattr(config, key, _update_dataclass(current, value))
+            else:
+                setattr(config, key, value)
+        config.rotation.input_dim = None
+        config.__post_init__()
+    return config
+
+
+def _linear_regression(x: Sequence[float], y: Sequence[float]) -> Tuple[float, float]:
+    if len(x) < 2 or len(y) < 2:
+        return float("nan"), float("nan")
+
+    x_arr = np.asarray(x, dtype=np.float64)
+    y_arr = np.asarray(y, dtype=np.float64)
+
+    x_mean = float(x_arr.mean())
+    y_mean = float(y_arr.mean())
+
+    denom = float(np.sum((x_arr - x_mean) ** 2))
+    if denom <= 0.0:
+        return float("nan"), y_mean
+
+    slope = float(np.sum((x_arr - x_mean) * (y_arr - y_mean)) / denom)
+    intercept = float(y_mean - slope * x_mean)
+    return slope, intercept
+
+
+def _distribution_summary(values: Sequence[float], quantiles: Sequence[float], bins: int) -> Dict[str, Any]:
+    if not values:
+        return {
+            "mean": float("nan"),
+            "median": float("nan"),
+            "std": float("nan"),
+            "min": float("nan"),
+            "max": float("nan"),
+            "quantiles": {},
+            "histogram": {"counts": [], "edges": []},
+        }
+
+    arr = np.asarray(values, dtype=np.float64)
+    stats = {
+        "mean": float(arr.mean()),
+        "median": float(np.median(arr)),
+        "std": float(arr.std(ddof=0)),
+        "min": float(arr.min()),
+        "max": float(arr.max()),
+    }
+
+    if quantiles:
+        q_vals = np.quantile(arr, quantiles)
+        stats["quantiles"] = {float(q): float(v) for q, v in zip(quantiles, q_vals)}
+    else:
+        stats["quantiles"] = {}
+
+    counts, edges = np.histogram(arr, bins=bins)
+    stats["histogram"] = {"counts": counts.tolist(), "edges": edges.astype(float).tolist()}
+    return stats
+
+
+def _log_distribution(logger, name: str, stats: Dict[str, Any]) -> None:
+    logger.info(
+        "%s: mean=%.3f Å | median=%.3f Å | std=%.3f Å | min=%.3f Å | max=%.3f Å",
+        name,
+        stats["mean"],
+        stats["median"],
+        stats["std"],
+        stats["min"],
+        stats["max"],
+    )
+    if stats.get("quantiles"):
+        quantiles = ", ".join(
+            f"{q * 100:.0f}%%={v:.3f} Å" for q, v in sorted(stats["quantiles"].items())
+        )
+        logger.info("%s quantiles: %s", name, quantiles)
+
+
+class Evaluator:
+    def __init__(self, config_path: str | Path) -> None:
+        self.logger = get_logger()
+        self.config_path = Path(config_path)
+        raw = _load_config(self.config_path)
+        self.data_cfg = _prepare_data_config(raw.get("data", {}))
+        self.runtime_cfg = _prepare_runtime_config(raw.get("eval", {}))
+        self.model_cfg = _prepare_model_config(raw.get("model", {}))
+
+        device_str = self.runtime_cfg.device or (
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self.device = torch.device(device_str)
+
+        self.logger.info(
+            "Evaluating checkpoint %s on %s", self.model_cfg.checkpoint, self.data_cfg.root
+        )
+
+    def _build_dataloader(self) -> DataLoader:
+        dataset = BackboneDataset(
+            self.data_cfg.root,
+            chain_ids=self.data_cfg.chain_ids,
+            length_cap=self.data_cfg.length_cap,
+            k=self.data_cfg.k,
+            cache=self.data_cfg.cache,
+        )
+        if len(dataset) == 0:
+            raise ValueError("Evaluation dataset is empty")
+        loader = DataLoader(
+            dataset,
+            batch_size=self.runtime_cfg.batch_size,
+            shuffle=False,
+            num_workers=self.data_cfg.num_workers,
+            pin_memory=self.device.type == "cuda",
+            collate_fn=collate_backbones,
+            drop_last=False,
+        )
+        return loader
+
+    def _load_model(self) -> GCPVQVAE:
+        checkpoint = load_checkpoint(self.model_cfg.checkpoint, map_location=self.device)
+        state_dict = checkpoint.get("model")
+        if state_dict is None:
+            raise KeyError("Checkpoint does not contain a 'model' state_dict")
+
+        raw_config = self.model_cfg.config or checkpoint.get("config")
+        model_config = _build_model_config(raw_config)
+        model = GCPVQVAE(model_config).to(self.device)
+
+        incompatible = model.load_state_dict(state_dict, strict=False)
+        if hasattr(incompatible, "missing_keys") and incompatible.missing_keys:
+            self.logger.warning("Missing keys when loading checkpoint: %s", incompatible.missing_keys)
+        if hasattr(incompatible, "unexpected_keys") and incompatible.unexpected_keys:
+            self.logger.warning(
+                "Unexpected keys when loading checkpoint: %s", incompatible.unexpected_keys
+            )
+
+        model.eval()
+        return model
+
+    def _align_chain(
+        self,
+        predicted: Tensor,
+        target: Tensor,
+        mask: Tensor,
+    ) -> Optional[Tensor]:
+        valid = mask.to(torch.bool)
+        if valid.sum() <= 0:
+            return None
+
+        src = predicted[valid].reshape(-1, 3)
+        dst = target[valid].reshape(-1, 3)
+        if src.shape[0] < 3 or dst.shape[0] < 3:
+            return None
+
+        rotation, translation, _ = kabsch_align(src, dst)
+        aligned = predicted.reshape(-1, 3) @ rotation + translation
+        return aligned.reshape_as(predicted)
+
+    def run(self) -> Dict[str, Any]:
+        model = self._load_model()
+        dataloader = self._build_dataloader()
+
+        rmsd_values: List[float] = []
+        tm_values: List[float] = []
+        gdt_values: List[float] = []
+        lengths: List[float] = []
+        perplexities: List[float] = []
+
+        num_codes = getattr(model.vq, "num_codes", 0)
+        code_usage = torch.zeros((num_codes,), dtype=torch.bool)
+
+        total_residues = 0
+
+        with torch.no_grad():
+            for batch_idx, batch in enumerate(dataloader):
+                outputs = model(batch)
+
+                decoded = outputs["decoded"].detach()
+                mask = outputs.get("mask")
+                if mask is None:
+                    mask = batch["mask"].to(decoded.device)
+                mask = mask.to(torch.bool)
+
+                target = batch["coords"].to(decoded.device, dtype=decoded.dtype)
+                atom_mask = batch.get("atom_mask")
+                if atom_mask is not None:
+                    atom_mask = atom_mask.to(decoded.device).to(torch.bool)
+                    residue_mask = mask & atom_mask.all(dim=-1)
+                else:
+                    residue_mask = mask
+
+                finite_mask = torch.isfinite(target).all(dim=-1).all(dim=-1)
+                residue_mask = residue_mask & finite_mask
+
+                batch_size = decoded.shape[0]
+                for i in range(batch_size):
+                    valid = residue_mask[i]
+                    if valid.sum().item() == 0:
+                        continue
+                    aligned = self._align_chain(decoded[i], target[i], valid)
+                    if aligned is None:
+                        continue
+
+                    valid_indices = valid
+                    pred_sel = aligned[valid_indices]
+                    tgt_sel = target[i][valid_indices]
+
+                    diff = pred_sel.reshape(-1, 3) - tgt_sel.reshape(-1, 3)
+                    sq = torch.sum(diff**2, dim=-1)
+                    rmsd_val = float(torch.sqrt(sq.mean()).cpu().item())
+                    rmsd_values.append(rmsd_val)
+
+                    length = int(valid_indices.sum().item())
+                    lengths.append(float(length))
+                    total_residues += length
+
+                    if self.runtime_cfg.tm_score:
+                        tm_val = float(tm_score(pred_sel, tgt_sel).cpu().item())
+                        tm_values.append(tm_val)
+
+                    if self.runtime_cfg.gdt_ts:
+                        gdt_val = float(gdt_ts(pred_sel, tgt_sel).cpu().item())
+                        gdt_values.append(gdt_val)
+
+                indices = outputs.get("indices")
+                if indices is not None and num_codes > 0:
+                    flat = indices.detach().to(torch.long)
+                    mask_indices = mask.detach()
+                    flat = torch.where(mask_indices, flat, torch.full_like(flat, -1))
+                    flat = flat[flat >= 0]
+                    if flat.numel() > 0:
+                        unique = torch.unique(flat)
+                        valid_unique = unique[(unique >= 0) & (unique < num_codes)]
+                        if valid_unique.numel() > 0:
+                            code_usage[valid_unique.cpu()] = True
+
+                vq_losses = outputs.get("vq_losses")
+                if isinstance(vq_losses, dict) and "perplexity" in vq_losses:
+                    perplexity = vq_losses["perplexity"]
+                    perplexities.append(float(perplexity.detach().cpu().item()))
+
+                if (
+                    self.runtime_cfg.max_batches is not None
+                    and batch_idx + 1 >= self.runtime_cfg.max_batches
+                ):
+                    break
+
+        slope, intercept = _linear_regression(lengths, rmsd_values)
+        rmsd_stats = _distribution_summary(
+            rmsd_values, self.runtime_cfg.quantiles, self.runtime_cfg.histogram_bins
+        )
+
+        summary: Dict[str, Any] = {
+            "num_chains": len(rmsd_values),
+            "num_residues": total_residues,
+            "rmsd": rmsd_stats,
+            "length_vs_rmsd": {"slope": slope, "intercept": intercept},
+            "codebook": {
+                "num_codes": num_codes,
+                "active_codes": int(code_usage.sum().item()) if num_codes > 0 else 0,
+                "utilization": (
+                    float(code_usage.float().mean().item()) if num_codes > 0 else 0.0
+                ),
+                "perplexity_mean": float(np.mean(perplexities)) if perplexities else float("nan"),
+                "perplexity_std": float(np.std(perplexities)) if perplexities else float("nan"),
+            },
+        }
+
+        if tm_values:
+            summary["tm_score"] = _distribution_summary(
+                tm_values, self.runtime_cfg.quantiles, self.runtime_cfg.histogram_bins
+            )
+        if gdt_values:
+            summary["gdt_ts"] = _distribution_summary(
+                gdt_values, self.runtime_cfg.quantiles, self.runtime_cfg.histogram_bins
+            )
+
+        _log_distribution(self.logger, "RMSD", rmsd_stats)
+        if tm_values:
+            _log_distribution(self.logger, "TM-score", summary["tm_score"])
+        if gdt_values:
+            _log_distribution(self.logger, "GDT-TS", summary["gdt_ts"])
+
+        if math.isfinite(slope):
+            self.logger.info(
+                "Length vs RMSD slope: %.3e Å/residue (intercept %.3f Å)", slope, intercept
+            )
+        else:
+            self.logger.info("Insufficient data to estimate length vs RMSD trend")
+
+        code_summary = summary["codebook"]
+        utilization_pct = code_summary["utilization"] * 100.0
+        self.logger.info(
+            "Codebook utilization: %d/%d (%.2f%%) | perplexity mean=%.2f std=%.2f",
+            code_summary["active_codes"],
+            code_summary["num_codes"],
+            utilization_pct,
+            code_summary["perplexity_mean"],
+            code_summary["perplexity_std"],
+        )
+
+        return summary
+
+
+def evaluate(config_path: str) -> Dict[str, Any]:
+    """Run evaluation using the specified configuration file."""
+
+    return Evaluator(config_path).run()
+
+
+__all__ = ["evaluate", "Evaluator"]

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import torch
+from torch import nn
+from torch.utils.data import Dataset
+
+import yaml
+import pytest
+
+from gcpvqvae.system import eval as eval_module
+
+
+class FakeDataset(Dataset):
+    def __init__(
+        self,
+        _root: str,
+        *,
+        chain_ids=None,
+        length_cap: int = 0,
+        k: int = 0,
+        cache: bool = True,
+    ) -> None:
+        del chain_ids, length_cap, k, cache
+        self.samples: List[Dict[str, torch.Tensor]] = []
+
+        coords_a = torch.tensor(
+            [
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+                [[0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [2.0, 1.0, 0.0]],
+            ],
+            dtype=torch.float32,
+        )
+        coords_b = torch.tensor(
+            [
+                [[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]],
+                [[1.0, 1.0, 0.0], [2.0, 1.0, 0.0], [3.0, 1.0, 0.0]],
+                [[2.0, 1.0, 0.0], [3.0, 1.0, 0.0], [4.0, 1.0, 0.0]],
+            ],
+            dtype=torch.float32,
+        )
+
+        self.samples.append(
+            {
+                "coords": coords_a,
+                "mask": torch.tensor([True, True], dtype=torch.bool),
+                "atom_mask": torch.ones((2, 3), dtype=torch.bool),
+            }
+        )
+        self.samples.append(
+            {
+                "coords": coords_b,
+                "mask": torch.tensor([True, True, True], dtype=torch.bool),
+                "atom_mask": torch.ones((3, 3), dtype=torch.bool),
+            }
+        )
+
+    def __len__(self) -> int:  # pragma: no cover - trivial wrapper
+        return len(self.samples)
+
+    def __getitem__(self, index: int) -> Dict[str, torch.Tensor]:
+        return self.samples[index]
+
+
+def fake_collate(batch: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+    max_len = max(item["coords"].shape[0] for item in batch)
+    batch_size = len(batch)
+
+    coords = torch.zeros((batch_size, max_len, 3, 3), dtype=torch.float32)
+    mask = torch.zeros((batch_size, max_len), dtype=torch.bool)
+    atom_mask = torch.zeros((batch_size, max_len, 3), dtype=torch.bool)
+
+    for i, item in enumerate(batch):
+        length = item["coords"].shape[0]
+        coords[i, :length] = item["coords"]
+        mask[i, :length] = item["mask"]
+        atom_mask[i, :length] = item["atom_mask"]
+
+    return {"coords": coords, "mask": mask, "atom_mask": atom_mask}
+
+
+class FakeModel(nn.Module):
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        super().__init__()
+        self.register_parameter("dummy", nn.Parameter(torch.zeros(1)))
+        self.vq = type("VQ", (), {"num_codes": 4})()
+
+    def forward(self, batch: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        coords = batch["coords"].to(self.dummy.device)
+        mask = batch["mask"].to(self.dummy.device)
+        decoded = coords + 0.1
+        indices = torch.where(
+            mask,
+            torch.zeros_like(mask, dtype=torch.long),
+            torch.full_like(mask, -1, dtype=torch.long),
+        )
+        vq_losses = {"perplexity": torch.tensor(2.0, device=self.dummy.device)}
+        return {"decoded": decoded, "mask": mask, "indices": indices, "vq_losses": vq_losses}
+
+
+def test_evaluate_reports_summary(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(eval_module, "BackboneDataset", FakeDataset)
+    monkeypatch.setattr(eval_module, "collate_backbones", fake_collate)
+    monkeypatch.setattr(eval_module, "GCPVQVAE", FakeModel)
+
+    checkpoint_path = tmp_path / "ckpt.pt"
+    model = FakeModel()
+    torch.save({"model": model.state_dict(), "config": {}}, checkpoint_path)
+
+    config = {
+        "data": {"root": "unused", "k": 1, "num_workers": 0, "cache": False},
+        "model": {"checkpoint": str(checkpoint_path)},
+        "eval": {"batch_size": 2, "tm_score": True, "gdt_ts": True, "histogram_bins": 5},
+    }
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+
+    summary = eval_module.evaluate(str(config_path))
+
+    assert summary["num_chains"] == 2
+    assert summary["num_residues"] == 5
+    assert summary["codebook"]["num_codes"] == 4
+    assert summary["codebook"]["active_codes"] == 1
+    assert summary["codebook"]["utilization"] == 0.25
+    assert summary["codebook"]["perplexity_mean"] == 2.0
+    assert summary["rmsd"]["mean"] == pytest.approx(0.0, abs=1e-6)
+    assert summary["tm_score"]["mean"] == pytest.approx(1.0, abs=1e-6)
+    assert summary["gdt_ts"]["mean"] == pytest.approx(1.0, abs=1e-6)
+    assert summary["length_vs_rmsd"]["slope"] == pytest.approx(0.0, abs=1e-6)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import torch
+
+from gcpvqvae.geometry.metrics import gdt_ts
+
+
+def test_gdt_ts_perfect_alignment() -> None:
+    coords = torch.zeros((5, 3, 3))
+    score = gdt_ts(coords, coords)
+    assert torch.isclose(score, torch.tensor(1.0))
+
+
+def test_gdt_ts_thresholds() -> None:
+    coords_a = torch.zeros((2, 3, 3))
+    coords_b = coords_a.clone()
+
+    coords_b[0, 1, 0] = 0.5  # within all thresholds
+    coords_b[1, 1, 0] = 5.0  # only within the 8 Å threshold
+
+    score = gdt_ts(coords_a, coords_b)
+    expected = torch.tensor((0.5 + 0.5 + 0.5 + 1.0) / 4.0)
+    assert torch.isclose(score, expected)


### PR DESCRIPTION
## Summary
- add an evaluation runner that loads checkpoints, reports RMSD/TM-score/GDT-TS statistics, and tracks codebook utilisation
- extend the geometry metrics helpers with a numerically stable TM-score scale and a reusable GDT-TS implementation
- add tests covering the evaluation summary reporting and the new metric utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d21feba35c8323be0bde87318149da