### PR TITLE
Fix training failure on empty CIF batches

### DIFF
--- a/src/gcpvqvae/models/losses.py
+++ b/src/gcpvqvae/models/losses.py
@@ -24,6 +24,15 @@ def _broadcast_mask(mask: Optional[Tensor], length: int) -> Optional[Tensor]:
     return mask.unsqueeze(-1).expand(-1, -1, 3).reshape(mask.shape[0], length * 3)
 
 
+def _zero_loss_like(tensor: Tensor) -> Tensor:
+    """Return a zero scalar that preserves gradients for ``tensor``."""
+
+    zero = torch.zeros((), device=tensor.device, dtype=tensor.dtype)
+    if tensor.requires_grad:
+        zero = zero.requires_grad_()
+    return zero
+
+
 def aligned_mse(
     pred: Tensor,
     target: Tensor,
@@ -44,7 +53,7 @@ def aligned_mse(
         if mask_flat is not None:
             mask_i = mask_flat[i]
             if mask_i.sum() < 3:
-                losses.append(torch.zeros((), device=pred.device, dtype=pred.dtype))
+                losses.append(_zero_loss_like(pred_flat[i]))
                 continue
         else:
             mask_i = None
@@ -65,7 +74,7 @@ def aligned_mse(
             diff = diff[mask_i]
 
         if diff.numel() == 0:
-            losses.append(torch.zeros((), device=pred.device, dtype=pred.dtype))
+            losses.append(_zero_loss_like(pred_flat[i]))
             continue
 
         losses.append(diff.pow(2).mean())
@@ -100,7 +109,7 @@ def backbone_distance_loss(
             target_i = target_flat[i]
 
         if pred_i.size(0) < 2:
-            losses.append(torch.zeros((), device=pred.device, dtype=pred.dtype))
+            losses.append(_zero_loss_like(pred_flat[i]))
             continue
 
         pred_dist = torch.cdist(pred_i, pred_i)
@@ -164,7 +173,7 @@ def backbone_direction_loss(
             tv = target_vectors[i]
 
         if pv.size(0) < 2:
-            losses.append(torch.zeros((), device=pred.device, dtype=pred.dtype))
+            losses.append(_zero_loss_like(pred_vectors[i]))
             continue
 
         pred_dot = torch.einsum("icd,jcd->ijc", pv, pv)

--- a/src/gcpvqvae/models/vq.py
+++ b/src/gcpvqvae/models/vq.py
@@ -129,6 +129,13 @@ class VectorQuantizer(nn.Module):
 
         self._initialised = False
 
+    @staticmethod
+    def _zero_loss_like(tensor: Tensor) -> Tensor:
+        zero = torch.zeros((), device=tensor.device, dtype=tensor.dtype)
+        if tensor.requires_grad:
+            zero = zero.requires_grad_()
+        return zero
+
     def _initialise_codebook(self, samples: Tensor) -> None:
         if self._initialised or samples.numel() == 0:
             return
@@ -180,10 +187,11 @@ class VectorQuantizer(nn.Module):
         if valid_latents.numel() == 0:
             quantized = torch.zeros_like(flat_latents)
             indices = torch.full((flat_latents.shape[0],), -1, dtype=torch.long, device=latents.device)
+            zero_loss = self._zero_loss_like(flat_latents)
             losses = {
-                "commitment": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
-                "codebook": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
-                "orthogonality": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
+                "commitment": self.beta * zero_loss,
+                "codebook": zero_loss,
+                "orthogonality": zero_loss,
                 "perplexity": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
             }
             quantized = quantized.reshape(original_shape)
@@ -217,7 +225,7 @@ class VectorQuantizer(nn.Module):
             identity = torch.eye(num_codes, device=latents.device, dtype=latents.dtype)
             orth_loss = ((gram - identity) ** 2).mean()
         else:
-            orth_loss = torch.tensor(0.0, device=latents.device, dtype=latents.dtype)
+            orth_loss = self._zero_loss_like(self.embedding)
 
         if self.training and self.decay < 1.0:
             with torch.no_grad():

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,58 @@
+import torch
+
+from gcpvqvae.models.losses import (
+    aligned_mse,
+    backbone_direction_loss,
+    backbone_distance_loss,
+    reconstruction_loss,
+)
+
+
+def _dummy_backbone(batch_size: int = 1, length: int = 1) -> torch.Tensor:
+    coords = torch.zeros(batch_size, length, 3, 3, requires_grad=True)
+    coords.data.uniform_(-1.0, 1.0)
+    return coords
+
+
+def test_aligned_mse_supports_fully_masked_batch() -> None:
+    pred = _dummy_backbone()
+    target = torch.zeros_like(pred)
+    mask = torch.zeros(pred.shape[:2], dtype=torch.bool)
+
+    loss = aligned_mse(pred, target, mask=mask)
+
+    assert loss.requires_grad
+    loss.backward()
+
+
+def test_backbone_distance_loss_supports_fully_masked_batch() -> None:
+    pred = _dummy_backbone()
+    target = torch.zeros_like(pred)
+    mask = torch.zeros(pred.shape[:2], dtype=torch.bool)
+
+    loss = backbone_distance_loss(pred, target, mask=mask)
+
+    assert loss.requires_grad
+    loss.backward()
+
+
+def test_backbone_direction_loss_supports_short_backbones() -> None:
+    pred = _dummy_backbone()
+    target = torch.zeros_like(pred)
+    mask = torch.zeros(pred.shape[:2], dtype=torch.bool)
+
+    loss = backbone_direction_loss(pred, target, mask=mask)
+
+    assert loss.requires_grad
+    loss.backward()
+
+
+def test_reconstruction_loss_requires_grad_with_empty_mask() -> None:
+    pred = _dummy_backbone()
+    target = torch.zeros_like(pred)
+    mask = torch.zeros(pred.shape[:2], dtype=torch.bool)
+
+    loss = reconstruction_loss(pred, target, mask=mask)
+
+    assert loss.requires_grad
+    loss.backward()

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 import gemmi
 import yaml
 
-from gcpvqvae.system.train import train
+from gcpvqvae.system.train import Trainer, train
 
 
 def _build_toy_structure(path):
@@ -117,3 +119,89 @@ def test_training_harness_runs_single_stage(tmp_path):
 
     checkpoints = list((output_dir / "checkpoints").glob("*.pt"))
     assert checkpoints, "training did not produce checkpoints"
+
+
+def test_training_on_cif_dataset_decreases_loss(tmp_path, monkeypatch):
+    data_root = Path(__file__).resolve().parent / "test_data" / "cif_50"
+
+    output_dir = tmp_path / "runs"
+    config = {
+        "data": {
+            "root": str(data_root),
+            "k": 4,
+            "num_workers": 0,
+            "cache": True,
+        },
+        "model": {
+            "gcp": {
+                "hidden_scalar_dim": 16,
+                "hidden_vector_dim": 4,
+                "edge_scalar_dim": 8,
+                "edge_vector_dim": 1,
+                "latent_dim": 16,
+                "layers": 2,
+            },
+            "vq": {
+                "num_codes": 16,
+                "dim": 16,
+                "beta": 0.25,
+                "decay": 0.99,
+                "kmeans_iters": 1,
+            },
+            "encoder": {
+                "model_dim": 64,
+                "num_layers": 2,
+                "num_heads": 2,
+                "num_kv_heads": 1,
+            },
+            "decoder": {
+                "model_dim": 64,
+                "num_layers": 2,
+                "num_heads": 2,
+                "num_kv_heads": 1,
+            },
+        },
+        "train": {
+            "seed": 7,
+            "amp": False,
+            "clip_grad": 1.0,
+            "random_rotation": False,
+            "log_interval": 1,
+            "checkpoint_interval": None,
+            "output_dir": str(output_dir),
+            "export": {"enabled": False},
+            "stages": [
+                {
+                    "name": "test",
+                    "length_cap": 128,
+                    "batch_size": 2,
+                    "base_lr": 0.001,
+                    "min_lr": 1e-4,
+                    "warmup_steps": 1,
+                    "total_steps": 4,
+                    "accumulation_steps": 1,
+                    "nan_mask_prob": 0.0,
+                }
+            ],
+        },
+    }
+
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(config, handle)
+
+    losses = []
+    original = Trainer._log_stage_progress
+
+    def capture_progress(self, stage, stage_step, total_steps, trackers, samples, residues, elapsed):
+        losses.append(trackers["loss"].average)
+        return original(self, stage, stage_step, total_steps, trackers, samples, residues, elapsed)
+
+    monkeypatch.setattr(Trainer, "_log_stage_progress", capture_progress)
+
+    train(str(config_path))
+
+    checkpoints = list((output_dir / "checkpoints").glob("*.pt"))
+    assert checkpoints, "training did not produce checkpoints"
+    assert len(losses) >= 2, "training did not log multiple loss values"
+    assert losses[-1] < losses[0], "training loss did not decrease"


### PR DESCRIPTION
## Summary
- make the reconstruction losses return gradient-bearing zeros when batches contain no valid residues
- ensure the vector quantizer reports zero auxiliary losses with gradients when no latents are active
- add regression tests that exercise the masked edge cases for the loss helpers

## Testing
- PYTHONPATH=src pytest tests/test_losses.py -q
- PYTHONPATH=src pytest tests/test_train.py::test_training_on_cif_dataset_decreases_loss -q

------
https://chatgpt.com/codex/tasks/task_b_68dabd7d687883239da5b4aa196878c4