### PR TITLE
Enable Hydra-style overrides in CLI workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "scipy",
     "gemmi",
     "biopython",
-    "pyyaml"
+    "pyyaml",
+    "hydra-core>=1.3"
 ]
 
 [project.optional-dependencies]

--- a/src/gcpvqvae/cli.py
+++ b/src/gcpvqvae/cli.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
+
+from gcpvqvae.system.configuration import compose_overrides
 
 try:  # Python 3.10+
     from importlib.metadata import PackageNotFoundError, version
@@ -46,7 +48,9 @@ def gpcvq() -> None:
         "Train a GCP-VQVAE model using the settings defined in CONFIG. "
         "The configuration file should provide ``data``, ``model``, and ``train`` "
         "sections as described in :mod:`gcpvqvae.system.train`.  Template files are "
-        "available under ``src/gcpvqvae/configs``."
+        "available under ``src/gcpvqvae/configs``.\n\n"
+        "Additional overrides can be supplied after CONFIG using Hydra's dotted "
+        "``key=value`` syntax.",
     ),
 )
 @click.argument(
@@ -54,12 +58,14 @@ def gpcvq() -> None:
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     metavar="CONFIG",
 )
-def train_command(config: Path) -> None:
+@click.argument("overrides", nargs=-1, metavar="[OVERRIDE]...", type=str)
+def train_command(config: Path, overrides: Tuple[str, ...]) -> None:
     """Kick off model training with the provided configuration file."""
 
     from gcpvqvae.system.train import train as run_train
 
-    run_train(str(config))
+    raw_config = compose_overrides(config, overrides)
+    run_train(raw_config)
 
 
 @gpcvq.command(
@@ -132,7 +138,9 @@ def decode_command(tokens: Path, output_path: Optional[Path]) -> None:
     help=(
         "Evaluate a trained model checkpoint using the experiment CONFIG file. "
         "The configuration should describe the dataset split, checkpoint to load, "
-        "and metrics to compute."
+        "and metrics to compute.\n\n"
+        "Overrides can be appended after CONFIG using Hydra's dotted "
+        "``key=value`` syntax.",
     ),
 )
 @click.argument(
@@ -140,13 +148,15 @@ def decode_command(tokens: Path, output_path: Optional[Path]) -> None:
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     metavar="CONFIG",
 )
-def eval_command(config: Path) -> None:
+@click.argument("overrides", nargs=-1, metavar="[OVERRIDE]...", type=str)
+def eval_command(config: Path, overrides: Tuple[str, ...]) -> None:
     """Run model evaluation for a specified configuration."""
 
     from gcpvqvae.system.eval import evaluate
 
     try:
-        evaluate(str(config))
+        raw_config = compose_overrides(config, overrides)
+        evaluate(raw_config)
     except NotImplementedError as exc:  # pragma: no cover - pending implementation
         raise click.ClickException(str(exc)) from exc
 
@@ -158,7 +168,9 @@ def eval_command(config: Path) -> None:
         "Inspect CONFIG for common issues and display model statistics. "
         "The validator checks for incompatible dimensions between sub-modules, "
         "invalid hyper-parameter settings, and reports the parameter counts for "
-        "each major component."
+        "each major component.\n\n"
+        "Overrides supplied after CONFIG (using Hydra's ``key=value`` syntax) "
+        "will be validated as well.",
     ),
 )
 @click.argument(
@@ -166,12 +178,14 @@ def eval_command(config: Path) -> None:
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     metavar="CONFIG",
 )
-def validate_config_command(config: Path) -> None:
+@click.argument("overrides", nargs=-1, metavar="[OVERRIDE]...", type=str)
+def validate_config_command(config: Path, overrides: Tuple[str, ...]) -> None:
     """Validate a configuration file and print a detailed report."""
 
     from gcpvqvae.system.config_validation import format_report, validate_config
 
-    report = validate_config(config)
+    raw_config = compose_overrides(config, overrides)
+    report = validate_config(raw_config)
     click.echo(format_report(report))
     if not report.valid:
         raise click.ClickException("Configuration validation failed.")

