### PR TITLE
Fix GCPNet bfloat16 mixed-precision handling

### DIFF
--- a/src/gcpvqvae/models/gcpcore.py
+++ b/src/gcpvqvae/models/gcpcore.py
@@ -52,6 +52,14 @@ def vector_linear(vectors: Tensor, weight: Tensor) -> Tensor:
             f"got {vectors.size(-2)}"
         )
 
+    vector_dtype = vectors.dtype
+    weight_dtype = weight.dtype
+
+    if vector_dtype != weight_dtype:
+        vectors = vectors.to(weight_dtype)
+        result = torch.einsum("oi,...ic->...oc", weight, vectors)
+        return result.to(vector_dtype)
+
     return torch.einsum("oi,...ic->...oc", weight, vectors)
 
 

--- a/src/gcpvqvae/models/gcpnet.py
+++ b/src/gcpvqvae/models/gcpnet.py
@@ -134,6 +134,7 @@ class GCPConv(nn.Module):
         num_nodes = node_scalars.shape[0]
         dtype = node_scalars.dtype
         device = node_scalars.device
+        vector_dtype = node_vectors.dtype
 
         if src.numel() == 0:
             agg_vectors = torch.zeros(
@@ -144,25 +145,26 @@ class GCPConv(nn.Module):
             agg_edge = torch.zeros((num_nodes, self.edge_scalar_dim), dtype=dtype, device=device)
             counts = torch.ones((num_nodes, 1), dtype=dtype, device=device)
         else:
-            norm_scalars = self.scalar_norm(node_scalars)
-            norm_vectors = self.vector_norm(node_vectors)
+            norm_scalars = self.scalar_norm(node_scalars).to(dtype)
+            norm_vectors = self.vector_norm(node_vectors).to(vector_dtype)
 
             combined_vectors = _gather_edge_vectors(
                 norm_vectors, edge_index, edge_vectors, edge_vector_channels=self.edge_vector_channels
             )
 
-            down = vector_linear(combined_vectors, self.vec_down)
-            down_norm = safe_norm(down, dim=-1)
+            down = vector_linear(combined_vectors, self.vec_down).to(vector_dtype)
+            down_norm = safe_norm(down, dim=-1).to(dtype)
 
-            signature_vectors = vector_linear(combined_vectors, self.vec_signature)
+            signature_vectors = vector_linear(combined_vectors, self.vec_signature).to(edge_frames.dtype)
             orient = torch.einsum("eac,ebc->eab", signature_vectors, edge_frames).reshape(-1, 9)
+            orient = orient.to(dtype)
 
             counts = torch.zeros((num_nodes, 1), dtype=dtype, device=device)
             counts.index_add_(0, dst, torch.ones((dst.numel(), 1), dtype=dtype, device=device))
             counts = torch.clamp(counts, min=1.0)
 
             agg_vectors = torch.zeros(
-                (num_nodes, self.hidden_vector_channels, 3), dtype=node_vectors.dtype, device=device
+                (num_nodes, self.hidden_vector_channels, 3), dtype=vector_dtype, device=device
             )
             agg_vectors.index_add_(0, dst, down)
             agg_vectors = agg_vectors / counts.unsqueeze(-1)
@@ -180,7 +182,7 @@ class GCPConv(nn.Module):
                     agg_edge = torch.zeros((num_nodes, self.edge_scalar_dim), dtype=dtype, device=device)
                 else:
                     agg_edge = torch.zeros((num_nodes, self.edge_scalar_dim), dtype=dtype, device=device)
-                    agg_edge.index_add_(0, dst, edge_scalars)
+                    agg_edge.index_add_(0, dst, edge_scalars.to(dtype))
                     agg_edge = agg_edge / counts
             else:
                 agg_edge = torch.zeros((num_nodes, 0), dtype=dtype, device=device)
@@ -188,14 +190,18 @@ class GCPConv(nn.Module):
             norm_scalars = norm_scalars  # retained for residual below
 
         if src.numel() == 0:
-            norm_scalars = self.scalar_norm(node_scalars)
+            norm_scalars = self.scalar_norm(node_scalars).to(dtype)
 
         scalar_input = torch.cat((norm_scalars, agg_q, agg_norm, agg_edge), dim=-1)
-        scalar_update = self.scalar_mlp(scalar_input)
+
+        mlp_input_dtype = self.scalar_mlp[0].weight.dtype
+        gate_input_dtype = self.gate_mlp[0].weight.dtype
+
+        scalar_update = self.scalar_mlp(scalar_input.to(mlp_input_dtype)).to(dtype)
         scalars_out = node_scalars + self.dropout(scalar_update)
 
-        vector_update = vector_linear(agg_vectors, self.vec_up)
-        gate = torch.sigmoid(self.gate_mlp(scalar_input))
+        vector_update = vector_linear(agg_vectors, self.vec_up).to(vector_dtype)
+        gate = torch.sigmoid(self.gate_mlp(scalar_input.to(gate_input_dtype))).to(vector_dtype)
         gated = apply_gating(vector_update, gate)
         vectors_out = node_vectors + self.vector_dropout(gated)
 
@@ -297,8 +303,9 @@ class GCPNetEncoder(nn.Module):
         if node_vectors.ndim != 3:
             raise ValueError("node_vectors must have shape (N, C, 3)")
 
-        scalars = self.scalar_proj(node_scalars)
-        vectors = vector_linear(node_vectors, self.vector_proj)
+        scalar_proj_dtype = self.scalar_proj.weight.dtype
+        scalars = self.scalar_proj(node_scalars.to(scalar_proj_dtype)).to(node_scalars.dtype)
+        vectors = vector_linear(node_vectors, self.vector_proj).to(node_vectors.dtype)
 
         if mask is not None:
             mask = mask.to(torch.bool)
@@ -306,7 +313,8 @@ class GCPNetEncoder(nn.Module):
             vectors = vectors * mask.unsqueeze(-1).unsqueeze(-1)
 
         if self.edge_scalar_proj is not None and edge_scalars.numel():
-            edge_scalars_projected = self.edge_scalar_proj(edge_scalars)
+            proj_dtype = self.edge_scalar_proj.weight.dtype
+            edge_scalars_projected = self.edge_scalar_proj(edge_scalars.to(proj_dtype)).to(edge_scalars.dtype)
         elif self.edge_scalar_proj is not None:
             edge_scalars_projected = edge_scalars.new_zeros(
                 (edge_scalars.shape[0], self.config.edge_scalar_dim)
@@ -328,8 +336,9 @@ class GCPNetEncoder(nn.Module):
                 vectors = vectors * mask.unsqueeze(-1).unsqueeze(-1)
 
         vec_norms = safe_norm(vectors, dim=-1)
-        readout_input = torch.cat((scalars, vec_norms), dim=-1)
-        embeddings = self.readout(readout_input)
+        readout_input = torch.cat((scalars, vec_norms.to(scalars.dtype)), dim=-1)
+        readout_dtype = self.readout[1].weight.dtype
+        embeddings = self.readout(readout_input.to(readout_dtype)).to(scalars.dtype)
 
         output: Dict[str, Tensor] = {
             "embeddings": embeddings,
@@ -338,7 +347,8 @@ class GCPNetEncoder(nn.Module):
         }
 
         if self.displacement_head is not None:
-            displacement = self.displacement_head(scalars)
+            disp_input_dtype = self.displacement_head[1].weight.dtype
+            displacement = self.displacement_head(scalars.to(disp_input_dtype)).to(scalars.dtype)
             if mask is not None:
                 displacement = displacement * mask.unsqueeze(-1)
             output["displacement"] = displacement

--- a/tests/test_gcpnet.py
+++ b/tests/test_gcpnet.py
@@ -40,3 +40,54 @@ def test_prepare_model_config_defaults_edge_scalar_input_dim() -> None:
     config = _prepare_model_config({"gcp": {"edge_scalar_dim": 32}})
 
     assert config.gcp.edge_scalar_input_dim == DEFAULT_EDGE_SCALAR_INPUT_DIM
+
+
+def test_gcpconv_supports_bfloat16_inputs() -> None:
+    conv = GCPNetEncoder().layers[0]
+
+    node_scalars = torch.randn(6, conv.scalar_dim, dtype=torch.bfloat16)
+    node_vectors = torch.randn(6, conv.vector_dim, 3, dtype=torch.bfloat16)
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=torch.long)
+    edge_scalars = torch.randn(edge_index.shape[1], conv.edge_scalar_dim, dtype=torch.bfloat16)
+    edge_vectors = torch.randn(edge_index.shape[1], conv.edge_vector_channels, 3, dtype=torch.bfloat16)
+    edge_frames = torch.randn(edge_index.shape[1], 3, 3, dtype=torch.bfloat16)
+
+    scalars_out, vectors_out = conv(
+        node_scalars,
+        node_vectors,
+        edge_index,
+        edge_scalars,
+        edge_vectors,
+        edge_frames,
+    )
+
+    assert scalars_out.dtype is torch.bfloat16
+    assert vectors_out.dtype is torch.bfloat16
+
+
+def test_gcpnet_encoder_supports_bfloat16_inputs() -> None:
+    config = GCPNetConfig(layers=2, hidden_scalar_dim=16, hidden_vector_dim=8, latent_dim=32)
+    encoder = GCPNetEncoder(config)
+
+    num_nodes = 5
+    num_edges = 4
+
+    node_scalars = torch.randn(num_nodes, config.node_scalar_dim, dtype=torch.bfloat16)
+    node_vectors = torch.randn(num_nodes, config.node_vector_dim, 3, dtype=torch.bfloat16)
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=torch.long)
+    edge_scalars = torch.randn(num_edges, config.edge_scalar_dim, dtype=torch.bfloat16)
+    edge_vectors = torch.randn(num_edges, config.edge_vector_dim, 3, dtype=torch.bfloat16)
+    edge_frames = torch.randn(num_edges, 3, 3, dtype=torch.bfloat16)
+
+    outputs = encoder(
+        node_scalars,
+        node_vectors,
+        edge_index,
+        edge_scalars,
+        edge_vectors,
+        edge_frames,
+    )
+
+    assert outputs["embeddings"].dtype is torch.bfloat16
+    assert outputs["node_scalars"].dtype is torch.bfloat16
+    assert outputs["node_vectors"].dtype is torch.bfloat16


### PR DESCRIPTION
## Summary
- normalize dtypes inside `vector_linear` and GCPConv to avoid mixed-precision index_add errors
- update GCPNetEncoder to cast tensors to the appropriate precision when calling linear layers
- add regression tests that exercise bfloat16 execution paths for the convolution and encoder

## Testing
- PYTHONPATH=src pytest tests/test_gcpnet.py

------
https://chatgpt.com/codex/tasks/task_b_68ddffed6e50832397af7f7b632cca49