### PR TITLE
Add default configs for training CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Starter templates live alongside that document.
 ```bash
 # Train using a configuration file in the repository
 # (adjust the path to point at your desired template)
-gpcvq train src/gcpvqvae/configs/base.yaml
+gpcvq train
 ```
 
 To train from a preprocessed dataset, point `data.root` at the directory
@@ -75,7 +75,7 @@ containing `preprocessed_dataset.json`. This can be done directly in the YAML
 file or via a command-line override:
 
 ```bash
-gpcvq train src/gcpvqvae/configs/base.yaml data.root=path/to/preprocessed
+gpcvq train data.root=path/to/preprocessed
 ```
 
 Any parameter can be overridden directly from the CLI using Hydra's dotted
@@ -83,7 +83,7 @@ syntax.  Append `section.key=value` pairs after the config path to tweak
 experiments without editing files:
 
 ```bash
-gpcvq train src/gcpvqvae/configs/small.yaml \
+gpcvq train --config src/gcpvqvae/configs/small.yaml \
     train.stages[0].batch_size=8 \
     model.vq.num_codes=128
 ```
@@ -91,12 +91,12 @@ gpcvq train src/gcpvqvae/configs/small.yaml \
 You can inspect the supported options with `gpcvq train --help`:
 
 ```text
-Usage: gpcvq train [OPTIONS] CONFIG
+Usage: gpcvq train [OPTIONS] [OVERRIDE]...
 
-  Train a GCP-VQVAE model using the settings defined in CONFIG. The
-  configuration file should provide ``data``, ``model``, and ``train``
-  sections as described in :mod:`gcpvqvae.system.train`. Template files are
-  available under ``src/gcpvqvae/configs``.
+  Train a GCP-VQVAE model. By default the command loads the settings from the
+  packaged ``base.yaml`` configuration. Provide ``--config`` to use an
+  alternative file. Additional overrides can be supplied using Hydra's dotted
+  ``key=value`` syntax.
 ```
 
 ### Pretraining the GCPNet encoder
@@ -104,11 +104,11 @@ Usage: gpcvq train [OPTIONS] CONFIG
 When you want to initialise the full model from a pretrained encoder, use the
 `train-gpcnet` subcommand. The schema mirrors the main trainer but omits the VQ
 and Transformer components so that only the GCPNet and rigid reconstruction head
-are optimised:
+are optimised. It defaults to the packaged `gcpnet_pretrain.yaml` file, but you
+can point to an alternative with `--config`:
 
 ```bash
-gpcvq train-gpcnet src/gcpvqvae/configs/gcpnet_pretrain.yaml \
-    data.root=path/to/backbones
+gpcvq train-gpcnet data.root=path/to/backbones
 ```
 
 The resulting checkpoints expose a `gcp_state` entry that can be referenced from

--- a/src/gcpvqvae/cli.py
+++ b/src/gcpvqvae/cli.py
@@ -7,7 +7,11 @@ from typing import Optional, Tuple
 
 import click
 
-from gcpvqvae.system.configuration import compose_overrides
+from gcpvqvae.system.configuration import (
+    DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH,
+    DEFAULT_TRAIN_CONFIG_PATH,
+    compose_overrides,
+)
 
 try:  # Python 3.10+
     from importlib.metadata import PackageNotFoundError, version
