### PR TITLE
Fix default edge scalar projection for GCPNet

### DIFF
--- a/src/gcpvqvae/configs/gcpnet_pretrain.yaml
+++ b/src/gcpvqvae/configs/gcpnet_pretrain.yaml
@@ -13,6 +13,7 @@ model:
     hidden_scalar_dim: 128
     hidden_vector_dim: 16
     edge_scalar_dim: 32
+    edge_scalar_input_dim: 8
     edge_vector_dim: 1
     latent_dim: 256
     layers: 6

--- a/src/gcpvqvae/models/gcpnet.py
+++ b/src/gcpvqvae/models/gcpnet.py
@@ -11,6 +11,10 @@ from torch import Tensor, nn
 from .gcpcore import apply_gating, safe_norm, vector_linear
 
 
+# Default number of scalar edge features produced by the featurisation pipeline.
+DEFAULT_EDGE_SCALAR_INPUT_DIM = 8
+
+
 class VectorLayerNorm(nn.Module):
     """LayerNorm-style normalisation for vector features."""
 
@@ -203,7 +207,7 @@ class GCPNetConfig:
     node_scalar_dim: int = 6
     node_vector_dim: int = 3
     edge_scalar_dim: int = 8
-    edge_scalar_input_dim: Optional[int] = None
+    edge_scalar_input_dim: Optional[int] = DEFAULT_EDGE_SCALAR_INPUT_DIM
     edge_vector_dim: int = 1
     hidden_scalar_dim: int = 128
     hidden_vector_dim: int = 16
@@ -224,11 +228,10 @@ class GCPNetEncoder(nn.Module):
 
         self.config = config or GCPNetConfig()
 
-        self.edge_scalar_in_dim = (
-            self.config.edge_scalar_input_dim
-            if self.config.edge_scalar_input_dim is not None
-            else self.config.edge_scalar_dim
-        )
+        if self.config.edge_scalar_input_dim is None:
+            self.edge_scalar_in_dim = self.config.edge_scalar_dim
+        else:
+            self.edge_scalar_in_dim = self.config.edge_scalar_input_dim
 
         self.scalar_proj = nn.Linear(self.config.node_scalar_dim, self.config.hidden_scalar_dim, bias=False)
         self.vector_proj = nn.Parameter(
@@ -343,4 +346,10 @@ class GCPNetEncoder(nn.Module):
         return output
 
 
-__all__ = ["GCPNetEncoder", "GCPNetConfig", "GCPConv", "VectorLayerNorm"]
+__all__ = [
+    "GCPNetEncoder",
+    "GCPNetConfig",
+    "GCPConv",
+    "VectorLayerNorm",
+    "DEFAULT_EDGE_SCALAR_INPUT_DIM",
+]

--- a/tests/test_gcpnet.py
+++ b/tests/test_gcpnet.py
@@ -1,0 +1,42 @@
+import torch
+
+from gcpvqvae.models.gcpnet import (
+    DEFAULT_EDGE_SCALAR_INPUT_DIM,
+    GCPNetConfig,
+    GCPNetEncoder,
+)
+from gcpvqvae.system.train_gcpnet import _prepare_model_config
+
+
+def test_gcpnet_encoder_projects_edge_scalars_with_default_input_dim() -> None:
+    config = GCPNetConfig(edge_scalar_dim=32)
+    encoder = GCPNetEncoder(config)
+
+    assert encoder.edge_scalar_proj is not None
+    weight = encoder.edge_scalar_proj.weight
+    assert weight.shape[1] == DEFAULT_EDGE_SCALAR_INPUT_DIM
+
+    num_nodes = 4
+    node_scalars = torch.randn(num_nodes, config.node_scalar_dim)
+    node_vectors = torch.randn(num_nodes, config.node_vector_dim, 3)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]], dtype=torch.long)
+    edge_scalars = torch.randn(edge_index.shape[1], DEFAULT_EDGE_SCALAR_INPUT_DIM)
+    edge_vectors = torch.randn(edge_index.shape[1], config.edge_vector_dim, 3)
+    edge_frames = torch.randn(edge_index.shape[1], 3, 3)
+
+    output = encoder(
+        node_scalars,
+        node_vectors,
+        edge_index,
+        edge_scalars,
+        edge_vectors,
+        edge_frames,
+    )
+
+    assert output["embeddings"].shape == (num_nodes, config.latent_dim)
+
+
+def test_prepare_model_config_defaults_edge_scalar_input_dim() -> None:
+    config = _prepare_model_config({"gcp": {"edge_scalar_dim": 32}})
+
+    assert config.gcp.edge_scalar_input_dim == DEFAULT_EDGE_SCALAR_INPUT_DIM


### PR DESCRIPTION
## Summary
- add an explicit default for the edge scalar input dimension used by the featuriser and expose it from the model
- update the standalone GCPNet pretraining config to declare the correct edge scalar input dimension
- add regression tests covering the default projection path and configuration loading

## Testing
- pytest tests/test_gcpnet.py

------
https://chatgpt.com/codex/tasks/task_b_68ddf9e235bc8323876efa46bd123aa4