### PR TITLE
Align configs with base GCPNet and add latent adapter

### DIFF
--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -33,6 +33,7 @@ omitted the defaults listed below are applied by the underlying dataclasses.
 | `node_scalar_dim` | `6` | Input scalar feature channels per residue. |
 | `node_vector_dim` | `3` | Input vector feature channels per residue. |
 | `edge_scalar_dim` | `8` | Scalar features attached to each edge. |
+| `edge_scalar_input_dim` | `null` | Optional raw dimensionality of edge scalar features (defaults to `edge_scalar_dim`). |
 | `edge_vector_dim` | `1` | Vector features per edge. |
 | `hidden_scalar_dim` | `128` | Scalar width of the hidden representations. |
 | `hidden_vector_dim` | `16` | Vector channel count inside the GCP blocks. |
@@ -43,6 +44,14 @@ omitted the defaults listed below are applied by the underlying dataclasses.
 | `init` | `"random"` | Select `"random"` for fresh weights or `"pretrained"` to load from a checkpoint. |
 | `init_checkpoint` | `null` | Filesystem path to the checkpoint containing pretrained GCPNet weights. |
 | `strict_init` | `True` | Whether to enforce an exact key match when loading weights. |
+
+### `model.adapter` – Latent projection (`LatentAdapterConfig`)
+
+| key | default | description |
+| --- | --- | --- |
+| `enabled` | `False` | Enables the linear adapter between the GCP encoder and Transformer stack. |
+| `output_dim` | `null` | Target dimensionality for the adapter projection (defaults to `model.vq.dim` when omitted). |
+| `bias` | `False` | Adds a bias term to the projection layer when set to `True`. |
 
 ### `model.encoder` and `model.decoder` – Transformer stacks (`TransformerConfig`)
 
@@ -155,8 +164,8 @@ Each stage entry orchestrates one phase of the curriculum.  Provide either
 Example templates are provided:
 
 - `base.yaml`: full-sized training schedule mirroring the manuscript.
-- `small.yaml`: reduced footprint configuration for local experiments.
-- `xsmall.yaml`: minimal configuration matching the continuous integration tests.
+- `small.yaml`: reduced footprint configuration for local experiments, reusing the base GCPNet with a latent adapter to shrink the Transformer.
+- `xsmall.yaml`: minimal configuration matching the continuous integration tests, also using the latent adapter for compact Transformer/VQ settings.
 - `gcpnet_pretrain.yaml`: lightweight schedule for pretraining the encoder in isolation.
 
 Feel free to copy these files and customise them using the options described

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -13,6 +13,7 @@ model:
     hidden_scalar_dim: 128
     hidden_vector_dim: 16
     edge_scalar_dim: 32
+    edge_scalar_input_dim: 8
     edge_vector_dim: 1
     latent_dim: 256
     layers: 6

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -8,15 +8,19 @@ data:
 
 model:
   gcp:
-    hidden_scalar_dim: 64
-    hidden_vector_dim: 8
-    edge_scalar_dim: 8
+    hidden_scalar_dim: 128
+    hidden_vector_dim: 16
+    edge_scalar_dim: 32
+    edge_scalar_input_dim: 8
     edge_vector_dim: 1
-    latent_dim: 128
-    layers: 3
+    latent_dim: 256
+    layers: 6
     init: random
     init_checkpoint: null
     strict_init: true
+  adapter:
+    enabled: true
+    output_dim: 128
   vq:
     num_codes: 512
     dim: 128

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -9,15 +9,19 @@ data:
 
 model:
   gcp:
-    hidden_scalar_dim: 16
-    hidden_vector_dim: 4
-    edge_scalar_dim: 8
+    hidden_scalar_dim: 128
+    hidden_vector_dim: 16
+    edge_scalar_dim: 32
+    edge_scalar_input_dim: 8
     edge_vector_dim: 1
-    latent_dim: 16
-    layers: 2
+    latent_dim: 256
+    layers: 6
     init: random
     init_checkpoint: null
     strict_init: true
+  adapter:
+    enabled: true
+    output_dim: 16
   vq:
     num_codes: 16
     dim: 16

