### PR TITLE
Fix EMA codebook updates with orthogonal regularization

### DIFF
--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -190,6 +190,11 @@ class GCPVQVAE(nn.Module):
             "total_loss": total_loss,
         }
 
+    def commit_updates(self) -> None:
+        """Apply any deferred updates inside the module."""
+
+        self.vq.commit_pending_codebook()
+
     # ----------------------------------------------------------- encode helper
     def _build_metadata(self, record: BackboneRecord) -> Dict[str, Any]:
         return {

--- a/src/gcpvqvae/models/vq.py
+++ b/src/gcpvqvae/models/vq.py
@@ -127,6 +127,8 @@ class VectorQuantizer(nn.Module):
         self.register_buffer("ema_codebook", torch.zeros(num_codes, dim))
         self.register_buffer("usage", torch.zeros(num_codes))
 
+        self._pending_codebook: Optional[Tensor] = None
+
         self._initialised = False
 
     @staticmethod
@@ -168,6 +170,9 @@ class VectorQuantizer(nn.Module):
         *,
         mask: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Tensor, Dict[str, Tensor]]:
+        if self._pending_codebook is not None:
+            self.commit_pending_codebook()
+
         if latents.size(-1) != self.dim:
             raise ValueError(f"Expected latent dim {self.dim}, got {latents.size(-1)}")
 
@@ -239,8 +244,7 @@ class VectorQuantizer(nn.Module):
                 cluster_size = self.ema_cluster_size + self.eps
                 n = cluster_size.sum()
                 cluster_size = cluster_size / (n + self.num_codes * self.eps) * n
-                updated = self.ema_codebook / cluster_size.unsqueeze(1)
-                self.embedding.copy_(updated)
+                self._pending_codebook = self.ema_codebook / cluster_size.unsqueeze(1)
 
         one_hot = F.one_hot(assignment, num_classes=self.num_codes).to(latents.dtype)
         avg_probs = one_hot.mean(dim=0)
@@ -267,6 +271,15 @@ class VectorQuantizer(nn.Module):
         }
 
         return quantized, indices, losses
+
+    def commit_pending_codebook(self) -> None:
+        """Apply any queued EMA codebook update."""
+
+        if self._pending_codebook is None:
+            return
+        with torch.no_grad():
+            self.embedding.copy_(self._pending_codebook)
+        self._pending_codebook = None
 
 
 __all__ = ["VectorQuantizer"]

--- a/src/gcpvqvae/system/train.py
+++ b/src/gcpvqvae/system/train.py
@@ -553,6 +553,8 @@ class Trainer:
                         loss = outputs["total_loss"] / max(stage.accumulation_steps, 1)
 
                     loss.backward()
+                    if hasattr(self.model, "commit_updates"):
+                        self.model.commit_updates()
                     accum_counter += 1
 
                     batch_mask = batch["mask"]

--- a/tests/test_vq.py
+++ b/tests/test_vq.py
@@ -116,3 +116,28 @@ def test_vector_quantizer_perplexity_increases_after_updates() -> None:
 
     assert losses_before["perplexity"].item() == pytest.approx(1.0, abs=1e-5)
     assert losses_after["perplexity"].item() > 2.0
+
+
+def test_vector_quantizer_supports_orthogonal_regularisation_with_ema() -> None:
+    torch.manual_seed(0)
+    vq = VectorQuantizer(
+        num_codes=8,
+        dim=4,
+        beta=0.25,
+        decay=0.95,
+        rotation_trick=False,
+        orthogonal_reg_weight=1.0,
+    )
+
+    latents = torch.randn(2, 16, 4, requires_grad=True)
+    vq.train()
+    _, _, losses = vq(latents)
+    total = losses["commitment"] + losses["codebook"] + losses["orthogonality"]
+
+    total.backward()
+    assert latents.grad is not None
+    assert torch.isfinite(latents.grad).all()
+
+    # Applying the EMA update should not raise and should clear the pending tensor.
+    vq.commit_pending_codebook()
+    assert vq._pending_codebook is None


### PR DESCRIPTION
## Summary
- queue EMA codebook updates inside the vector quantizer and commit them outside the autograd graph to avoid in-place modification errors when orthogonal regularisation is enabled
- expose a `commit_updates` helper on the model and call it from the trainer after each backward pass so pending vector-quantiser updates are flushed immediately
- cover the new behaviour with a unit test that exercises EMA updates alongside the orthogonality loss

## Testing
- pytest tests/test_vq.py
- pytest tests/test_train.py

------
https://chatgpt.com/codex/tasks/task_b_68db18b9a8908323bf2e17e9dd27d0fc