### PR TITLE
Fix Kabsch alignment under low precision dtypes

### DIFF
--- a/src/gcpvqvae/geometry/frames.py
+++ b/src/gcpvqvae/geometry/frames.py
@@ -204,7 +204,11 @@ def kabsch_align(
 
     cov = src_centered.transpose(0, 1) @ dst_centered
 
-    u, _, vh = torch.linalg.svd(cov, full_matrices=False)
+    svd_input = cov
+    if cov.dtype in (torch.float16, torch.bfloat16):
+        svd_input = cov.to(torch.float32)
+
+    u, _, vh = torch.linalg.svd(svd_input, full_matrices=False)
     rotation = u @ vh
 
     if not allow_reflections:
@@ -213,6 +217,9 @@ def kabsch_align(
             vh = vh.clone()
             vh[-1, :] *= -1
             rotation = u @ vh
+
+    if rotation.dtype != src_sel.dtype:
+        rotation = rotation.to(src_sel.dtype)
 
     translation = dst_mean - src_mean @ rotation
 

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -193,3 +193,25 @@ def test_kabsch_align_float32_accuracy() -> None:
     assert torch.allclose(R, rotation, atol=1e-5)
     assert torch.allclose(t, translation, atol=1e-5)
     assert aligned is not None and torch.allclose(aligned, transformed, atol=1e-5)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_kabsch_align_low_precision_dtypes(dtype: torch.dtype) -> None:
+    _set_seed()
+    device = torch.device("cpu")
+    points = torch.randn(12, 3, device=device, dtype=dtype)
+    rotation = _random_rotation(device, torch.float32).to(dtype)
+    translation = torch.tensor([0.25, -0.4, 0.9], device=device, dtype=dtype)
+
+    transformed = (points @ rotation) + translation
+    R, t, aligned = kabsch_align(points, transformed, return_aligned=True)
+
+    assert R.dtype == dtype
+    assert t.dtype == dtype
+    assert aligned is not None and aligned.dtype == dtype
+
+    expected_rotation = rotation.to(torch.float32)
+    expected_translation = translation.to(torch.float32)
+    assert torch.allclose(R.to(torch.float32), expected_rotation, atol=5e-2, rtol=5e-2)
+    assert torch.allclose(t.to(torch.float32), expected_translation, atol=5e-2, rtol=5e-2)
+    assert torch.allclose(aligned.to(torch.float32), transformed.to(torch.float32), atol=5e-2, rtol=5e-2)


### PR DESCRIPTION
## Summary
- promote low precision covariance matrices to float32 before the SVD in `kabsch_align`
- ensure the computed rotation is cast back to the original dtype for downstream computations
- add a regression test covering bfloat16 tensors during Kabsch alignment

## Testing
- pytest tests/test_frames.py

------
https://chatgpt.com/codex/tasks/task_b_68de03905b188323a833dca619b45472