### PR TITLE
Document configuration options and add small presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,25 @@ gpcvq --help
 ### Training models
 
 Use the `train` subcommand to launch an experiment from a YAML configuration file.
-The configuration is expected to follow the schema used by
-`gcpvqvae.system.train`, with top-level `data`, `model`, and `train` sections.
-Template files are available under `src/gcpvqvae/configs`.
+Configurations follow a simple schema with top-level `data`, `model`, and `train`
+sections.  A detailed reference of every option and its default value is
+available in [`src/gcpvqvae/configs/README.md`](src/gcpvqvae/configs/README.md).
+Starter templates live alongside that document.
 
 ```bash
 # Train using a configuration file in the repository
 # (adjust the path to point at your desired template)
 gpcvq train src/gcpvqvae/configs/base.yaml
+```
+
+Any parameter can be overridden directly from the CLI using Hydra's dotted
+syntax.  Append `section.key=value` pairs after the config path to tweak
+experiments without editing files:
+
+```bash
+gpcvq train src/gcpvqvae/configs/small.yaml \
+    train.stages[0].batch_size=8 \
+    model.vq.num_codes=128
 ```
 
 You can inspect the supported options with `gpcvq train --help`:

--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -1,0 +1,141 @@
+# Configuration reference
+
+This directory contains Hydra-compatible YAML configuration files used by the
+GCP-VQVAE command line interface and training utilities.  A configuration file
+is organised into three top-level sections:
+
+- `data`: how structures are loaded and featurised
+- `model`: architecture hyper-parameters for the encoder, VQ layer, decoder and
+  auxiliary heads
+- `train`: optimiser-free training loop settings and stage schedule
+
+Hydra allows any value to be overridden at runtime using dotted `section.key`
+notation (see the project-wide `README.md` for examples).  When a field is
+omitted the defaults listed below are applied by the underlying dataclasses.
+
+## `data` section
+
+| key | type | default | description |
+| --- | --- | --- | --- |
+| `root` | str | **required** | Path to an mmCIF file or directory that backs the dataset. |
+| `chain_ids` | sequence[str] \| null | `null` | Optional subset of chain identifiers to keep. |
+| `k` | int | `16` | Number of nearest neighbours per residue when building the kNN graph. |
+| `num_workers` | int | `0` | DataLoader worker processes. |
+| `cache` | bool | `True` | Whether to cache parsed mmCIF records on disk. |
+
+## `model` section
+
+### `model.gcp` – GCP encoder (`GCPNetConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `node_scalar_dim` | `6` | Input scalar feature channels per residue. |
+| `node_vector_dim` | `3` | Input vector feature channels per residue. |
+| `edge_scalar_dim` | `8` | Scalar features attached to each edge. |
+| `edge_vector_dim` | `1` | Vector features per edge. |
+| `hidden_scalar_dim` | `128` | Scalar width of the hidden representations. |
+| `hidden_vector_dim` | `16` | Vector channel count inside the GCP blocks. |
+| `latent_dim` | `256` | Output embedding dimension fed to the Transformer. |
+| `layers` | `6` | Number of stacked GCP convolution layers. |
+| `dropout` | `0.0` | Dropout applied within the convolutions. |
+| `displacement_head` | `False` | Enables an auxiliary displacement prediction head. |
+
+### `model.encoder` and `model.decoder` – Transformer stacks (`TransformerConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `input_dim` | derived | Automatically set to match the upstream module (`latent_dim` for the encoder, VQ dimension for the decoder). |
+| `model_dim` | `1024` | Hidden width of the Transformer blocks. |
+| `output_dim` | `null` | Optional projection size (defaults to `model_dim`). |
+| `num_layers` | `12` | Number of Transformer blocks. |
+| `num_heads` | `12` | Attention heads per block. |
+| `num_kv_heads` | `3` | Key/value heads (for grouped-query attention). |
+| `dropout` | `0.0` | Dropout applied after each block and on the final output. |
+| `ffn_multiplier` | `4.0` | Multiplier controlling the feed-forward hidden size. |
+| `use_rope` | `True` | Enables rotary positional embeddings. |
+
+### `model.vq` – Vector-quantiser (`VectorQuantizerConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `num_codes` | `4096` | Size of the codebook. |
+| `dim` | `256` | Codebook embedding dimension. |
+| `beta` | `0.25` | Commitment loss weight. |
+| `decay` | `0.99` | EMA decay for codebook updates. |
+| `epsilon` | `1e-5` | Numerical stability constant. |
+| `kmeans_iters` | `10` | Initial K-means refinement iterations. |
+| `rotation_trick` | `True` | Enables the rotation trick from VQ-VAE v2. |
+| `orthogonal_reg_weight` | `0.0` | Strength of the optional orthogonality penalty. |
+| `orthogonal_reg_max_codes` | `512` | Maximum codes used when computing the penalty. |
+
+### `model.rotation` – Rigid-frame decoder (`RotationHeadConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `input_dim` | derived | Automatically matches the decoder output width. |
+| `translation_scale` | `1.0` | Scale factor applied to predicted translations. |
+| `template` | `null` | Optional tensor describing a template structure. |
+
+### `model.data` – Training-time preprocessing (`DataPipelineConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `length_cap` | `2048` | Maximum residues per chain fed to the model. |
+| `knn` | `16` | Neighbours per residue when re-constructing edges during training. |
+
+## `train` section
+
+### Top-level training settings (`TrainConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `seed` | `42` | Seed for PyTorch, NumPy, and Python RNGs. |
+| `device` | `null` | Forces training onto a specific device identifier (defaults to CUDA if available). |
+| `amp` | `True` | Enables automatic mixed precision. |
+| `clip_grad` | `1.0` | Gradient clipping value (L2 norm). |
+| `random_rotation` | `True` | Applies random SO(3) augmentation to each batch. |
+| `log_interval` | `50` | Number of optimisation steps between log updates. |
+| `checkpoint_interval` | `null` | Frequency (in steps) for saving checkpoints; `null` disables periodic checkpoints. |
+| `output_dir` | `"runs"` | Base directory for logs, checkpoints, and exports. |
+| `export` | see below | Nested configuration controlling structure exports. |
+| `stages` | `[]` | List of training stage dictionaries (`StageConfig`). |
+
+### `train.export` (`ExportConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `enabled` | `True` | Toggles structure export. |
+| `directory` | `null` | Output directory for exported structures (defaults to `<output_dir>/exports`). |
+| `every_n_steps` | `null` | If set, export samples every `n` optimisation steps. |
+| `on_stage_end` | `True` | Export a batch at the end of each stage. |
+| `num_samples` | `1` | Number of structures to export at each trigger. |
+
+### `train.stages[]` (`StageConfig`)
+
+Each stage entry orchestrates one phase of the curriculum.  Provide either
+`total_steps` **or** `epochs`:
+
+| key | default | description |
+| --- | --- | --- |
+| `name` | **required** | Stage identifier used in logs. |
+| `length_cap` | **required** | Maximum residues per training sample during the stage. |
+| `batch_size` | **required** | Number of chains per optimisation step. |
+| `base_lr` | **required** | Peak learning rate reached after warmup. |
+| `min_lr` | **required** | Minimum learning rate used at the start/end of cosine decay. |
+| `warmup_steps` | **required** | Linear warmup duration in optimisation steps. |
+| `total_steps` | `null` | Number of optimisation steps to run (mutually exclusive with `epochs`). |
+| `epochs` | `null` | Number of dataset passes (used when `total_steps` is omitted). |
+| `accumulation_steps` | `1` | Gradient accumulation factor. |
+| `nan_mask_prob` | `0.0` | Probability of applying random NaN masking augmentation. |
+| `nan_mask_span` | `[1, 1]` | Range for contiguous residue spans used during NaN masking. |
+
+## Selecting a template
+
+Example templates are provided:
+
+- `base.yaml`: full-sized training schedule mirroring the manuscript.
+- `small.yaml`: reduced footprint configuration for local experiments.
+- `xsmall.yaml`: minimal configuration matching the continuous integration tests.
+
+Feel free to copy these files and customise them using the options described
+above.

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -1,7 +1,7 @@
-# Lightweight configuration for quick smoke tests on a small mmCIF folder.
+# Small-scale configuration for quick smoke tests on a modest mmCIF folder.
 
 data:
-  root: "data/pilot"
+  root: "data/small"
   k: 12
   num_workers: 4
   cache: true
@@ -41,11 +41,11 @@ train:
   random_rotation: true
   log_interval: 5
   checkpoint_interval: 5
-  output_dir: "runs/pilot"
+  output_dir: "runs/small"
   export:
     enabled: false
   stages:
-    - name: pilot
+    - name: small
       length_cap: 512
       batch_size: 4
       base_lr: 0.0003

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -1,0 +1,57 @@
+# Extra-small configuration matching the reduced model used in the unit tests.
+# Suitable for debugging and CI runs where fast iteration is required.
+
+data:
+  root: "tests/test_data/cif_50"
+  k: 4
+  num_workers: 0
+  cache: true
+
+model:
+  gcp:
+    hidden_scalar_dim: 16
+    hidden_vector_dim: 4
+    edge_scalar_dim: 8
+    edge_vector_dim: 1
+    latent_dim: 16
+    layers: 2
+  vq:
+    num_codes: 16
+    dim: 16
+    beta: 0.25
+    decay: 0.99
+    kmeans_iters: 1
+  encoder:
+    model_dim: 64
+    num_layers: 2
+    num_heads: 2
+    num_kv_heads: 1
+    dropout: 0.0
+  decoder:
+    model_dim: 64
+    num_layers: 2
+    num_heads: 2
+    num_kv_heads: 1
+    dropout: 0.0
+
+train:
+  seed: 7
+  amp: false
+  clip_grad: 1.0
+  random_rotation: false
+  log_interval: 1
+  checkpoint_interval: null
+  output_dir: "runs/xsmall"
+  export:
+    enabled: false
+  stages:
+    - name: debug
+      length_cap: 128
+      batch_size: 2
+      base_lr: 0.001
+      min_lr: 0.0001
+      warmup_steps: 1
+      total_steps: 4
+      accumulation_steps: 1
+      nan_mask_prob: 0.0
+      nan_mask_span: [1, 1]


### PR DESCRIPTION
## Summary
- rename the lightweight `pilot` template to `small` and align its metadata
- add an `xsmall` configuration mirroring the minimal model used in unit tests
- document all configuration options and defaults with a dedicated README and link to it from the main docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db05d45f208323ae8f8350a3e165a6