--- a/src/gcpvqvae/models/gcpnet.py
+++ b/src/gcpvqvae/models/gcpnet.py
@@ -203,6 +203,7 @@ class GCPNetConfig:
     node_scalar_dim: int = 6
     node_vector_dim: int = 3
     edge_scalar_dim: int = 8
+    edge_scalar_input_dim: Optional[int] = None
     edge_vector_dim: int = 1
     hidden_scalar_dim: int = 128
     hidden_vector_dim: int = 16
@@ -223,10 +224,28 @@ class GCPNetEncoder(nn.Module):
 
         self.config = config or GCPNetConfig()
 
+        self.edge_scalar_in_dim = (
+            self.config.edge_scalar_input_dim
+            if self.config.edge_scalar_input_dim is not None
+            else self.config.edge_scalar_dim
+        )
+
         self.scalar_proj = nn.Linear(self.config.node_scalar_dim, self.config.hidden_scalar_dim, bias=False)
         self.vector_proj = nn.Parameter(
             torch.randn(self.config.hidden_vector_dim, self.config.node_vector_dim) * 0.02
         )
+
+        if self.config.edge_scalar_dim > 0:
+            self.edge_scalar_proj = nn.Linear(
+                self.edge_scalar_in_dim,
+                self.config.edge_scalar_dim,
+                bias=False,
+            )
+            if self.edge_scalar_in_dim == self.config.edge_scalar_dim:
+                with torch.no_grad():
+                    self.edge_scalar_proj.weight.copy_(torch.eye(self.config.edge_scalar_dim))
+        else:
+            self.edge_scalar_proj = None
 
         self.layers = nn.ModuleList(
             [
@@ -283,8 +302,24 @@ class GCPNetEncoder(nn.Module):
             scalars = scalars * mask.unsqueeze(-1)
             vectors = vectors * mask.unsqueeze(-1).unsqueeze(-1)
 
+        if self.edge_scalar_proj is not None and edge_scalars.numel():
+            edge_scalars_projected = self.edge_scalar_proj(edge_scalars)
+        elif self.edge_scalar_proj is not None:
+            edge_scalars_projected = edge_scalars.new_zeros(
+                (edge_scalars.shape[0], self.config.edge_scalar_dim)
+            )
+        else:
+            edge_scalars_projected = edge_scalars
+
         for layer in self.layers:
-            scalars, vectors = layer(scalars, vectors, edge_index, edge_scalars, edge_vectors, edge_frames)
+            scalars, vectors = layer(
+                scalars,
+                vectors,
+                edge_index,
+                edge_scalars_projected,
+                edge_vectors,
+                edge_frames,
+            )
             if mask is not None:
                 scalars = scalars * mask.unsqueeze(-1)
                 vectors = vectors * mask.unsqueeze(-1).unsqueeze(-1)

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -44,6 +44,15 @@ class VectorQuantizerConfig:
 
 
 @dataclass
+class LatentAdapterConfig:
+    """Optional linear adapter bridging the GCP encoder and Transformer."""
+
+    enabled: bool = False
+    output_dim: Optional[int] = None
+    bias: bool = False
+
+
+@dataclass
 class RotationHeadConfig:
     """Parameters for the rigid 6D rotation decoder head."""
 
@@ -66,12 +75,22 @@ class GCPVQVAEConfig:
         )
     )
     vq: VectorQuantizerConfig = field(default_factory=VectorQuantizerConfig)
+    adapter: LatentAdapterConfig = field(default_factory=LatentAdapterConfig)
     rotation: RotationHeadConfig = field(default_factory=RotationHeadConfig)
     data: DataPipelineConfig = field(default_factory=DataPipelineConfig)
 
     def __post_init__(self) -> None:
         # Ensure dimensional consistency between the sub-modules.
