### PR TITLE
Rename DataConfig worker and progress options

### DIFF
--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -20,7 +20,9 @@ omitted the defaults listed below are applied by the underlying dataclasses.
 | `root` | str | **required** | Path to an mmCIF file or directory that backs the dataset. |
 | `chain_ids` | sequence[str] \| null | `null` | Optional subset of chain identifiers to keep. |
 | `k` | int | `16` | Number of nearest neighbours per residue when building the kNN graph. |
-| `num_workers` | int | `0` | DataLoader worker processes. |
+| `num_dataloader_workers` | int | `0` | DataLoader worker processes. |
+| `num_file_parser_workers` | int \| null | `null` | Parallel workers used when parsing mmCIF files. |
+| `show_progress` | bool | `True` | Display a progress bar while preprocessing structures. |
 | `cache` | bool | `True` | Whether to cache parsed mmCIF records on disk. |
 
 ## `model` section

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -5,7 +5,7 @@
 data:
   root: "data/train"          # path to a directory with mmCIF files
   k: 16                        # kNN edges per residue
-  num_workers: 8
+  num_dataloader_workers: 8
   cache: true
 
 model:

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -3,7 +3,7 @@
 data:
   root: "data/small"
   k: 12
-  num_workers: 4
+  num_dataloader_workers: 4
   cache: true
 
 model:

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -4,7 +4,7 @@
 data:
   root: "tests/test_data/cif_50"
   k: 4
-  num_workers: 0
+  num_dataloader_workers: 0
   cache: true
 
 model:

--- a/src/gcpvqvae/system/eval.py
+++ b/src/gcpvqvae/system/eval.py
@@ -30,10 +30,10 @@ class EvalDataConfig:
     chain_ids: Optional[Sequence[str]] = None
     length_cap: int = 2048
     k: int = 16
-    num_workers: int = 0
+    num_dataloader_workers: int = 0
     cache: bool = True
-    parser_workers: Optional[int] = None
-    progress: bool = True
+    num_file_parser_workers: Optional[int] = None
+    show_progress: bool = True
 
 
 @dataclass
@@ -82,14 +82,20 @@ def _prepare_data_config(raw: Dict[str, Any]) -> EvalDataConfig:
         chain_ids=tuple(chain_ids) if chain_ids is not None else None,
         length_cap=int(raw.get("length_cap", 2048)),
         k=int(raw.get("k", 16)),
-        num_workers=int(raw.get("num_workers", 0)),
-        cache=bool(raw.get("cache", True)),
-        parser_workers=(
-            int(raw["parser_workers"])
-            if raw.get("parser_workers") is not None
-            else None
+        num_dataloader_workers=int(
+            raw.get("num_dataloader_workers", raw.get("num_workers", 0))
         ),
-        progress=bool(raw.get("progress", True)),
+        cache=bool(raw.get("cache", True)),
+        num_file_parser_workers=(
+            int(raw["num_file_parser_workers"])
+            if raw.get("num_file_parser_workers") is not None
+            else (
+                int(raw["parser_workers"])
+                if raw.get("parser_workers") is not None
+                else None
+            )
+        ),
+        show_progress=bool(raw.get("show_progress", raw.get("progress", True))),
     )
 
 
@@ -238,8 +244,8 @@ class Evaluator:
             length_cap=self.data_cfg.length_cap,
             k=self.data_cfg.k,
             cache=self.data_cfg.cache,
-            progress=self.data_cfg.progress,
-            num_workers=self.data_cfg.parser_workers,
+            progress=self.data_cfg.show_progress,
+            num_workers=self.data_cfg.num_file_parser_workers,
         )
         if len(dataset) == 0:
             raise ValueError("Evaluation dataset is empty")
@@ -247,7 +253,7 @@ class Evaluator:
             dataset,
             batch_size=self.runtime_cfg.batch_size,
             shuffle=False,
-            num_workers=self.data_cfg.num_workers,
+            num_workers=self.data_cfg.num_dataloader_workers,
             pin_memory=self.device.type == "cuda",
             collate_fn=collate_backbones,
             drop_last=False,

--- a/src/gcpvqvae/system/train.py
+++ b/src/gcpvqvae/system/train.py
@@ -37,10 +37,10 @@ class DataConfig:
     root: str
     chain_ids: Optional[Sequence[str]] = None
     k: int = 16