--- a/src/gcpvqvae/system/config_validation.py
+++ b/src/gcpvqvae/system/config_validation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -275,10 +275,13 @@ def _build_model_summary(config: GCPVQVAEConfig) -> Tuple[Optional[ModelSummary]
     return ModelSummary(total_parameters=total, component_parameters=components, codebook=codebook_info), []
 
 
-def validate_config(path: Path) -> ValidationReport:
-    """Validate a configuration file and collect high-level statistics."""
+def validate_config(config: Mapping[str, Any] | str | Path) -> ValidationReport:
+    """Validate a configuration mapping or file and collect statistics."""
 
-    raw = _load_yaml(path)
+    if isinstance(config, Mapping):
+        raw = dict(config)
+    else:
+        raw = _load_yaml(Path(config))
     issues: List[ValidationIssue] = []
 
     model_raw = raw.get("model")

--- a/src/gcpvqvae/system/configuration.py
+++ b/src/gcpvqvae/system/configuration.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Dict, Optional
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, cast
+
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
 
 from gcpvqvae.models.gcpvqvae import GCPVQVAEConfig
 
@@ -43,5 +48,45 @@ def build_model_config(raw: Optional[Dict[str, Any]]) -> GCPVQVAEConfig:
     return config
 
 
-__all__ = ["build_model_config", "update_dataclass"]
+def compose_overrides(config_path: Path, overrides: Iterable[str]) -> Dict[str, Any]:
+    """Load ``config_path`` and apply Hydra-style ``overrides``.
+
+    Parameters
+    ----------
+    config_path:
+        Base configuration file to load.
+    overrides:
+        Iterable of override strings following Hydra's ``key=value`` syntax.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A plain Python dictionary with all overrides applied and interpolations
+        resolved.
+    """
+
+    config_path = Path(config_path)
+    if not config_path.exists():  # pragma: no cover - handled by CLI before calling
+        raise FileNotFoundError(config_path)
+
+    overrides = list(overrides)
+    config_dir = config_path.parent.resolve()
+    config_name = config_path.stem
+
+    global_hydra = GlobalHydra.instance()
+    if global_hydra.is_initialized():
+        global_hydra.clear()
+
+    with initialize_config_dir(
+        config_dir=str(config_dir), job_name="gpcvq_cli", version_base=None
+    ):
+        cfg = compose(config_name=config_name, overrides=overrides)
+
+    container = OmegaConf.to_container(cfg, resolve=True)
+    if not isinstance(container, dict):  # pragma: no cover - Hydra guarantees mapping
+        raise TypeError("Hydra compose did not return a mapping")
+    return cast(Dict[str, Any], container)
+
+
+__all__ = ["build_model_config", "compose_overrides", "update_dataclass"]
 

--- a/src/gcpvqvae/system/eval.py
+++ b/src/gcpvqvae/system/eval.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -10,8 +11,6 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
-
-import yaml
 
 from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
 from gcpvqvae.geometry.frames import kabsch_align
@@ -53,11 +52,19 @@ class EvalModelConfig:
 
 
 def _load_config(path: str | Path) -> Dict[str, Any]:
+    import yaml
+
     with open(path, "r", encoding="utf-8") as handle:
         raw = yaml.safe_load(handle)
     if not isinstance(raw, dict):
         raise ValueError("Configuration file must define a dictionary")
     return raw
+
+
+def _coerce_config(config: Mapping[str, Any] | str | Path) -> Dict[str, Any]:
+    if isinstance(config, Mapping):
+        return dict(config)
+    return _load_config(config)
 
 
 def _prepare_data_config(raw: Dict[str, Any]) -> EvalDataConfig:
@@ -196,10 +203,13 @@ def _log_distribution(logger, name: str, stats: Dict[str, Any]) -> None:
 
 
 class Evaluator:
-    def __init__(self, config_path: str | Path) -> None:
+    def __init__(self, config: Mapping[str, Any] | str | Path) -> None:
         self.logger = get_logger()
-        self.config_path = Path(config_path)
-        raw = _load_config(self.config_path)
+        if isinstance(config, Mapping):
+            self.config_path = None
+        else:
+            self.config_path = Path(config)
+        raw = _coerce_config(config)
         self.data_cfg = _prepare_data_config(raw.get("data", {}))
         self.runtime_cfg = _prepare_runtime_config(raw.get("eval", {}))
         self.model_cfg = _prepare_model_config(raw.get("model", {}))
@@ -420,10 +430,10 @@ class Evaluator:
         return summary
 
 
-def evaluate(config_path: str) -> Dict[str, Any]:
+def evaluate(config: Mapping[str, Any] | str | Path) -> Dict[str, Any]:
     """Run evaluation using the specified configuration file."""
 
-    return Evaluator(config_path).run()
+    return Evaluator(config).run()
 
 
 __all__ = ["evaluate", "Evaluator"]

--- a/src/gcpvqvae/system/train.py
+++ b/src/gcpvqvae/system/train.py
@@ -7,6 +7,7 @@ import dataclasses
 import math
 import random
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -16,8 +17,6 @@ import torch
 from torch import nn
 from torch.nn.utils import clip_grad_norm_
 from torch.utils.data import DataLoader
-
-import yaml
 
 from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
 from gcpvqvae.data.mmcif import BackboneRecord, write_mmcif
@@ -284,11 +283,19 @@ def _prepare_data_config(raw: Dict[str, Any]) -> DataConfig:
 
 
 def _load_config(path: str | Path) -> Dict[str, Any]:
+    import yaml
+
     with open(path, "r", encoding="utf-8") as handle:
         config = yaml.safe_load(handle)
     if not isinstance(config, dict):
         raise ValueError("Configuration file must define a dictionary")
     return config
+
+
+def _coerce_config(config: Mapping[str, Any] | str | Path) -> Dict[str, Any]:
+    if isinstance(config, Mapping):
+        return dict(config)
+    return _load_config(config)
 
 
 def _codebook_statistics(vq: nn.Module) -> Tuple[float, float]:
@@ -394,8 +401,8 @@ def _export_samples(
 
 
 class Trainer:
-    def __init__(self, config_path: str | Path) -> None:
-        raw = _load_config(config_path)
+    def __init__(self, config: Mapping[str, Any] | str | Path) -> None:
+        raw = _coerce_config(config)
         self.data_cfg = _prepare_data_config(raw.get("data", {}))
         self.train_cfg = _prepare_train_config(raw.get("train", {}))
         self.model_cfg = build_model_config(raw.get("model"))
@@ -648,10 +655,10 @@ class Trainer:
             self.logger.info("Completed stage %s", stage.name)
 
 
-def train(config_path: str) -> None:
+def train(config: Mapping[str, Any] | str | Path) -> None:
     """Entry point mirroring the public API."""
 
-    Trainer(config_path).run()
+    Trainer(config).run()
 
 
 __all__ = ["train", "Trainer"]


### PR DESCRIPTION
## Summary
- add hydra-core as a dependency and provide a helper that composes configs with Hydra overrides
- allow the train, eval, and validate-config CLI commands to accept override arguments and pass merged configs downstream
- teach the training, evaluation, and validation entry points to work with in-memory config dictionaries in addition to file paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68daf61bbbf88323963da50316dc0005