### PR TITLE
Add coverage for rotation and VQ invariants and integration smoke tests

### DIFF
--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -67,3 +67,22 @@ def test_rotation_decoder_respects_mask() -> None:
     assert torch.allclose(ca_positions[0], torch.tensor([1.0, 0.0, 0.0]))
     assert torch.allclose(ca_positions[1], torch.zeros(3))
     assert torch.allclose(t, torch.tensor([1.0, 0.0, 0.0]))
+
+
+def test_rotation_decoder_produces_valid_rotations() -> None:
+    torch.manual_seed(0)
+    decoder = RotationDecoder(9)
+
+    latents = torch.randn(2, 5, 9)
+    _, (R, _t) = decoder(latents)
+
+    identity = torch.eye(3).expand(R.shape[0], 3, 3)
+    rt_r = torch.matmul(R.transpose(-1, -2), R)
+    assert torch.allclose(rt_r, identity, atol=1e-5)
+    det = torch.linalg.det(R)
+    assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+
+    basis = torch.eye(3)
+    rotated = torch.matmul(R, basis)
+    norms = torch.linalg.norm(rotated, dim=-2)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -2,10 +2,91 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import gemmi
 import torch
 
+from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
+from gcpvqvae.geometry.frames import kabsch_align
+from gcpvqvae.geometry.metrics import rmsd
 from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.gcpvqvae import (
+    DataPipelineConfig,
+    GCPNetConfig,
+    GCPVQVAE,
+    GCPVQVAEConfig,
+    RotationHeadConfig,
+    TransformerConfig,
+    VectorQuantizerConfig,
+)
 from gcpvqvae.models.vq import VectorQuantizer
+
+
+def _build_roundtrip_structure(path: Path) -> None:
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(30.0, 30.0, 30.0, 90.0, 90.0, 90.0)
+
+    model = gemmi.Model("0")
+    chain = gemmi.Chain("A")
+    for idx in range(1, 5):
+        residue = gemmi.Residue()
+        residue.name = "GLY"
+        residue.het_flag = " "
+        residue.seqid = gemmi.SeqId(str(idx))
+        base = 3.6 * (idx - 1)
+        alt = (-1) ** idx
+        for name, pos in zip(
+            ["N", "CA", "C"],
+            [
+                (base, 0.1 * alt, 0.0),
+                (base + 1.2, 0.2 * alt, 0.2 * alt),
+                (base + 2.3, 0.15 * alt, 0.3),
+            ],
+        ):
+            atom = gemmi.Atom()
+            atom.name = name
+            atom.pos = gemmi.Position(*pos)
+            atom.occ = 1.0
+            residue.add_atom(atom)
+        chain.add_residue(residue)
+    model.add_chain(chain)
+    structure.add_model(model)
+    structure.setup_entities()
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+
+def _make_small_config() -> GCPVQVAEConfig:
+    gcp_cfg = GCPNetConfig(
+        hidden_scalar_dim=32,
+        hidden_vector_dim=4,
+        edge_scalar_dim=8,
+        edge_vector_dim=1,
+        latent_dim=32,
+        layers=2,
+    )
+    vq_cfg = VectorQuantizerConfig(num_codes=16, dim=32, beta=0.25, decay=0.9, kmeans_iters=1)
+    enc_cfg = TransformerConfig(
+        input_dim=gcp_cfg.latent_dim,
+        model_dim=64,
+        output_dim=vq_cfg.dim,
+        num_layers=2,
+        num_heads=4,
+        num_kv_heads=2,
+        dropout=0.0,
+    )
+    dec_cfg = TransformerConfig(
+        input_dim=vq_cfg.dim,
+        model_dim=64,
+        num_layers=2,
+        num_heads=4,
+        num_kv_heads=1,
+        dropout=0.0,
+    )
+    rot_cfg = RotationHeadConfig(input_dim=64, translation_scale=1.0)
+    data_cfg = DataPipelineConfig(length_cap=256, knn=4)
+    return GCPVQVAEConfig(gcp=gcp_cfg, encoder=enc_cfg, decoder=dec_cfg, vq=vq_cfg, rotation=rot_cfg, data=data_cfg)
 
 
 def test_vq_decoder_pipeline_runs() -> None:
@@ -22,3 +103,45 @@ def test_vq_decoder_pipeline_runs() -> None:
     total_loss = losses["commitment"] + losses["codebook"]
     total_loss.backward()
     assert torch.isfinite(latents.grad).all()
+
+
+def test_roundtrip_rmsd_after_brief_training(tmp_path) -> None:
+    structure_path = Path(tmp_path) / "toy.cif"
+    _build_roundtrip_structure(structure_path)
+
+    dataset = BackboneDataset(structure_path, k=2)
+    batch = collate_backbones([dataset[0]])
+
+    model = GCPVQVAE(_make_small_config())
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    for _ in range(300):
+        optimizer.zero_grad()
+        output = model(batch)
+        output["total_loss"].backward()
+        optimizer.step()
+
+    encoded = model.encode(str(structure_path), chain_id="A", k=2)
+    decoded = model.decode(
+        encoded["tokens"],
+        pose_header=encoded["pose_header"],
+        mask=encoded["mask"],
+        metadata=encoded["metadata"],
+    )
+
+    coords = decoded["coords"]
+    mask = decoded["mask"]
+    reference = dataset[0]["coords"]
+
+    mask_flat = mask.repeat_interleave(3)
+    _, _, aligned = kabsch_align(
+        reference.view(-1, 3),
+        coords.view(-1, 3),
+        mask=mask_flat,
+        allow_reflections=False,
+        return_aligned=True,
+    )
+    aligned_coords = aligned.view_as(coords)
+
+    value = rmsd(coords.unsqueeze(0), aligned_coords.unsqueeze(0), mask=mask.unsqueeze(0)).item()
+    assert value < 2.0

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -54,6 +54,31 @@ def test_build_local_frames_right_handed() -> None:
     assert torch.all(det > 0.99)
 
 