-    num_workers: int = 0
+    num_dataloader_workers: int = 0
     cache: bool = True
-    parser_workers: Optional[int] = None
-    progress: bool = True
+    num_file_parser_workers: Optional[int] = None
+    show_progress: bool = True
 
 
 @dataclass
@@ -94,13 +94,13 @@ class EvalDuringTrainingConfig:
     interval: Optional[int] = None
     root: Optional[str] = None
     batch_size: int = 1
-    num_workers: int = 0
+    num_dataloader_workers: int = 0
     length_cap: Optional[int] = None
     chain_ids: Optional[Tuple[str, ...]] = None
     k: Optional[int] = None
     cache: Optional[bool] = None
-    parser_workers: Optional[int] = None
-    progress: Optional[bool] = None
+    num_file_parser_workers: Optional[int] = None
+    show_progress: Optional[bool] = None
     tm_score: bool = True
     gdt_ts: bool = False
     histogram_bins: int = 20
@@ -327,15 +327,40 @@ def _prepare_eval_during_training_config(
 
     histogram_bins = max(int(raw.get("histogram_bins", 20)), 1)
 
+    num_dataloader_workers_raw = raw.get("num_dataloader_workers")
+    if num_dataloader_workers_raw is None and "num_workers" in raw:
+        num_dataloader_workers_raw = raw.get("num_workers")
+    num_dataloader_workers = (
+        int(num_dataloader_workers_raw) if num_dataloader_workers_raw is not None else 0
+    )
+
+    num_file_parser_workers_raw = raw.get("num_file_parser_workers")
+    if num_file_parser_workers_raw is None and "parser_workers" in raw:
+        num_file_parser_workers_raw = raw.get("parser_workers")
+    num_file_parser_workers = (
+        int(num_file_parser_workers_raw)
+        if num_file_parser_workers_raw is not None
+        else None
+    )
+
+    show_progress_raw = raw.get("show_progress")
+    if show_progress_raw is None and "progress" in raw:
+        show_progress_raw = raw.get("progress")
+    show_progress = (
+        bool(show_progress_raw) if show_progress_raw is not None else None
+    )
+
     return EvalDuringTrainingConfig(
         interval=interval,
         root=root_path,
         batch_size=int(raw.get("batch_size", 1)),
-        num_workers=int(raw.get("num_workers", 0)),
+        num_dataloader_workers=num_dataloader_workers,
         length_cap=length_cap_int,
         chain_ids=chain_ids,
         k=k_int,
         cache=cache_flag,
+        num_file_parser_workers=num_file_parser_workers,
+        show_progress=show_progress,
         tm_score=bool(raw.get("tm_score", True)),
         gdt_ts=bool(raw.get("gdt_ts", False)),
         histogram_bins=histogram_bins,
@@ -411,16 +436,30 @@ def _prepare_data_config(raw: Dict[str, Any]) -> DataConfig:
     root = raw.get("root")
     if root is None:
         raise ValueError("Data configuration requires a 'root' path")
-    parser_workers_raw = raw.get("parser_workers")
-    parser_workers = int(parser_workers_raw) if parser_workers_raw is not None else None
+
+    num_dataloader_workers_raw = raw.get("num_dataloader_workers")
+    if num_dataloader_workers_raw is None and "num_workers" in raw:
+        num_dataloader_workers_raw = raw.get("num_workers")
+    num_dataloader_workers = int(num_dataloader_workers_raw or 0)
+
+    parser_workers_raw = raw.get("num_file_parser_workers")
+    if parser_workers_raw is None and "parser_workers" in raw:
+        parser_workers_raw = raw.get("parser_workers")
+    num_file_parser_workers = (
+        int(parser_workers_raw) if parser_workers_raw is not None else None
+    )
+
+    show_progress_raw = raw.get("show_progress")
+    if show_progress_raw is None and "progress" in raw:
+        show_progress_raw = raw.get("progress")
     return DataConfig(
         root=str(root),
         chain_ids=raw.get("chain_ids"),
         k=int(raw.get("k", 16)),
-        num_workers=int(raw.get("num_workers", 0)),
+        num_dataloader_workers=num_dataloader_workers,
         cache=bool(raw.get("cache", True)),
-        parser_workers=parser_workers,
-        progress=bool(raw.get("progress", True)),
+        num_file_parser_workers=num_file_parser_workers,
+        show_progress=bool(show_progress_raw if show_progress_raw is not None else True),
     )
 
 
@@ -750,14 +789,14 @@ class Trainer:
             length_cap=stage.length_cap,
             k=self.data_cfg.k,
             cache=self.data_cfg.cache,
-            progress=self.data_cfg.progress,
-            num_workers=self.data_cfg.parser_workers,
+            progress=self.data_cfg.show_progress,
+            num_workers=self.data_cfg.num_file_parser_workers,
         )
         loader = DataLoader(
             dataset,
             batch_size=stage.batch_size,
             shuffle=True,
-            num_workers=self.data_cfg.num_workers,
+            num_workers=self.data_cfg.num_dataloader_workers,
             pin_memory=self.device.type == "cuda",
             collate_fn=collate_backbones,
             drop_last=False,
@@ -784,14 +823,14 @@ class Trainer:
             k=self.eval_cfg.k if self.eval_cfg.k is not None else self.data_cfg.k,
             cache=self.eval_cfg.cache if self.eval_cfg.cache is not None else self.data_cfg.cache,
             progress=(
-                self.eval_cfg.progress
-                if self.eval_cfg.progress is not None
-                else self.data_cfg.progress
+                self.eval_cfg.show_progress
+                if self.eval_cfg.show_progress is not None
+                else self.data_cfg.show_progress
             ),
             num_workers=(
-                self.eval_cfg.parser_workers
-                if self.eval_cfg.parser_workers is not None
-                else self.data_cfg.parser_workers
+                self.eval_cfg.num_file_parser_workers
+                if self.eval_cfg.num_file_parser_workers is not None
+                else self.data_cfg.num_file_parser_workers
             ),
         )
         if len(dataset) == 0:
@@ -805,7 +844,7 @@ class Trainer:
             dataset,
             batch_size=self.eval_cfg.batch_size,
             shuffle=False,
-            num_workers=self.eval_cfg.num_workers,
+            num_workers=self.eval_cfg.num_dataloader_workers,
             pin_memory=self.device.type == "cuda",
             collate_fn=collate_backbones,
             drop_last=False,

--- a/tests/test_cli_config_validation.py
+++ b/tests/test_cli_config_validation.py
@@ -15,7 +15,12 @@ def _write_config(path: Path, config: dict) -> Path:
 
 def _base_config() -> dict:
     return {
-        "data": {"root": "data/train", "k": 8, "num_workers": 0, "cache": False},
+        "data": {
+            "root": "data/train",
+            "k": 8,
+            "num_dataloader_workers": 0,
+            "cache": False,
+        },
         "model": {
             "gcp": {
                 "hidden_scalar_dim": 32,

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -111,7 +111,12 @@ def test_evaluate_reports_summary(tmp_path, monkeypatch) -> None:
     torch.save({"model": model.state_dict(), "config": {}}, checkpoint_path)
 
     config = {
-        "data": {"root": "unused", "k": 1, "num_workers": 0, "cache": False},
+        "data": {
+            "root": "unused",
+            "k": 1,
+            "num_dataloader_workers": 0,
+            "cache": False,
+        },
         "model": {"checkpoint": str(checkpoint_path)},
         "eval": {"batch_size": 2, "tm_score": True, "gdt_ts": True, "histogram_bins": 5},
     }

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -54,7 +54,7 @@ def test_training_harness_runs_single_stage(tmp_path):
         "data": {
             "root": str(data_path),
             "k": 4,
-            "num_workers": 0,
+            "num_dataloader_workers": 0,
             "cache": True,
         },
         "model": {
@@ -129,7 +129,7 @@ def test_training_on_cif_dataset_decreases_loss(tmp_path, monkeypatch):
         "data": {
             "root": str(data_root),
             "k": 4,
-            "num_workers": 0,
+            "num_dataloader_workers": 0,
             "cache": True,
         },
         "model": {


### PR DESCRIPTION
## Summary
- rename the DataConfig worker and progress fields and propagate the new names through the training and evaluation pipelines
- update configuration loaders to accept the renamed keys while maintaining backward compatibility
- refresh bundled configs, documentation, and tests to reference the new option names

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc321e6fc08323b31d8fe895c92c2b