### PR TITLE
Add GitHub Actions workflow to run pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,33 @@
+name: Run Pytest
+
+on:
+  push:
+    branches:
+      - main
+      - dev-codex
+  pull_request:
+    branches:
+      - main
+      - dev-codex
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest
+
+      - name: Run pytest
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs project dependencies and runs pytest
- trigger the workflow on pushes and pull requests targeting the main and dev-codex branches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db5f783e088323a0fdfdb37e313016