@@ -120,28 +124,28 @@ def preprocess_dataset_command(
 
 @gpcvq.command(
     name="train",
-    short_help="Train a model from a YAML configuration file.",
+    short_help="Train a model using an optional YAML configuration file.",
     help=(
-        "Train a GCP-VQVAE model using the settings defined in CONFIG. "
-        "The configuration file should provide ``data``, ``model``, and ``train`` "
-        "sections as described in :mod:`gcpvqvae.system.train`.  Template files are "
-        "available under ``src/gcpvqvae/configs``.\n\n"
-        "Additional overrides can be supplied after CONFIG using Hydra's dotted "
-        "``key=value`` syntax."
+        "Train a GCP-VQVAE model. By default the command loads the settings from "
+        "the packaged ``base.yaml`` configuration.  Provide ``--config`` to use an "
+        "alternative file.  Additional overrides can be supplied using Hydra's "
+        "dotted ``key=value`` syntax."
     ),
 )
-@click.argument(
-    "config",
+@click.option(
+    "--config",
+    "config_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
-    metavar="CONFIG",
+    help="Path to a YAML configuration file (defaults to base.yaml).",
 )
 @click.argument("overrides", nargs=-1, metavar="[OVERRIDE]...", type=str)
-def train_command(config: Path, overrides: Tuple[str, ...]) -> None:
+def train_command(config_path: Optional[Path], overrides: Tuple[str, ...]) -> None:
     """Kick off model training with the provided configuration file."""
 
     from gcpvqvae.system.train import train as run_train
 
-    raw_config = compose_overrides(config, overrides)
+    config_source = config_path if config_path is not None else DEFAULT_TRAIN_CONFIG_PATH
+    raw_config = compose_overrides(config_source, overrides)
     run_train(raw_config)
 
 
@@ -149,23 +153,28 @@ def train_command(config: Path, overrides: Tuple[str, ...]) -> None:
     name="train-gpcnet",
     short_help="Pretrain the standalone GCPNet encoder.",
     help=(
-        "Run GCPNet pretraining using the configuration specified in CONFIG. "
-        "The configuration schema mirrors the full trainer but focuses on the "
-        "encoder and rigid reconstruction head."
+        "Run GCPNet pretraining.  The command defaults to the packaged "
+        "``gcpnet_pretrain.yaml`` configuration but accepts ``--config`` to specify "
+        "an alternative file.  Hydra-style overrides may be appended using "
+        "``key=value`` syntax."
     ),
 )
-@click.argument(
-    "config",
+@click.option(
+    "--config",
+    "config_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
-    metavar="CONFIG",
+    help="Path to a YAML configuration file (defaults to gcpnet_pretrain.yaml).",
 )
 @click.argument("overrides", nargs=-1, metavar="[OVERRIDE]...", type=str)
-def train_gpcnet_command(config: Path, overrides: Tuple[str, ...]) -> None:
+def train_gpcnet_command(config_path: Optional[Path], overrides: Tuple[str, ...]) -> None:
     """Launch GCPNet-only pretraining from the CLI."""
 
     from gcpvqvae.system.train_gcpnet import train as run_train_gcpnet
 
-    raw_config = compose_overrides(config, overrides)
+    config_source = (
+        config_path if config_path is not None else DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH
+    )
+    raw_config = compose_overrides(config_source, overrides)
     run_train_gcpnet(raw_config)
 
 

--- a/src/gcpvqvae/system/configuration.py
+++ b/src/gcpvqvae/system/configuration.py
@@ -24,6 +24,11 @@ import yaml
 from gcpvqvae.models.gcpvqvae import GCPVQVAEConfig
 
 
+_CONFIG_DIR = Path(__file__).resolve().parents[1] / "configs"
+DEFAULT_TRAIN_CONFIG_PATH = _CONFIG_DIR / "base.yaml"
+DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH = _CONFIG_DIR / "gcpnet_pretrain.yaml"
+
+
 def update_dataclass(instance: Any, updates: Dict[str, Any]) -> Any:
     """Recursively apply ``updates`` to a dataclass ``instance``."""
 
@@ -149,5 +154,11 @@ def compose_overrides(config_path: Path, overrides: Iterable[str]) -> Dict[str, 
     return cast(Dict[str, Any], container)
 
 
-__all__ = ["build_model_config", "compose_overrides", "update_dataclass"]
+__all__ = [
+    "build_model_config",
+    "compose_overrides",
+    "update_dataclass",
+    "DEFAULT_TRAIN_CONFIG_PATH",
+    "DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH",
+]
 

--- a/tests/test_configuration_overrides.py
+++ b/tests/test_configuration_overrides.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import yaml
 
-from gcpvqvae.system.configuration import compose_overrides
+from gcpvqvae.system.configuration import (
+    DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH,
+    DEFAULT_TRAIN_CONFIG_PATH,
+    compose_overrides,
+)
 
 
 def _write_config(path: Path, config: dict) -> Path:
@@ -28,3 +32,19 @@ def test_cli_overrides_update_logging_block(tmp_path):
 
     assert result["train"]["log"]["enabled"] is True
     assert result["train"]["log"]["project"] == "my-project"
+
+
+def test_default_train_config_matches_base_yaml():
+    raw = yaml.safe_load(DEFAULT_TRAIN_CONFIG_PATH.read_text(encoding="utf-8"))
+    result = compose_overrides(DEFAULT_TRAIN_CONFIG_PATH, ())
+
+    assert result == raw
+
+
+def test_default_gcpnet_config_matches_packaged_yaml():
+    raw = yaml.safe_load(
+        DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH.read_text(encoding="utf-8")
+    )
+    result = compose_overrides(DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH, ())
+
+    assert result == raw


### PR DESCRIPTION
## Summary
- make `gpcvq train` and `gpcvq train-gpcnet` default to the packaged configuration files while still allowing overrides via `--config`
- expose the default configuration paths for reuse and update the README to document the new CLI usage
- add regression tests to ensure the packaged defaults match the bundled YAML files

## Testing
- pytest tests/test_configuration_overrides.py

------
https://chatgpt.com/codex/tasks/task_b_68ddeaa0806c832395944ce23a6f5dd7