### PR TITLE
Handle hydra absence in configuration loader

### DIFF
--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -10,7 +10,7 @@ model:
   gcp:
     hidden_scalar_dim: 64
     hidden_vector_dim: 8
-    edge_scalar_dim: 16
+    edge_scalar_dim: 8
     edge_vector_dim: 1
     latent_dim: 128
     layers: 3

--- a/src/gcpvqvae/system/configuration.py
+++ b/src/gcpvqvae/system/configuration.py
@@ -6,9 +6,20 @@ import dataclasses
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, cast
 
-from hydra import compose, initialize_config_dir
-from hydra.core.global_hydra import GlobalHydra
-from omegaconf import OmegaConf
+try:  # Optional dependency – available in full installations
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+except ModuleNotFoundError:  # pragma: no cover - exercised when hydra is absent
+    compose = None  # type: ignore[assignment]
+    initialize_config_dir = None  # type: ignore[assignment]
+    GlobalHydra = None  # type: ignore[assignment]
+
+try:  # OmegaConf ships with hydra-core but we guard against it missing too
+    from omegaconf import OmegaConf
+except ModuleNotFoundError:  # pragma: no cover - exercised when hydra is absent
+    OmegaConf = None  # type: ignore[assignment]
+
+import yaml
 
 from gcpvqvae.models.gcpvqvae import GCPVQVAEConfig
 
@@ -48,6 +59,48 @@ def build_model_config(raw: Optional[Dict[str, Any]]) -> GCPVQVAEConfig:
     return config
 
 
+def _apply_override(target: Dict[str, Any], dotted_key: str, value: Any) -> None:
+    parts = [part for part in dotted_key.split(".") if part]
+    if not parts:
+        raise ValueError("Override key must not be empty")
+
+    cursor = target
+    for part in parts[:-1]:
+        current = cursor.get(part)
+        if current is None:
+            current = {}
+            cursor[part] = current
+        if not isinstance(current, dict):
+            raise TypeError(
+                f"Cannot override '{dotted_key}': '{part}' does not contain nested keys"
+            )
+        cursor = current
+
+    cursor[parts[-1]] = value
+
+
+def _parse_override(override: str) -> tuple[str, Any]:
+    if "=" not in override:
+        raise ValueError(f"Invalid override '{override}': expected key=value syntax")
+    key, raw_value = override.split("=", 1)
+    # ``yaml.safe_load`` gives us a reasonable approximation of Hydra's coercion rules.
+    value = yaml.safe_load(raw_value)
+    return key, value
+
+
+def _fallback_compose(config_path: Path, overrides: Iterable[str]) -> Dict[str, Any]:
+    with open(config_path, "r", encoding="utf-8") as handle:
+        base = yaml.safe_load(handle) or {}
+    if not isinstance(base, dict):
+        raise TypeError("Configuration file must contain a mapping")
+
+    for override in overrides:
+        key, value = _parse_override(override)
+        _apply_override(base, key, value)
+
+    return base
+
+
 def compose_overrides(config_path: Path, overrides: Iterable[str]) -> Dict[str, Any]:
     """Load ``config_path`` and apply Hydra-style ``overrides``.
 
@@ -73,6 +126,9 @@ def compose_overrides(config_path: Path, overrides: Iterable[str]) -> Dict[str, 
     config_dir = config_path.parent.resolve()
     config_name = config_path.stem
 
+    if compose is None or initialize_config_dir is None or GlobalHydra is None:
+        return _fallback_compose(config_path, overrides)
+
     global_hydra = GlobalHydra.instance()
     if global_hydra.is_initialized():
         global_hydra.clear()
@@ -81,6 +137,11 @@ def compose_overrides(config_path: Path, overrides: Iterable[str]) -> Dict[str, 
         config_dir=str(config_dir), job_name="gpcvq_cli", version_base=None
     ):
         cfg = compose(config_name=config_name, overrides=overrides)
+
+    if OmegaConf is None:  # pragma: no cover - hydra guarantees OmegaConf
+        raise ModuleNotFoundError(
+            "OmegaConf is required when hydra-core is installed; reinstall hydra-core"
+        )
 
     container = OmegaConf.to_container(cfg, resolve=True)
     if not isinstance(container, dict):  # pragma: no cover - Hydra guarantees mapping


### PR DESCRIPTION
## Summary
- set the small configuration's GCP edge scalar width to match the dataset-provided feature size
- add a YAML-based fallback override loader so CLI commands work without hydra installed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db11cfbb58832386460071027c35f3