-        self.encoder.input_dim = self.gcp.latent_dim
+        if self.adapter.enabled:
+            target_dim = self.adapter.output_dim or self.vq.dim
+            if target_dim is None:
+                raise ValueError(
+                    "Latent adapter requires either 'output_dim' or 'vq.dim' to be set"
+                )
+            self.adapter.output_dim = target_dim
+            self.encoder.input_dim = target_dim
+        else:
+            self.encoder.input_dim = self.gcp.latent_dim
         self.encoder.output_dim = self.vq.dim
         self.decoder.input_dim = self.vq.dim
         if self.decoder.output_dim is None:
@@ -93,6 +112,15 @@ class GCPVQVAE(nn.Module):
 
         self.encoder_gcp = GCPNetEncoder(self.config.gcp)
         self._initialize_gcp_encoder()
+        self.latent_adapter: Optional[nn.Module]
+        if self.config.adapter.enabled:
+            self.latent_adapter = nn.Linear(
+                self.config.gcp.latent_dim,
+                self.config.adapter.output_dim or self.config.vq.dim,
+                bias=self.config.adapter.bias,
+            )
+        else:
+            self.latent_adapter = None
         self.encoder_transformer = GCPTokensTransformer(self.config.encoder)
         self.vq = VectorQuantizer(
             self.config.vq.num_codes,
@@ -184,6 +212,11 @@ class GCPVQVAE(nn.Module):
     def _reshape_batch(self, tensor: Tensor, batch: int, length: int) -> Tensor:
         return tensor.reshape(batch, length, *tensor.shape[1:])
 
+    def _project_embeddings(self, embeddings: Tensor) -> Tensor:
+        if self.latent_adapter is None:
+            return embeddings
+        return self.latent_adapter(embeddings)
+
     # ----------------------------------------------------------------- forward
     def forward(self, batch: Dict[str, Tensor]) -> Dict[str, Tensor]:
         device = self._device()
@@ -216,8 +249,9 @@ class GCPVQVAE(nn.Module):
             mask=flat_mask,
         )
         embeddings = gcp_out["embeddings"].reshape(batch_size, max_len, -1)
+        projected = self._project_embeddings(embeddings)
 
-        enc_hidden = self.encoder_transformer(embeddings, mask=mask)
+        enc_hidden = self.encoder_transformer(projected, mask=mask)
         quantized, indices, vq_losses = self.vq(enc_hidden, mask=mask)
 
         dec_hidden = self.decoder_transformer(quantized, mask=mask)
@@ -296,7 +330,8 @@ class GCPVQVAE(nn.Module):
             mask=mask,
         )
         embeddings = gcp_out["embeddings"].unsqueeze(0)
-        enc_hidden = self.encoder_transformer(embeddings, mask=mask.unsqueeze(0))
+        projected = self._project_embeddings(embeddings)
+        enc_hidden = self.encoder_transformer(projected, mask=mask.unsqueeze(0))
         quantized, indices, vq_losses = self.vq(enc_hidden, mask=mask.unsqueeze(0))
         return embeddings, enc_hidden, quantized, {"indices": indices, "vq": vq_losses}
 
@@ -484,6 +519,7 @@ __all__ = [
     "GCPVQVAE",
     "GCPVQVAEConfig",
     "VectorQuantizerConfig",
+    "LatentAdapterConfig",
     "RotationHeadConfig",
     "DataPipelineConfig",
 ]

