### PR TITLE
Support step-based training duration

### DIFF
--- a/configs/config_vqvae.yaml
+++ b/configs/config_vqvae.yaml
@@ -70,6 +70,7 @@ model:  # Settings controlling model construction
 train_settings:  # Parameters that control the training loop
   data_path: ../../datasets/vqvae/uniref_50/  # Directory containing HDF5 training data
   num_epochs: 32  # Total number of epochs to train for
+  num_steps: null  # Optional total number of optimizer steps to run; overrides num_epochs when provided
   sample_weighting:  # Curriculum weighting on samples by sequence length
     enabled: True  # Turn dynamic sample weighting on or off
     min_weight: 1.0  # Minimum weight assigned to any training example

--- a/train.py
+++ b/train.py
@@ -116,6 +116,7 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
     logging = kwargs.pop('logging')
     profiler = kwargs.pop('profiler')
     profile_train_loop = kwargs.pop('profile_train_loop')
+    max_steps = kwargs.pop('max_steps', None)
     codebook_size = configs.model.vqvae.vector_quantization.codebook_size
     accum_iter = configs.train_settings.grad_accumulation
     alignment_strategy = configs.train_settings.losses.alignment_strategy
@@ -135,6 +136,7 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
     progress_bar.set_description(f"Epoch {epoch}")
 
     net.train()
+    reached_max_steps = False
     for i, data in enumerate(train_loader):
         with accelerator.accumulate(net):
             if profile_train_loop:
@@ -211,6 +213,10 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
                 progress_bar.update(1)
                 global_step += 1
 
+                if max_steps is not None and global_step >= max_steps:
+                    reached_max_steps = True
+                    break
+
                 if (
                     accelerator.is_main_process
                     and train_save_mode == 'steps'
@@ -255,6 +261,9 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
                 progress_postfix(optimizer, loss_dict, global_step)
             )
 
+        if reached_max_steps:
+            break
+
     # Compute average losses and metrics
     avgs = average_losses(acc)
     metrics_values = compute_metrics(metrics)
@@ -289,7 +298,8 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
         "activation": np.round(avg_activation * 100, 1),
         "counter": acc['counter'],
         "global_step": global_step,
-        "adaptive_loss_coeffs": adaptive_loss_coeffs
+        "adaptive_loss_coeffs": adaptive_loss_coeffs,
+        "reached_max_steps": reached_max_steps,
     }
     return return_dict
 
@@ -520,6 +530,19 @@ def main(dict_config, config_file_path):
         train_steps = np.ceil(len(train_dataloader) / configs.train_settings.grad_accumulation)
         logging.info(f'number of train steps per epoch: {int(train_steps)}')
 
+    max_steps = getattr(configs.train_settings, 'num_steps', None)
+    if max_steps is not None:
+        max_steps = int(max_steps)
+        if max_steps <= 0:
+            raise ValueError('train_settings.num_steps must be a positive integer when provided.')
+        if accelerator.is_main_process:
+            logging.info(
+                'Training duration configured for %s optimizer steps; this overrides num_epochs.',
+                f'{max_steps:,}'
+            )
+
+    total_epochs = int(getattr(configs.train_settings, 'num_epochs', 0))
+
     # Maybe monitor resource usage during training.
     prof = None
     profile_train_loop = configs.train_settings.profile_train_loop
@@ -552,7 +575,11 @@ def main(dict_config, config_file_path):
 
     best_valid_metrics = {'gdtts': 0.0, 'mae': 1000.0, 'rmsd': 1000.0, 'lddt': 0.0, 'loss': 1000.0, 'tm_score': 0.0,
                           'perplexity': 1000.0}
-    for epoch in range(1, configs.train_settings.num_epochs + 1):
+    epoch = 0
+    while True:
+        if max_steps is None and epoch >= total_epochs:
+            break
+        epoch += 1
         start_time = time.time()
         training_loop_reports = train_loop(net, train_dataloader, epoch, adaptive_loss_coeffs,
                                            accelerator=accelerator,
@@ -560,7 +587,8 @@ def main(dict_config, config_file_path):
                                            scheduler=scheduler, configs=configs,
                                            logging=logging, global_step=global_step,
                                            writer=train_writer, result_path=result_path,
-                                           profiler=prof, profile_train_loop=profile_train_loop)
+                                           profiler=prof, profile_train_loop=profile_train_loop,
+                                           max_steps=max_steps)
 
         if profile_train_loop:
             prof.stop()
@@ -587,6 +615,7 @@ def main(dict_config, config_file_path):
                 f'activation {training_loop_reports["activation"]:.1f}')
 
         global_step = training_loop_reports["global_step"]
+        reached_max_steps = training_loop_reports.get("reached_max_steps", False)
         # Update adaptive coefficients from training loop
         adaptive_loss_coeffs = training_loop_reports.get("adaptive_loss_coeffs", adaptive_loss_coeffs)
         accelerator.wait_for_everyone()
@@ -664,6 +693,14 @@ def main(dict_config, config_file_path):
                                 configs=configs)
                 logging.info(f'\tsaving the best models in {model_path}')
                 logging.info(f'\tbest valid rmsd: {best_valid_metrics["rmsd"]:.4f}')
+
+        if max_steps is not None and reached_max_steps:
+            if accelerator.is_main_process:
+                logging.info(
+                    'Reached the configured maximum number of training steps (%s); ending training loop.',
+                    f'{max_steps:,}'
+                )
+            break
 
     logging.info("Training is completed!\n")
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -297,10 +297,22 @@ def prepare_tensorboard(result_path):
 def prepare_optimizer(net, configs, num_train_samples, logging):
     optimizer, scheduler = load_opt(net, configs, logging)
     if scheduler is None:
-        whole_steps = np.ceil(
+        steps_per_epoch = np.ceil(
             num_train_samples / configs.train_settings.grad_accumulation
-        ) * configs.train_settings.num_epochs / configs.optimizer.decay.num_restarts
-        first_cycle_steps = np.ceil(whole_steps / configs.optimizer.decay.num_restarts)
+        )
+        configured_num_steps = getattr(configs.train_settings, 'num_steps', None)
+        if configured_num_steps is not None:
+            total_training_steps = int(configured_num_steps)
+        else:
+            total_training_steps = int(np.ceil(steps_per_epoch * configs.train_settings.num_epochs))
+
+        if total_training_steps <= 0:
+            raise ValueError('Total number of training steps must be positive to build the scheduler.')
+
+        num_restarts = max(1, configs.optimizer.decay.num_restarts)
+        whole_steps = total_training_steps / num_restarts
+        first_cycle_steps = int(np.ceil(whole_steps / num_restarts))
+        first_cycle_steps = max(1, first_cycle_steps)
         scheduler = CosineAnnealingWarmupRestarts(
             optimizer,
             first_cycle_steps=first_cycle_steps,


### PR DESCRIPTION
## Summary
- allow the training loop to respect an optional `num_steps` limit that overrides epoch-based scheduling
- adjust optimizer scheduler setup to compute durations from either epochs or steps
- document the new `train_settings.num_steps` option in the default configuration

## Testing
- python -m compileall train.py utils/utils.py

------
https://chatgpt.com/codex/tasks/task_b_68defe08548883239e946a81d926618b