### PR TITLE
Remove parallel file parsing option

### DIFF
--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -21,7 +21,6 @@ omitted the defaults listed below are applied by the underlying dataclasses.
 | `chain_ids` | sequence[str] \| null | `null` | Optional subset of chain identifiers to keep. |
 | `k` | int | `16` | Number of nearest neighbours per residue when building the kNN graph. |
 | `num_dataloader_workers` | int | `0` | DataLoader worker processes. |
-| `num_file_parser_workers` | int \| null | `null` | Parallel workers used when parsing mmCIF files. |
 | `show_progress` | bool | `True` | Display a progress bar while preprocessing structures. |
 | `cache` | bool | `True` | Whether to cache parsed mmCIF records on disk. |
 

--- a/src/gcpvqvae/data/dataset.py
+++ b/src/gcpvqvae/data/dataset.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ProcessPoolExecutor
-from multiprocessing import get_context
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -71,7 +69,6 @@ class BackboneDataset(Dataset):
         k: int = 16,
         cache: bool = True,
         progress: bool = True,
-        num_workers: Optional[int] = None,
     ) -> None:
         self.root = Path(root)
         if not self.root.exists():
@@ -98,22 +95,12 @@ class BackboneDataset(Dataset):
         else:
             chain_filter = None
 
-        worker_count = (num_workers or 0)
         try:
-            if worker_count > 1 and total > 1:
-                ctx = get_context("spawn")
-                with ProcessPoolExecutor(max_workers=worker_count, mp_context=ctx) as executor:
-                    args = [(str(file), length_cap, chain_filter) for file in files]
-                    for records in executor.map(_load_records_for_dataset, args):
-                        self._store_records(records)
-                        if progress_bar is not None:
-                            progress_bar.update(1)
-            else:
-                for file in files:
-                    records = _load_records_for_dataset((str(file), length_cap, chain_filter))
-                    self._store_records(records)
-                    if progress_bar is not None:
-                        progress_bar.update(1)
+            for file in files:
+                records = _load_records_for_dataset((str(file), length_cap, chain_filter))
+                self._store_records(records)
+                if progress_bar is not None:
+                    progress_bar.update(1)
         finally:
             if progress_bar is not None:
                 progress_bar.close()

--- a/src/gcpvqvae/system/eval.py
+++ b/src/gcpvqvae/system/eval.py
@@ -32,7 +32,6 @@ class EvalDataConfig:
     k: int = 16
     num_dataloader_workers: int = 0
     cache: bool = True
-    num_file_parser_workers: Optional[int] = None
     show_progress: bool = True
 
 
@@ -86,15 +85,6 @@ def _prepare_data_config(raw: Dict[str, Any]) -> EvalDataConfig:
             raw.get("num_dataloader_workers", raw.get("num_workers", 0))
         ),
         cache=bool(raw.get("cache", True)),
-        num_file_parser_workers=(
-            int(raw["num_file_parser_workers"])
-            if raw.get("num_file_parser_workers") is not None
-            else (
-                int(raw["parser_workers"])
-                if raw.get("parser_workers") is not None
-                else None
-            )
-        ),
         show_progress=bool(raw.get("show_progress", raw.get("progress", True))),
     )
 
@@ -245,7 +235,6 @@ class Evaluator:
             k=self.data_cfg.k,
             cache=self.data_cfg.cache,
             progress=self.data_cfg.show_progress,
-            num_workers=self.data_cfg.num_file_parser_workers,
         )
         if len(dataset) == 0:
             raise ValueError("Evaluation dataset is empty")

--- a/src/gcpvqvae/system/train.py
+++ b/src/gcpvqvae/system/train.py
@@ -39,7 +39,6 @@ class DataConfig:
     k: int = 16
     num_dataloader_workers: int = 0
     cache: bool = True
-    num_file_parser_workers: Optional[int] = None
     show_progress: bool = True
 
 
@@ -99,7 +98,6 @@ class EvalDuringTrainingConfig:
     chain_ids: Optional[Tuple[str, ...]] = None
     k: Optional[int] = None
     cache: Optional[bool] = None
-    num_file_parser_workers: Optional[int] = None
     show_progress: Optional[bool] = None
     tm_score: bool = True
     gdt_ts: bool = False
@@ -334,15 +332,6 @@ def _prepare_eval_during_training_config(
         int(num_dataloader_workers_raw) if num_dataloader_workers_raw is not None else 0
     )
 
-    num_file_parser_workers_raw = raw.get("num_file_parser_workers")
-    if num_file_parser_workers_raw is None and "parser_workers" in raw:
-        num_file_parser_workers_raw = raw.get("parser_workers")
-    num_file_parser_workers = (
-        int(num_file_parser_workers_raw)
-        if num_file_parser_workers_raw is not None
-        else None
-    )
-
     show_progress_raw = raw.get("show_progress")
     if show_progress_raw is None and "progress" in raw:
         show_progress_raw = raw.get("progress")