--- a/src/gcpvqvae/system/config_validation.py
+++ b/src/gcpvqvae/system/config_validation.py
@@ -92,10 +92,35 @@ def _check_model_consistency(raw_model: Optional[Dict[str, Any]]) -> List[Valida
     decoder_model_dim = _get_nested(raw_model, "decoder", "model_dim")
     rotation_input = _get_nested(raw_model, "rotation", "input_dim")
     vq_dim = _get_nested(raw_model, "vq", "dim")
+    adapter_enabled = _get_nested(raw_model, "adapter", "enabled")
+    adapter_output = _get_nested(raw_model, "adapter", "output_dim")
 
     if latent_dim is not None:
         _ensure_positive(latent_dim, "model.gcp.latent_dim", issues)
-    if encoder_input is not None and latent_dim is not None and encoder_input != latent_dim:
+    if adapter_enabled:
+        if adapter_output is not None:
+            _ensure_positive(adapter_output, "model.adapter.output_dim", issues)
+        target_input = adapter_output if adapter_output is not None else vq_dim
+        if (
+            encoder_input is not None
+            and target_input is not None
+            and encoder_input != target_input
+        ):
+            issues.append(
+                ValidationIssue(
+                    "error",
+                    (
+                        "encoder.input_dim (%s) does not match latent adapter output (%s)"
+                        % (encoder_input, target_input)
+                    ),
+                    "model.encoder.input_dim",
+                )
+            )
+    elif (
+        encoder_input is not None
+        and latent_dim is not None
+        and encoder_input != latent_dim
+    ):
         issues.append(
             ValidationIssue(
                 "error",

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -13,6 +13,7 @@ from gcpvqvae.models.gcpvqvae import (
     DataPipelineConfig,
     GCPVQVAE,
     GCPVQVAEConfig,
+    LatentAdapterConfig,
     RotationHeadConfig,
     VectorQuantizerConfig,
 )
@@ -159,6 +160,64 @@ def test_encode_decode_roundtrip(tmp_path, suffix) -> None:
     record = decoded["records"]
     assert isinstance(record, BackboneRecord)
     assert record.coords.shape[0] == int(mask.sum().item())
+
+
+def test_latent_adapter_projects_embeddings(tmp_path) -> None:
+    structure_path = Path(tmp_path) / "adapter.cif"
+    _build_test_structure(structure_path)
+
+    dataset = BackboneDataset(structure_path, k=2, progress=False)
+    batch = collate_backbones([dataset[0]])
+
+    gcp_cfg = GCPNetConfig(
+        hidden_scalar_dim=128,
+        hidden_vector_dim=16,
+        edge_scalar_dim=32,
+        edge_scalar_input_dim=8,
+        edge_vector_dim=1,
+        latent_dim=256,
+        layers=3,
+    )
+    adapter_cfg = LatentAdapterConfig(enabled=True, output_dim=32, bias=True)
+    vq_cfg = VectorQuantizerConfig(num_codes=16, dim=24, beta=0.25, decay=0.9, kmeans_iters=1)
+    enc_cfg = TransformerConfig(
+        input_dim=gcp_cfg.latent_dim,
+        model_dim=48,
+        output_dim=vq_cfg.dim,
+        num_layers=2,
+        num_heads=4,
+        num_kv_heads=2,
+        dropout=0.0,
+    )
+    dec_cfg = TransformerConfig(
+        input_dim=vq_cfg.dim,
+        model_dim=48,
+        num_layers=2,
+        num_heads=4,
+        num_kv_heads=1,
+        dropout=0.0,
+    )
+    rot_cfg = RotationHeadConfig(input_dim=48, translation_scale=1.0)
+    data_cfg = DataPipelineConfig(length_cap=512, knn=2)
+    config = GCPVQVAEConfig(
+        gcp=gcp_cfg,
+        encoder=enc_cfg,
+        decoder=dec_cfg,
+        vq=vq_cfg,
+        rotation=rot_cfg,
+        data=data_cfg,
+        adapter=adapter_cfg,
+    )
+
+    model = GCPVQVAE(config)
+    assert model.latent_adapter is not None
+    assert model.latent_adapter.weight.shape[1] == gcp_cfg.latent_dim
+    assert model.latent_adapter.weight.shape[0] == adapter_cfg.output_dim
+    assert model.encoder_transformer.config.input_dim == adapter_cfg.output_dim
+
+    output = model(batch)
+    assert output["gcp_embeddings"].shape[-1] == gcp_cfg.latent_dim
+    assert output["encoder_hidden"].shape[-1] == vq_cfg.dim
 
 
 def test_gcpnet_pretrained_initialisation(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- propagate the base GCPNet hyperparameters to every shipped config and add a latent adapter plus edge-scalar projection settings for smaller VQVAE footprints
- extend GCPVQVAE with the optional adapter layer and update config validation and documentation for the new knobs
- add a regression test that exercises the adapter-projected embeddings path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dde324a6748323a22513731fcec13b