### PR TITLE
Nest training log interval under log config

### DIFF
--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -94,7 +94,6 @@ omitted the defaults listed below are applied by the underlying dataclasses.
 | `amp` | `True` | Enables automatic mixed precision. |
 | `clip_grad` | `1.0` | Gradient clipping value (L2 norm). |
 | `random_rotation` | `True` | Applies random SO(3) augmentation to each batch. |
-| `log_interval` | `50` | Number of optimisation steps between log updates. |
 | `checkpoint_interval` | `null` | Frequency (in steps) for saving checkpoints; `null` disables periodic checkpoints. |
 | `output_dir` | `"runs"` | Base directory for logs, checkpoints, and exports. |
 | `log` | see below | Nested configuration controlling experiment logging backends. |
@@ -116,6 +115,7 @@ values shown below.
 | `tags` | `[]` | Optional list of tags applied to the run. |
 | `dir` | `null` | Directory used for W&B file artefacts (defaults to `<output_dir>`). |
 | `mode` | `null` | Advanced W&B init mode (`online`, `offline`, etc.). |
+| `interval` | `50` | Number of optimisation steps between progress log updates. |
 
 ### `train.export` (`ExportConfig`)
 

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -44,7 +44,6 @@ train:
   amp: true
   clip_grad: 1.0
   random_rotation: true
-  log_interval: 100
   checkpoint_interval: 5000
   output_dir: "runs/full"
   log:
@@ -55,6 +54,7 @@ train:
     tags: []
     dir: null
     mode: null
+    interval: 100
   eval:
     interval: null              # run evaluation every N optimisation steps (null disables)
     root: null                  # path to directory of evaluation PDB/mmCIF files

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -39,7 +39,6 @@ train:
   amp: false
   clip_grad: 1.0
   random_rotation: true
-  log_interval: 5
   checkpoint_interval: 5
   output_dir: "runs/small"
   log:
@@ -50,6 +49,7 @@ train:
     tags: []
     dir: null
     mode: null
+    interval: 5
   eval:
     interval: null
     root: null

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -39,7 +39,6 @@ train:
   amp: false
   clip_grad: 1.0
   random_rotation: false
-  log_interval: 1
   checkpoint_interval: null
   output_dir: "runs/xsmall"
   log:
@@ -50,6 +49,7 @@ train:
     tags: []
     dir: null
     mode: null
+    interval: 1
   eval:
     interval: null
     root: null

--- a/src/gcpvqvae/system/train.py
+++ b/src/gcpvqvae/system/train.py
@@ -84,6 +84,7 @@ class LogConfig:
     tags: Tuple[str, ...] = ()
     dir: Optional[str] = None
     mode: Optional[str] = None
+    interval: int = 50
 
 
 @dataclass
@@ -109,7 +110,6 @@ class TrainConfig:
     amp: bool = True
     clip_grad: float = 1.0
     random_rotation: bool = True
-    log_interval: int = 50
     checkpoint_interval: Optional[int] = None
     output_dir: str = "runs"
     export: ExportConfig = field(default_factory=ExportConfig)
@@ -368,6 +368,11 @@ def _prepare_train_config(raw: Dict[str, Any]) -> TrainConfig:
         tags = ()
     else:
         tags = (str(raw_tags),)
+    interval_value = None
+    if isinstance(log_cfg_raw, Mapping):
+        interval_value = log_cfg_raw.get("interval")
+    if interval_value is None:
+        interval_value = raw.get("log_interval")
     log_cfg = LogConfig(
         enabled=bool(log_cfg_raw.get("enabled", False)),
         project=log_cfg_raw.get("project"),
@@ -376,6 +381,7 @@ def _prepare_train_config(raw: Dict[str, Any]) -> TrainConfig:
         tags=tags,
         dir=log_cfg_raw.get("dir"),
         mode=log_cfg_raw.get("mode"),
+        interval=int(interval_value) if interval_value is not None else 50,
     )
     stages = [_prepare_stage_config(stage) for stage in raw.get("stages", [])]
     if not stages:
@@ -388,7 +394,6 @@ def _prepare_train_config(raw: Dict[str, Any]) -> TrainConfig:
         amp=bool(raw.get("amp", True)),
         clip_grad=float(raw.get("clip_grad", 1.0)),
         random_rotation=bool(raw.get("random_rotation", True)),
-        log_interval=int(raw.get("log_interval", 50)),
         checkpoint_interval=int(checkpoint) if checkpoint is not None else None,
         output_dir=str(raw.get("output_dir", "runs")),
         export=export,
@@ -1020,7 +1025,7 @@ class Trainer:
                                     self.logger,
                                 )
 
-                        if self.train_cfg.log_interval and stage_step % self.train_cfg.log_interval == 0:
+                        if self.train_cfg.log.interval and stage_step % self.train_cfg.log.interval == 0:
                             now = time.perf_counter()
                             self._log_stage_progress(
                                 stage,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -91,9 +91,9 @@ def test_training_harness_runs_single_stage(tmp_path):
             "amp": False,
             "clip_grad": 1.0,
             "random_rotation": False,
-            "log_interval": 1,
             "checkpoint_interval": 1,
             "output_dir": str(output_dir),
+            "log": {"interval": 1},
             "export": {"enabled": False},
             "stages": [
                 {
@@ -166,9 +166,9 @@ def test_training_on_cif_dataset_decreases_loss(tmp_path, monkeypatch):
             "amp": False,
             "clip_grad": 1.0,
             "random_rotation": False,
-            "log_interval": 1,
             "checkpoint_interval": None,
             "output_dir": str(output_dir),
+            "log": {"interval": 1},
             "export": {"enabled": False},
             "stages": [
                 {


### PR DESCRIPTION
## Summary
- move the training log interval into the nested `train.log.interval` option and update parsing to keep backward compatibility
- refresh built-in configs, documentation, and tests to use the new layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc06c84318832386a30e7fc6c22215