+def test_build_local_frames_equivariant_under_rigid_transform() -> None:
+    torch.manual_seed(0)
+    coords = torch.randn(6, 3)
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]])
+
+    original = build_local_frames(coords, edge_index)
+
+    rotation = _random_rotation(device=torch.device("cpu"), dtype=torch.float64).to(torch.float32)
+    translation = torch.tensor([0.4, -0.7, 1.1])
+
+    transformed = coords @ rotation + translation
+    transformed_frames = build_local_frames(transformed, edge_index)
+
+    relation = torch.matmul(transformed_frames, original.transpose(-1, -2))
+    ortho = torch.matmul(relation.transpose(-1, -2), relation)
+    identity = torch.eye(3).expand_as(ortho)
+    assert torch.allclose(ortho, identity, atol=1e-5)
+    assert torch.all(torch.linalg.det(relation) > 0.99)
+
+    orthogonality = torch.matmul(transformed_frames.transpose(-1, -2), transformed_frames)
+    identity = torch.eye(3).expand_as(orthogonality)
+    assert torch.allclose(orthogonality, identity, atol=1e-5)
+    assert torch.all(torch.linalg.det(transformed_frames) > 0.99)
+
+
 def _set_seed() -> None:
     torch.manual_seed(0)
 

--- a/tests/test_vq.py
+++ b/tests/test_vq.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
 import torch
 
-from gcpvqvae.models.vq import VectorQuantizer
+from gcpvqvae.models.vq import VectorQuantizer, _rotation_trick_gradient
 
 
 def test_vector_quantizer_assigns_nearest_codes() -> None:
@@ -33,6 +34,8 @@ def test_vector_quantizer_assigns_nearest_codes() -> None:
     quantized, indices, losses = vq(latents)
 
     assert indices.tolist() == [0, 1, 2]
+    assert torch.all(indices >= 0)
+    assert torch.all(indices < vq.num_codes)
     expected = torch.tensor(
         [
             [1.0, 0.0, 0.0],
@@ -62,3 +65,54 @@ def test_vector_quantizer_supports_masks() -> None:
     assert indices.tolist() == [0, -1]
     assert torch.allclose(quantized[0], torch.tensor([1.0, 0.0]))
     assert torch.allclose(quantized[1], latents[1])  # straight-through when masked
+
+
+def test_rotation_trick_gradient_matches_closed_form() -> None:
+    torch.manual_seed(0)
+    vq = VectorQuantizer(num_codes=4, dim=3, beta=0.25, decay=1.0, rotation_trick=True)
+    with torch.no_grad():
+        vq.embedding.copy_(torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [-1.0, 0.0, 0.0]]))
+
+    latents = torch.tensor(
+        [
+            [0.8, 0.3, 0.1],
+            [0.0, 0.9, 0.4],
+            [0.2, 0.1, 0.9],
+            [-0.7, 0.2, 0.1],
+        ],
+        requires_grad=True,
+        dtype=torch.float32,
+    )
+
+    quantized, _indices, _ = vq(latents)
+    upstream = torch.randn_like(quantized)
+    quantized.backward(upstream)
+
+    expected = _rotation_trick_gradient(upstream, latents.detach(), quantized.detach(), vq.eps)
+    assert torch.allclose(latents.grad, expected, atol=1e-5)
+
+
+def test_vector_quantizer_perplexity_increases_after_updates() -> None:
+    torch.manual_seed(0)
+    vq = VectorQuantizer(num_codes=4, dim=2, beta=0.1, decay=0.8, rotation_trick=False, kmeans_iters=0)
+    with torch.no_grad():
+        vq.embedding.zero_()
+
+    uniform = torch.zeros(12, 2)
+    vq.train()
+    _, _, losses_before = vq(uniform)
+
+    cluster_a = torch.tensor([[1.0, 0.0], [1.1, 0.1], [0.9, -0.1]])
+    cluster_b = torch.tensor([[-1.0, 0.2], [-0.9, -0.2], [-1.2, 0.0]])
+    cluster_c = torch.tensor([[0.0, 1.0], [0.2, 1.1], [-0.1, 0.8]])
+
+    for _ in range(30):
+        latents = torch.cat([cluster_a, cluster_b, cluster_c], dim=0)
+        noise = 0.05 * torch.randn_like(latents)
+        vq(latents + noise)
+
+    vq.eval()
+    _, _, losses_after = vq(torch.cat([cluster_a, cluster_b, cluster_c], dim=0))
+
+    assert losses_before["perplexity"].item() == pytest.approx(1.0, abs=1e-5)
+    assert losses_after["perplexity"].item() > 2.0


### PR DESCRIPTION
## Summary
- extend decoder unit tests to verify the 6D rotation head always produces SO(3) matrices with unit-column norms
- add a small end-to-end training smoke test that checks a briefly trained model achieves a low RMSD roundtrip on a toy structure
- add frame equivariance and vector-quantizer rotation-trick/perplexity checks to harden the geometric and VQ test suites

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d6d70c04d48323903ce121c4c3c22d