@@ -359,7 +348,6 @@ def _prepare_eval_during_training_config(
         chain_ids=chain_ids,
         k=k_int,
         cache=cache_flag,
-        num_file_parser_workers=num_file_parser_workers,
         show_progress=show_progress,
         tm_score=bool(raw.get("tm_score", True)),
         gdt_ts=bool(raw.get("gdt_ts", False)),
@@ -442,13 +430,6 @@ def _prepare_data_config(raw: Dict[str, Any]) -> DataConfig:
         num_dataloader_workers_raw = raw.get("num_workers")
     num_dataloader_workers = int(num_dataloader_workers_raw or 0)
 
-    parser_workers_raw = raw.get("num_file_parser_workers")
-    if parser_workers_raw is None and "parser_workers" in raw:
-        parser_workers_raw = raw.get("parser_workers")
-    num_file_parser_workers = (
-        int(parser_workers_raw) if parser_workers_raw is not None else None
-    )
-
     show_progress_raw = raw.get("show_progress")
     if show_progress_raw is None and "progress" in raw:
         show_progress_raw = raw.get("progress")
@@ -458,7 +439,6 @@ def _prepare_data_config(raw: Dict[str, Any]) -> DataConfig:
         k=int(raw.get("k", 16)),
         num_dataloader_workers=num_dataloader_workers,
         cache=bool(raw.get("cache", True)),
-        num_file_parser_workers=num_file_parser_workers,
         show_progress=bool(show_progress_raw if show_progress_raw is not None else True),
     )
 
@@ -790,7 +770,6 @@ class Trainer:
             k=self.data_cfg.k,
             cache=self.data_cfg.cache,
             progress=self.data_cfg.show_progress,
-            num_workers=self.data_cfg.num_file_parser_workers,
         )
         loader = DataLoader(
             dataset,
@@ -826,11 +805,6 @@ class Trainer:
                 self.eval_cfg.show_progress
                 if self.eval_cfg.show_progress is not None
                 else self.data_cfg.show_progress
-            ),
-            num_workers=(
-                self.eval_cfg.num_file_parser_workers
-                if self.eval_cfg.num_file_parser_workers is not None
-                else self.data_cfg.num_file_parser_workers
             ),
         )
         if len(dataset) == 0:

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -207,30 +207,28 @@ def _assert_tensors_equal(tensor_a: torch.Tensor, tensor_b: torch.Tensor) -> Non
         assert torch.equal(tensor_a, tensor_b)
 
 
-def test_dataset_parallel_parsing_matches_serial():
+def test_dataset_repeated_parsing_matches():
     data_root = Path("tests/test_data/cif_50")
 
-    serial_dataset = BackboneDataset(
+    first_dataset = BackboneDataset(
         data_root,
         k=2,
         cache=True,
         progress=False,
-        num_workers=1,
     )
-    parallel_dataset = BackboneDataset(
+    second_dataset = BackboneDataset(
         data_root,
         k=2,
         cache=True,
         progress=False,
-        num_workers=2,
     )
 
-    assert len(serial_dataset) == len(parallel_dataset)
-    assert serial_dataset._keys == parallel_dataset._keys  # type: ignore[attr-defined]
+    assert len(first_dataset) == len(second_dataset)
+    assert first_dataset._keys == second_dataset._keys  # type: ignore[attr-defined]
 
-    for idx in range(len(serial_dataset)):
-        serial_sample = serial_dataset[idx]
-        parallel_sample = parallel_dataset[idx]
+    for idx in range(len(first_dataset)):
+        first_sample = first_dataset[idx]
+        second_sample = second_dataset[idx]
 
         tensor_fields = [
             "coords",
@@ -248,13 +246,13 @@ def test_dataset_parallel_parsing_matches_serial():
             "edge_frames",
         ]
         for field in tensor_fields:
-            _assert_tensors_equal(serial_sample[field], parallel_sample[field])  # type: ignore[index]
+            _assert_tensors_equal(first_sample[field], second_sample[field])  # type: ignore[index]
 
         pose_fields = ["rotation", "translation"]
         for field in pose_fields:
-            _assert_tensors_equal(serial_sample["pose"][field], parallel_sample["pose"][field])  # type: ignore[index]
+            _assert_tensors_equal(first_sample["pose"][field], second_sample["pose"][field])  # type: ignore[index]
 
-        assert serial_sample["metadata"] == parallel_sample["metadata"]
+        assert first_sample["metadata"] == second_sample["metadata"]
 
 
 def test_dataset_skips_chains_without_valid_backbone():


### PR DESCRIPTION
## Summary
- remove the multiprocessing-based mmCIF parsing path and always process files sequentially while retaining progress reporting
- drop the num_file_parser_workers configuration fields from training/evaluation configs and documentation
- update dataset tests to reflect the simplified parsing behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc3fbbd96c8323bd584a83005844be