### PR TITLE
Fix small config edge scalar dimension mismatch

### DIFF
--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -10,7 +10,7 @@ model:
   gcp:
     hidden_scalar_dim: 64
     hidden_vector_dim: 8
-    edge_scalar_dim: 16
+    edge_scalar_dim: 8
     edge_vector_dim: 1
     latent_dim: 128
     layers: 3


### PR DESCRIPTION
## Summary
- set the small configuration's GCP edge scalar width to match the dataset-provided feature size

## Testing
- pytest *(fails: missing optional dependency `hydra` required by the test harness)*

------
https://chatgpt.com/codex/tasks/task_b_68db11cfbb58832386460071027c35f3