### PR TITLE
Fix CLI subcommand help strings

### DIFF
--- a/src/gcpvqvae/cli.py
+++ b/src/gcpvqvae/cli.py
@@ -50,7 +50,7 @@ def gpcvq() -> None:
         "sections as described in :mod:`gcpvqvae.system.train`.  Template files are "
         "available under ``src/gcpvqvae/configs``.\n\n"
         "Additional overrides can be supplied after CONFIG using Hydra's dotted "
-        "``key=value`` syntax.",
+        "``key=value`` syntax."
     ),
 )
 @click.argument(
@@ -140,7 +140,7 @@ def decode_command(tokens: Path, output_path: Optional[Path]) -> None:
         "The configuration should describe the dataset split, checkpoint to load, "
         "and metrics to compute.\n\n"
         "Overrides can be appended after CONFIG using Hydra's dotted "
-        "``key=value`` syntax.",
+        "``key=value`` syntax."
     ),
 )
 @click.argument(
@@ -170,7 +170,7 @@ def eval_command(config: Path, overrides: Tuple[str, ...]) -> None:
         "invalid hyper-parameter settings, and reports the parameter counts for "
         "each major component.\n\n"
         "Overrides supplied after CONFIG (using Hydra's ``key=value`` syntax) "
-        "will be validated as well.",
+        "will be validated as well."
     ),
 )
 @click.argument(


### PR DESCRIPTION
## Summary
- ensure Click help descriptions for subcommands are passed as single strings
- prevent AttributeError when requesting help for CLI subcommands

## Testing
- PYTHONPATH=src python -m gcpvqvae.cli train -h

------
https://chatgpt.com/codex/tasks/task_b_68db5b45732083239843851c80a6229d