### PR TITLE
Add dataset preprocessing command and support preprocessed inputs

### DIFF
--- a/src/gcpvqvae/cli.py
+++ b/src/gcpvqvae/cli.py
@@ -42,6 +42,83 @@ def gpcvq() -> None:
 
 
 @gpcvq.command(
+    name="preprocess-dataset",
+    short_help="Precompute and cache dataset features.",
+    help=(
+        "Parse INPUT (a backbone file or directory) and write a cached representation "
+        "to OUTPUT. The resulting directory can be supplied to other commands in place "
+        "of the original structure files."
+    ),
+)
+@click.argument(
+    "input",
+    type=click.Path(exists=True, path_type=Path),
+    metavar="INPUT",
+)
+@click.argument(
+    "output",
+    type=click.Path(path_type=Path),
+    metavar="OUTPUT",
+)
+@click.option(
+    "--chain-id",
+    "chain_ids",
+    multiple=True,
+    help="Restrict preprocessing to specific chain identifiers.",
+)
+@click.option(
+    "--length-cap",
+    type=int,
+    default=2048,
+    show_default=True,
+    help="Maximum sequence length to load from the source data.",
+)
+@click.option(
+    "--k",
+    type=int,
+    default=16,
+    show_default=True,
+    help="Number of nearest neighbours to use when computing geometric features.",
+)
+@click.option(
+    "--overwrite/--no-overwrite",
+    default=False,
+    show_default=True,
+    help="Overwrite OUTPUT if it already exists.",
+)
+@click.option(
+    "--progress/--no-progress",
+    "show_progress",
+    default=True,
+    show_default=True,
+    help="Display progress while preprocessing.",
+)
+def preprocess_dataset_command(
+    input: Path,
+    output: Path,
+    chain_ids: Tuple[str, ...],
+    length_cap: int,
+    k: int,
+    overwrite: bool,
+    show_progress: bool,
+) -> None:
+    """Preprocess raw backbone data for faster reuse."""
+
+    from gcpvqvae.data.preprocessing import preprocess_dataset
+
+    manifest_path = preprocess_dataset(
+        input,
+        output,
+        chain_ids=chain_ids if chain_ids else None,
+        length_cap=length_cap,
+        k=k,
+        overwrite=overwrite,
+        progress=show_progress,
+    )
+    click.echo(f"Preprocessed dataset written to {manifest_path}")
+
+
+@gpcvq.command(
     name="train",
     short_help="Train a model from a YAML configuration file.",
     help=(

--- a/src/gcpvqvae/data/dataset.py
+++ b/src/gcpvqvae/data/dataset.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import torch
 from torch.utils.data import Dataset
@@ -12,6 +13,10 @@ from .featurize import featurize_backbone
 from .mmcif import PAD_INDEX, BackboneRecord, load_mmcif
 
 Tensor = torch.Tensor
+
+PREPROCESSED_MANIFEST = "preprocessed_dataset.json"
+PREPROCESSED_SAMPLES_DIR = "samples"
+PREPROCESSED_VERSION = 1
 
 try:  # pragma: no cover - tqdm is optional at runtime
     from tqdm.auto import tqdm
@@ -57,6 +62,67 @@ def _discover_files(root: Path) -> List[Path]:
     return files
 
 
+def _clone_nested(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.clone()
+    if isinstance(value, dict):
+        return {key: _clone_nested(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_clone_nested(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_nested(item) for item in value)
+    return value
+
+
+def _trim_sample(sample: Dict[str, Any], max_length: int) -> Dict[str, Any]:
+    if max_length <= 0:
+        return sample
+
+    seq_length = int(sample["coords"].shape[0])  # type: ignore[index]
+    if seq_length <= max_length:
+        return sample
+
+    slice_obj = slice(0, max_length)
+    tensor_keys = [
+        "coords",
+        "mask",
+        "atom_mask",
+        "seq",
+        "nan_mask",
+        "node_scalars",
+        "node_vectors",
+        "backbone_vectors",
+        "torsion_angles",
+    ]
+    for key in tensor_keys:
+        if key in sample and isinstance(sample[key], torch.Tensor):
+            sample[key] = sample[key][slice_obj]
+
+    if "edge_index" in sample and isinstance(sample["edge_index"], torch.Tensor):
+        edge_index = sample["edge_index"]
+        valid = (edge_index < max_length).all(dim=0)
+        sample["edge_index"] = edge_index[:, valid]
+        for edge_key in ("edge_scalars", "edge_vectors", "edge_frames"):
+            if edge_key in sample and isinstance(sample[edge_key], torch.Tensor):
+                sample[edge_key] = sample[edge_key][valid]
+
+    if "seq_str" in sample and isinstance(sample["seq_str"], str):
+        sample["seq_str"] = sample["seq_str"][:max_length]
+
+    metadata = sample.get("metadata")
+    if isinstance(metadata, dict):
+        trimmed = dict(metadata)
+        if "sequence" in trimmed and isinstance(trimmed["sequence"], str):
+            trimmed["sequence"] = trimmed["sequence"][:max_length]
+        if "residue_ids" in trimmed and isinstance(trimmed["residue_ids"], list):
+            trimmed["residue_ids"] = trimmed["residue_ids"][:max_length]
+        if "residue_names" in trimmed and isinstance(trimmed["residue_names"], list):
+            trimmed["residue_names"] = trimmed["residue_names"][:max_length]
+        sample["metadata"] = trimmed
+
+    return sample
+
+
 class BackboneDataset(Dataset):
     """Dataset of protein backbones ready for GCP featurization."""
 
@@ -78,8 +144,19 @@ class BackboneDataset(Dataset):
         self.k = k
         self.chain_filter = set(chain_ids) if chain_ids is not None else None
         self._cache_enabled = cache
-        self._records: Dict[Tuple[str, str], BackboneRecord] = {}
+        self._records: Dict[Tuple[str, str], BackboneRecord | Dict[str, Any]] = {}
         self._keys: List[Tuple[str, str]] = []
+        self._preprocessed = False
+        self._preprocessed_files: List[Path] = []
+        self._source_length_cap: Optional[int] = None
+
+        if self.root.is_dir():
+            manifest_path = self.root / PREPROCESSED_MANIFEST
+            if manifest_path.is_file():
+                self._init_from_preprocessed(manifest_path, chain_ids, length_cap, k)
+                if not self._keys:
+                    raise ValueError("Dataset does not contain any valid backbone chains")
+                return
 
         files = _discover_files(self.root)
 
@@ -120,7 +197,9 @@ class BackboneDataset(Dataset):
 
     def _get_record(self, key: Tuple[str, str]) -> BackboneRecord:
         if self._cache_enabled and key in self._records:
-            return self._records[key]
+            cached = self._records[key]
+            if isinstance(cached, BackboneRecord):
+                return cached
 
         path, chain_id = key
         records = load_mmcif(path, chain_id=chain_id, length_cap=self.length_cap)
@@ -133,6 +212,8 @@ class BackboneDataset(Dataset):
 
     def __getitem__(self, index: int) -> Dict[str, Tensor | Dict[str, object]]:
         key = self._keys[index]
+        if self._preprocessed:
+            return self._get_preprocessed_sample(index, key)
         record = self._get_record(key)
 
         features = featurize_backbone(record, k=self.k)
@@ -165,6 +246,96 @@ class BackboneDataset(Dataset):
             },
         }
 
+        return sample
+
+    def _init_from_preprocessed(
+        self,
+        manifest_path: Path,
+        chain_ids: Optional[Iterable[str]],
+        length_cap: int,
+        k: int,
+    ) -> None:
+        with manifest_path.open("r", encoding="utf-8") as handle:
+            manifest = json.load(handle)
+
+        version = manifest.get("version")
+        if version != PREPROCESSED_VERSION:
+            raise ValueError(
+                f"Unsupported preprocessed dataset version {version!r}; expected {PREPROCESSED_VERSION}"
+            )
+
+        manifest_k = manifest.get("k")
+        if manifest_k is not None and manifest_k != k:
+            raise ValueError(
+                f"Preprocessed dataset was generated with k={manifest_k} "
+                f"but k={k} was requested"
+            )
+
+        entries = manifest.get("entries")
+        if not isinstance(entries, list):
+            raise ValueError("Invalid preprocessed dataset manifest: missing 'entries'")
+
+        chain_filter = set(chain_ids) if chain_ids is not None else None
+
+        filtered: List[Dict[str, Any]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            chain_id = entry.get("chain_id")
+            file_rel = entry.get("file")
+            if not isinstance(chain_id, str) or not isinstance(file_rel, str):
+                continue
+            if chain_filter is not None and chain_id not in chain_filter:
+                continue
+            filtered.append(entry)
+
+        if not filtered:
+            raise ValueError("Dataset does not contain any valid backbone chains")
+
+        source_length_cap = manifest.get("length_cap")
+        if isinstance(source_length_cap, int) and source_length_cap > 0:
+            self._source_length_cap = source_length_cap
+        else:
+            self._source_length_cap = None
+
+        self.length_cap = length_cap
+        if self._source_length_cap is not None:
+            self.length_cap = min(self.length_cap, self._source_length_cap)
+        self.k = manifest_k if isinstance(manifest_k, int) and manifest_k > 0 else k
+        self.chain_filter = chain_filter
+        self._preprocessed = True
+        self._preprocessed_files = []
+        self._keys = []
+
+        for entry in filtered:
+            file_rel = entry["file"]
+            sample_path = manifest_path.parent / file_rel
+            if not sample_path.exists():
+                raise FileNotFoundError(sample_path)
+            source_path = entry.get("source_path")
+            if not isinstance(source_path, str):
+                source_path = str(sample_path)
+            chain_id = entry["chain_id"]
+            key = (source_path, chain_id)
+            self._keys.append(key)
+            self._preprocessed_files.append(sample_path)
+
+    def _get_preprocessed_sample(
+        self, index: int, key: Tuple[str, str]
+    ) -> Dict[str, Tensor | Dict[str, object]]:
+        if self._cache_enabled and key in self._records:
+            cached = self._records[key]
+        else:
+            sample_path = self._preprocessed_files[index]
+            cached = torch.load(sample_path, map_location="cpu")
+            if not isinstance(cached, dict):
+                raise TypeError(f"Preprocessed sample at {sample_path} is not a mapping")
+            if self._cache_enabled:
+                self._records[key] = cached
+
+        sample = _clone_nested(cached)
+        if self.length_cap and self.length_cap > 0:
+            sample = _trim_sample(sample, self.length_cap)
         return sample
 
 
@@ -266,4 +437,10 @@ def collate_backbones(batch: List[Dict[str, Tensor | Dict[str, object]]]) -> Dic
     }
 
 
-__all__ = ["BackboneDataset", "collate_backbones"]
+__all__ = [
+    "BackboneDataset",
+    "collate_backbones",
+    "PREPROCESSED_MANIFEST",
+    "PREPROCESSED_SAMPLES_DIR",
+    "PREPROCESSED_VERSION",
+]

--- a/src/gcpvqvae/data/preprocessing.py
+++ b/src/gcpvqvae/data/preprocessing.py
@@ -1,0 +1,154 @@
+"""Utilities for preprocessing backbone datasets for fast reuse."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import torch
+
+from .dataset import (
+    BackboneDataset,
+    PREPROCESSED_MANIFEST,
+    PREPROCESSED_SAMPLES_DIR,
+    PREPROCESSED_VERSION,
+)
+
+try:  # pragma: no cover - tqdm is optional
+    from tqdm.auto import tqdm
+except Exception:  # pragma: no cover - tqdm is optional
+    tqdm = None
+
+
+def _to_cpu(data):
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu()
+    if isinstance(data, dict):
+        return {key: _to_cpu(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [_to_cpu(item) for item in data]
+    if isinstance(data, tuple):
+        return tuple(_to_cpu(item) for item in data)
+    return data
+
+
+def preprocess_dataset(
+    input_root: str | Path,
+    output_dir: str | Path,
+    *,
+    chain_ids: Optional[Sequence[str]] = None,
+    length_cap: int = 2048,
+    k: int = 16,
+    overwrite: bool = False,
+    progress: bool = True,
+) -> Path:
+    """Materialise a :class:`BackboneDataset` to disk for reuse.
+
+    Parameters
+    ----------
+    input_root:
+        Directory or file containing the raw structure data.
+    output_dir:
+        Directory where the preprocessed representation should be stored.
+    chain_ids:
+        Optional iterable of chain identifiers to retain.
+    length_cap:
+        Maximum chain length to load from the raw data.
+    k:
+        Neighbourhood size used when computing geometric features.
+    overwrite:
+        Whether to delete any existing data under ``output_dir``.
+    progress:
+        Show a progress bar while writing samples.
+
+    Returns
+    -------
+    Path
+        The path to the manifest describing the processed dataset.
+    """
+
+    output_path = Path(output_dir)
+    if output_path.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"Output directory {output_path} already exists. Pass overwrite=True to replace it."
+            )
+        shutil.rmtree(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    dataset = BackboneDataset(
+        input_root,
+        chain_ids=chain_ids,
+        length_cap=length_cap,
+        k=k,
+        cache=True,
+        progress=progress,
+    )
+
+    samples_dir = output_path / PREPROCESSED_SAMPLES_DIR
+    samples_dir.mkdir(parents=True, exist_ok=True)
+
+    entries: List[Dict[str, object]] = []
+    iterator = range(len(dataset))
+    progress_bar = None
+    if progress and tqdm is not None:
+        progress_bar = tqdm(total=len(dataset), desc="Saving preprocessed samples")
+
+    try:
+        for index in iterator:
+            sample = dataset[index]
+            cpu_sample = _to_cpu(sample)
+            file_name = f"{index:08d}.pt"
+            sample_path = samples_dir / file_name
+            torch.save(cpu_sample, sample_path)
+
+            metadata = cpu_sample.get("metadata", {})
+            if isinstance(metadata, dict):
+                source_path = metadata.get("path")
+                chain_id = metadata.get("chain_id")
+                sequence = metadata.get("sequence")
+            else:
+                source_path = None
+                chain_id = None
+                sequence = None
+
+            mask = cpu_sample.get("mask")
+            length = None
+            if isinstance(mask, torch.Tensor):
+                length = int(mask.to(torch.bool).sum().item())
+            entries.append(
+                {
+                    "file": str(Path(PREPROCESSED_SAMPLES_DIR) / file_name),
+                    "source_path": source_path,
+                    "chain_id": chain_id,
+                    "sequence": sequence,
+                    "length": length,
+                }
+            )
+
+            if progress_bar is not None:
+                progress_bar.update(1)
+    finally:
+        if progress_bar is not None:
+            progress_bar.close()
+
+    manifest = {
+        "version": PREPROCESSED_VERSION,
+        "source": str(Path(input_root).resolve()),
+        "length_cap": dataset.length_cap,
+        "k": dataset.k,
+        "chain_ids": sorted(set(chain_ids)) if chain_ids else None,
+        "num_samples": len(entries),
+        "entries": entries,
+    }
+
+    manifest_path = output_path / PREPROCESSED_MANIFEST
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+
+    return manifest_path
+
+
+__all__ = ["preprocess_dataset"]

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict, List
 
+import gemmi
 import torch
 from torch import nn
 from torch.utils.data import Dataset
@@ -9,6 +11,7 @@ from torch.utils.data import Dataset
 import yaml
 import pytest
 
+from gcpvqvae.data.preprocessing import preprocess_dataset
 from gcpvqvae.system import eval as eval_module
 
 
@@ -65,6 +68,46 @@ class FakeDataset(Dataset):
         return self.samples[index]
 
 
+def _build_eval_structure(path: Path) -> None:
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(30.0, 30.0, 30.0, 90.0, 90.0, 90.0)
+
+    model = gemmi.Model("0")
+    chain = gemmi.Chain("A")
+    for idx in range(1, 3):
+        residue = gemmi.Residue()
+        residue.name = "GLY"
+        residue.het_flag = " "
+        residue.seqid = gemmi.SeqId(str(idx))
+        base = 3.8 * (idx - 1)
+
+        atom_n = gemmi.Atom()
+        atom_n.name = "N"
+        atom_n.pos = gemmi.Position(base, 0.0, 0.0)
+        atom_n.occ = 1.0
+        residue.add_atom(atom_n)
+
+        atom_ca = gemmi.Atom()
+        atom_ca.name = "CA"
+        atom_ca.pos = gemmi.Position(base + 1.2, 0.3, 0.0)
+        atom_ca.occ = 1.0
+        residue.add_atom(atom_ca)
+
+        atom_c = gemmi.Atom()
+        atom_c.name = "C"
+        atom_c.pos = gemmi.Position(base + 2.3, 0.1, 0.0)
+        atom_c.occ = 1.0
+        residue.add_atom(atom_c)
+
+        chain.add_residue(residue)
+    model.add_chain(chain)
+
+    structure.add_model(model)
+    structure.setup_entities()
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+
 def fake_collate(batch: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
     max_len = max(item["coords"].shape[0] for item in batch)
     batch_size = len(batch)
@@ -102,7 +145,19 @@ class FakeModel(nn.Module):
 
 
 def test_evaluate_reports_summary(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(eval_module, "BackboneDataset", FakeDataset)
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    raw_path = raw_dir / "toy.cif"
+    _build_eval_structure(raw_path)
+
+    processed_dir = tmp_path / "processed"
+    preprocess_dataset(raw_dir, processed_dir, k=1, progress=False)
+
+    def dataset_factory(root, **kwargs):
+        assert Path(root) == processed_dir
+        return FakeDataset(str(root), **kwargs)
+
+    monkeypatch.setattr(eval_module, "BackboneDataset", dataset_factory)
     monkeypatch.setattr(eval_module, "collate_backbones", fake_collate)
     monkeypatch.setattr(eval_module, "GCPVQVAE", FakeModel)
 
@@ -112,7 +167,7 @@ def test_evaluate_reports_summary(tmp_path, monkeypatch) -> None:
 
     config = {
         "data": {
-            "root": "unused",
+            "root": str(processed_dir),
             "k": 1,
             "num_dataloader_workers": 0,
             "cache": False,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+
+import gemmi
+import json
+import torch
+
+from gcpvqvae.data.dataset import (
+    BackboneDataset,
+    PREPROCESSED_MANIFEST,
+)
+from gcpvqvae.data.preprocessing import preprocess_dataset
+
+
+def _make_dataset(path: Path) -> None:
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(30.0, 30.0, 30.0, 90.0, 90.0, 90.0)
+
+    model = gemmi.Model("0")
+    for chain_id, residue_names in {"A": ["ALA", "GLY", "SER"], "B": ["VAL", "TYR"]}.items():
+        chain = gemmi.Chain(chain_id)
+        for idx, name in enumerate(residue_names, start=1):
+            residue = gemmi.Residue()
+            residue.name = name
+            residue.het_flag = " "
+            residue.seqid = gemmi.SeqId(str(idx))
+            base = 3.6 * (idx - 1)
+
+            atom_n = gemmi.Atom()
+            atom_n.name = "N"
+            atom_n.pos = gemmi.Position(base, idx * 0.1, 0.0)
+            atom_n.occ = 1.0
+            residue.add_atom(atom_n)
+
+            atom_ca = gemmi.Atom()
+            atom_ca.name = "CA"
+            atom_ca.pos = gemmi.Position(base + 1.2, idx * 0.1, 0.3)
+            atom_ca.occ = 1.0
+            residue.add_atom(atom_ca)
+
+            atom_c = gemmi.Atom()
+            atom_c.name = "C"
+            atom_c.pos = gemmi.Position(base + 2.3, idx * 0.1, 0.5)
+            atom_c.occ = 1.0
+            residue.add_atom(atom_c)
+
+            chain.add_residue(residue)
+        model.add_chain(chain)
+
+    structure.add_model(model)
+    structure.setup_entities()
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+
+def test_preprocess_dataset_roundtrip(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    raw_path = raw_dir / "toy.cif"
+    _make_dataset(raw_path)
+
+    output_dir = tmp_path / "processed"
+    manifest_path = preprocess_dataset(raw_dir, output_dir, k=4, progress=False)
+
+    assert manifest_path == output_dir / PREPROCESSED_MANIFEST
+    assert manifest_path.exists()
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["num_samples"] == 2
+    assert manifest["k"] == 4
+
+    raw_dataset = BackboneDataset(raw_dir, k=4, progress=False)
+    processed_dataset = BackboneDataset(output_dir, k=4, progress=False)
+
+    assert len(raw_dataset) == len(processed_dataset) == 2
+
+    raw_map = {}
+    for sample in raw_dataset:
+        metadata = sample["metadata"]
+        raw_map[(metadata["path"], metadata["chain_id"])] = sample
+
+    processed_map = {}
+    for sample in processed_dataset:
+        metadata = sample["metadata"]
+        processed_map[(metadata["path"], metadata["chain_id"])] = sample
+
+    assert raw_map.keys() == processed_map.keys()
+
+    for key in raw_map:
+        raw_sample = raw_map[key]
+        processed_sample = processed_map[key]
+        assert torch.allclose(raw_sample["coords"], processed_sample["coords"])
+        assert torch.equal(raw_sample["mask"], processed_sample["mask"])
+        assert raw_sample["metadata"]["sequence"] == processed_sample["metadata"]["sequence"]
+
+    limited_dataset = BackboneDataset(output_dir, k=4, length_cap=2, progress=False)
+    limited_sequences = {}
+    for sample in limited_dataset:
+        metadata = sample["metadata"]
+        limited_sequences[metadata["chain_id"]] = metadata["sequence"]
+        assert sample["coords"].shape[0] <= 2
+        assert len(sample["seq_str"]) <= 2
+    assert set(limited_sequences) == {"A", "B"}
+    assert limited_sequences["A"] == "AG"
+    assert limited_sequences["B"] == "VY"
+
+    filtered_dataset = BackboneDataset(output_dir, k=4, chain_ids=["B"], progress=False)
+    assert len(filtered_dataset) == 1
+    filtered_sample = filtered_dataset[0]
+    assert filtered_sample["metadata"]["chain_id"] == "B"
+    assert filtered_sample["metadata"]["sequence"] == "VY"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import gemmi
 import yaml
 
+from gcpvqvae.data.preprocessing import preprocess_dataset
 from gcpvqvae.system.train import Trainer, train
 
 
@@ -112,6 +113,85 @@ def test_training_harness_runs_single_stage(tmp_path):
     }
 
     config_path = tmp_path / "config.yaml"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(config, handle)
+
+    train(str(config_path))
+
+    checkpoints = list((output_dir / "checkpoints").glob("*.pt"))
+    assert checkpoints, "training did not produce checkpoints"
+
+
+def test_training_with_preprocessed_dataset(tmp_path):
+    data_path = tmp_path / "toy.cif"
+    _build_toy_structure(data_path)
+
+    processed_root = tmp_path / "processed"
+    preprocess_dataset(data_path, processed_root, k=4, progress=False)
+
+    output_dir = tmp_path / "runs"
+    config = {
+        "data": {
+            "root": str(processed_root),
+            "k": 4,
+            "num_dataloader_workers": 0,
+            "cache": True,
+        },
+        "model": {
+            "gcp": {
+                "hidden_scalar_dim": 32,
+                "hidden_vector_dim": 4,
+                "edge_scalar_dim": 8,
+                "edge_vector_dim": 1,
+                "latent_dim": 64,
+                "layers": 2,
+            },
+            "vq": {
+                "num_codes": 64,
+                "dim": 64,
+                "beta": 0.25,
+                "decay": 0.99,
+                "kmeans_iters": 1,
+            },
+            "encoder": {
+                "model_dim": 128,
+                "num_layers": 2,
+                "num_heads": 4,
+                "num_kv_heads": 2,
+            },
+            "decoder": {
+                "model_dim": 128,
+                "num_layers": 2,
+                "num_heads": 4,
+                "num_kv_heads": 1,
+            },
+        },
+        "train": {
+            "seed": 321,
+            "amp": False,
+            "clip_grad": 1.0,
+            "random_rotation": False,
+            "checkpoint_interval": 1,
+            "output_dir": str(output_dir),
+            "log": {"interval": 1},
+            "export": {"enabled": False},
+            "stages": [
+                {
+                    "name": "test",
+                    "length_cap": 512,
+                    "batch_size": 1,
+                    "base_lr": 0.001,
+                    "min_lr": 1e-5,
+                    "warmup_steps": 1,
+                    "epochs": 1,
+                    "accumulation_steps": 1,
+                    "nan_mask_prob": 0.0,
+                }
+            ],
+        },
+    }
+
+    config_path = tmp_path / "config_preprocessed.yaml"
     with open(config_path, "w", encoding="utf-8") as handle:
         yaml.safe_dump(config, handle)
 


### PR DESCRIPTION
## Summary
- add a `gpcvq preprocess-dataset` CLI command that materialises backbone features for reuse
- extend `BackboneDataset` to detect and serve preprocessed datasets while honouring requested length caps
- cover preprocessing plus train/eval entry points with new unit tests using cached datasets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc45e738b883239ab930785a8469de