### PR TITLE
Add configurable wandb logging support

### DIFF
--- a/configs/config_vqvae.yaml
+++ b/configs/config_vqvae.yaml
@@ -2,9 +2,27 @@ fix_seed: 0  # Integer seed applied to NumPy and PyTorch for reproducible traini
 checkpoints_every:
   steps: null  # Interval in optimizer steps for writing checkpoints (overrides epochs when set)
   epochs: 256  # Interval in epochs at which checkpoints are written to disk
-log_every:
-  steps: null  # Interval in optimizer steps for aggregated training logs (overrides epochs when set)
-  epochs: 1  # Interval in epochs for aggregated training logs when step interval is not provided
+log:
+  interval:
+    steps: null  # Interval in optimizer steps for aggregated logs (overrides epochs when set)
+    epochs: 1  # Interval in epochs for aggregated logs when step interval is not provided
+  wandb:
+    enabled: False  # Enable logging scalars to Weights & Biases when True
+    project: null  # WandB project name
+    run_name: null  # Optional display name for the run
+    entity: null  # WandB entity/organization
+    group: null  # Logical experiment group for the run
+    job_type: null  # Job type label reported to WandB
+    tags: []  # List of tags attached to the run for filtering
+    notes: null  # Free-form notes stored with the run
+    dir: null  # Directory used by WandB to store run artifacts (defaults to result_path when null)
+    mode: online  # WandB init mode (online, offline, disabled)
+    resume: null  # Resume behavior passed to wandb.init (e.g., allow, must, never)
+    id: null  # Explicit run ID used when resuming
+    config: {}  # Extra key/value pairs forwarded to wandb.init(config=...)
+    watch:
+      log: null  # Optional wandb.watch log mode (e.g., gradients)
+      log_freq: null  # Logging frequency for wandb.watch when enabled
 tensorboard_log: True  # Enable TensorBoard logging on the main process
 tqdm_progress_bar: False  # Show per-iteration tqdm progress bars when running locally
 result_path: ./results/test  # Root directory used to store training outputs and logs

--- a/train.py
+++ b/train.py
@@ -5,6 +5,7 @@ import os
 import torch
 from collections.abc import Mapping
 from numbers import Number
+from typing import Any, Dict, Optional
 from utils.custom_losses import calculate_decoder_loss, log_per_loss_grad_norms
 from utils.utils import (
     save_backbone_pdb,
@@ -39,6 +40,101 @@ from utils.training_helpers import (
     progress_postfix,
     log_tensorboard_epoch,
 )
+
+
+def _init_wandb_run(configs, raw_config: Dict[str, Any], result_path: Optional[str], *, logging):
+    log_config = getattr(configs, 'log', None)
+    wandb_config = getattr(log_config, 'wandb', None) if log_config is not None else None
+    if not wandb_config or not getattr(wandb_config, 'enabled', False):
+        return None, None
+
+    project = getattr(wandb_config, 'project', None)
+    if project is None:
+        logging.warning('WandB logging enabled but no project specified; falling back to default project name.')
+
+    import wandb  # Imported lazily to avoid dependency when logging is disabled
+
+    init_kwargs: Dict[str, Any] = {}
+    if project is not None:
+        init_kwargs['project'] = project
+
+    name = getattr(wandb_config, 'run_name', None)
+    if name is not None:
+        init_kwargs['name'] = name
+
+    entity = getattr(wandb_config, 'entity', None)
+    if entity is not None:
+        init_kwargs['entity'] = entity
+
+    group = getattr(wandb_config, 'group', None)
+    if group is not None:
+        init_kwargs['group'] = group
+
+    job_type = getattr(wandb_config, 'job_type', None)
+    if job_type is not None:
+        init_kwargs['job_type'] = job_type
+
+    notes = getattr(wandb_config, 'notes', None)
+    if notes is not None:
+        init_kwargs['notes'] = notes
+
+    tags = getattr(wandb_config, 'tags', None)
+    if tags:
+        init_kwargs['tags'] = list(tags)
+
+    run_id = getattr(wandb_config, 'id', None)
+    if run_id is not None:
+        init_kwargs['id'] = run_id
+
+    resume = getattr(wandb_config, 'resume', None)
+    if resume is not None:
+        init_kwargs['resume'] = resume
+
+    mode = getattr(wandb_config, 'mode', None)
+    if mode is not None:
+        init_kwargs['mode'] = mode
+
+    wandb_dir = getattr(wandb_config, 'dir', None)
+    if wandb_dir is None and result_path is not None:
+        init_kwargs['dir'] = result_path
+    elif wandb_dir is not None:
+        init_kwargs['dir'] = wandb_dir
+
+    extra_config = getattr(wandb_config, 'config', None)
+    config_payload: Dict[str, Any] = {}
+    if isinstance(extra_config, Mapping):
+        config_payload.update(dict(extra_config))
+    config_payload.setdefault('config_file', getattr(configs, 'config_path', None))
+    config_payload.update(raw_config)
+
+    init_kwargs['config'] = config_payload
+
+    run = wandb.init(**init_kwargs)
+    return run, wandb_config
+
+
+def _format_loss_name(name: str) -> str:
+    return name[:-5] if name.endswith('_loss') else name
+
+
+def _log_step_losses_to_wandb(loss_dict: Dict[str, torch.Tensor], phase: str, *, step: int, wandb_run) -> None:
+    if wandb_run is None:
+        return
+
+    log_payload: Dict[str, float] = {}
+    for key, value in loss_dict.items():
+        if not torch.is_tensor(value) or value.numel() != 1:
+            continue
+        scalar = float(value.detach().item())
+        if key.startswith('unscaled_'):
+            base = _format_loss_name(key[len('unscaled_'):])
+            log_payload[f'{phase}/unscaled_step_loss/{base}'] = scalar
+        elif key.endswith('_loss'):
+            base = _format_loss_name(key)
+            log_payload[f'{phase}/step_loss/{base}'] = scalar
+
+    if log_payload:
+        wandb_run.log(log_payload, step=step)
 
 
 def _extract_interval_value(interval_config, key):
@@ -116,6 +212,7 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
     logging = kwargs.pop('logging')
     profiler = kwargs.pop('profiler')
     profile_train_loop = kwargs.pop('profile_train_loop')
+    wandb_run = kwargs.pop('wandb_run', None)
     max_steps = kwargs.pop('max_steps', None)
     codebook_size = configs.model.vqvae.vector_quantization.codebook_size
     accum_iter = configs.train_settings.grad_accumulation
@@ -169,7 +266,7 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
             # Log per-loss gradient norms and adjust adaptive coefficients
             adaptive_loss_coeffs = log_per_loss_grad_norms(
                 loss_dict, net, configs, writer, accelerator,
-                global_step, adaptive_loss_coeffs
+                global_step, adaptive_loss_coeffs, wandb_run=wandb_run
             )
 
 
@@ -201,8 +298,11 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
                     grad_norm = torch.norm(
                         torch.stack([torch.norm(p.grad.detach(), 2) for p in net.parameters() if p.grad is not None and p.requires_grad]),
                         2)
-                    if accelerator.is_main_process and configs.tensorboard_log:
-                        writer.add_scalar('gradient norm/total_amp_scaled', grad_norm.item(), global_step)
+                    if accelerator.is_main_process:
+                        if configs.tensorboard_log:
+                            writer.add_scalar('gradient norm/total_amp_scaled', grad_norm.item(), global_step)
+                        if wandb_run is not None:
+                            wandb_run.log({'train/gradient_norm/total_amp_scaled': grad_norm.item()}, step=global_step)
 
                 # Accelerate Gradient clipping: unscale the gradients (only when using FP16 AMP) and then apply clipping
                 accelerator.clip_grad_norm_(net.parameters(), configs.optimizer.grad_clip_norm)
@@ -216,6 +316,10 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
                 if max_steps is not None and global_step >= max_steps:
                     reached_max_steps = True
                     break
+
+                if accelerator.is_main_process and wandb_run is not None:
+                    _log_step_losses_to_wandb(loss_dict, 'train', step=global_step, wandb_run=wandb_run)
+                    wandb_run.log({'train/lr': optimizer.param_groups[0]['lr']}, step=global_step)
 
                 if (
                     accelerator.is_main_process
@@ -282,6 +386,32 @@ def train_loop(net, train_loader, epoch, adaptive_loss_coeffs, **kwargs):
             include_ntp=include_ntp,
         )
 
+    if accelerator.is_main_process and wandb_run is not None:
+        payload: Dict[str, float] = {
+            'train/loss/total': avgs['avg_step_loss'],
+            'train/loss/rec': avgs['avg_rec_loss'],
+            'train/loss/vq': avgs['avg_vq_loss'],
+            'train/metric/mae': metrics_values['mae'],
+            'train/metric/rmsd': metrics_values['rmsd'],
+            'train/metric/gdtts': metrics_values['gdtts'],
+            'train/metric/tm_score': metrics_values['tm_score'],
+            'train/metric/activation_percent': np.round(avg_activation * 100, 1),
+        }
+        if 'avg_ntp_loss' in avgs:
+            payload['train/loss/ntp'] = avgs['avg_ntp_loss']
+        if 'avg_unscaled_step_loss' in avgs:
+            payload['train/unscaled_loss/total'] = avgs['avg_unscaled_step_loss']
+        if 'avg_unscaled_rec_loss' in avgs:
+            payload['train/unscaled_loss/rec'] = avgs['avg_unscaled_rec_loss']
+        if 'avg_unscaled_vq_loss' in avgs:
+            payload['train/unscaled_loss/vq'] = avgs['avg_unscaled_vq_loss']
+        if 'avg_unscaled_ntp_loss' in avgs:
+            payload['train/unscaled_loss/ntp'] = avgs['avg_unscaled_ntp_loss']
+        perplexity = metrics_values.get('perplexity', float('nan'))
+        if perplexity == perplexity:
+            payload['train/metric/perplexity'] = perplexity
+        wandb_run.log(payload, step=global_step)
+
     # Reset the metrics for the next epoch
     reset_metrics(metrics)
 
@@ -313,6 +443,8 @@ def valid_loop(net, valid_loader, epoch, **kwargs):
     codebook_size = configs.model.vqvae.vector_quantization.codebook_size
     alignment_strategy = configs.train_settings.losses.alignment_strategy
     valid_save_mode, valid_save_value = parse_interval(configs.valid_settings.save_pdb_every)
+    wandb_run = kwargs.pop('wandb_run', None)
+    global_step = kwargs.get('global_step', None)
 
     # Initialize metrics and accumulators for validation
     metrics = init_metrics(configs, accelerator)
@@ -420,6 +552,32 @@ def valid_loop(net, valid_loader, epoch, **kwargs):
             include_ntp=include_ntp,
         )
 
+    if accelerator.is_main_process and wandb_run is not None:
+        payload: Dict[str, float] = {
+            'eval/loss/total': avgs['avg_step_loss'],
+            'eval/loss/rec': avgs['avg_rec_loss'],
+            'eval/loss/vq': avgs['avg_vq_loss'],
+            'eval/metric/mae': metrics_values['mae'],
+            'eval/metric/rmsd': metrics_values['rmsd'],
+            'eval/metric/gdtts': metrics_values['gdtts'],
+            'eval/metric/tm_score': metrics_values['tm_score'],
+            'eval/metric/activation_percent': np.round(avg_activation * 100, 1),
+        }
+        if 'avg_ntp_loss' in avgs:
+            payload['eval/loss/ntp'] = avgs['avg_ntp_loss']
+        if 'avg_unscaled_step_loss' in avgs:
+            payload['eval/unscaled_loss/total'] = avgs['avg_unscaled_step_loss']
+        if 'avg_unscaled_rec_loss' in avgs:
+            payload['eval/unscaled_loss/rec'] = avgs['avg_unscaled_rec_loss']
+        if 'avg_unscaled_vq_loss' in avgs:
+            payload['eval/unscaled_loss/vq'] = avgs['avg_unscaled_vq_loss']
+        if 'avg_unscaled_ntp_loss' in avgs:
+            payload['eval/unscaled_loss/ntp'] = avgs['avg_unscaled_ntp_loss']
+        perplexity = metrics_values.get('perplexity', float('nan'))
+        if perplexity == perplexity:
+            payload['eval/metric/perplexity'] = perplexity
+        wandb_run.log(payload, step=global_step if global_step is not None else epoch)
+
     # Reset metrics for the next epoch
     reset_metrics(metrics)
 
@@ -447,7 +605,8 @@ def main(dict_config, config_file_path):
         np.random.seed(configs.fix_seed)
 
     checkpoint_interval = getattr(configs, 'checkpoints_every', None)
-    log_interval = getattr(configs, 'log_every', None)
+    log_config = getattr(configs, 'log', None)
+    log_interval = getattr(log_config, 'interval', None) if log_config is not None else getattr(configs, 'log_every', None)
     _, log_value = parse_interval(log_interval)
     eval_interval = configs.valid_settings.do_every
 
@@ -490,6 +649,12 @@ def main(dict_config, config_file_path):
 
     logging = get_logging(result_path, configs)
 
+    wandb_run = None
+    wandb_settings = getattr(log_config, 'wandb', None) if log_config is not None else None
+    if accelerator.is_main_process:
+        wandb_run, wandb_settings = _init_wandb_run(configs, dict_config, result_path, logging=logging)
+    accelerator.wait_for_everyone()
+
     train_dataloader, valid_dataloader = prepare_gcpnet_vqvae_dataloaders(
         logging, accelerator, configs, encoder_configs=encoder_configs, decoder_configs=decoder_configs
     )
@@ -517,6 +682,18 @@ def main(dict_config, config_file_path):
     net, optimizer, train_dataloader, valid_dataloader, scheduler = accelerator.prepare(
         net, optimizer, train_dataloader, valid_dataloader, scheduler
     )
+
+    if accelerator.is_main_process and wandb_run is not None and wandb_settings is not None:
+        watch_config = getattr(wandb_settings, 'watch', None)
+        if watch_config is not None:
+            watch_log = getattr(watch_config, 'log', None)
+            if watch_log:
+                watch_kwargs: Dict[str, Any] = {'log': watch_log}
+                log_freq = getattr(watch_config, 'log_freq', None)
+                if log_freq is not None:
+                    watch_kwargs['log_freq'] = int(log_freq)
+                import wandb
+                wandb.watch(accelerator.unwrap_model(net), **watch_kwargs)
 
     net.to(accelerator.device)
 
@@ -588,7 +765,8 @@ def main(dict_config, config_file_path):
                                            logging=logging, global_step=global_step,
                                            writer=train_writer, result_path=result_path,
                                            profiler=prof, profile_train_loop=profile_train_loop,
-                                           max_steps=max_steps)
+                                           max_steps=max_steps,
+                                           wandb_run=wandb_run if accelerator.is_main_process else None)
 
         if profile_train_loop:
             prof.stop()
@@ -613,6 +791,16 @@ def main(dict_config, config_file_path):
                 f'perplexity {training_loop_reports.get("perplexity", float("nan")):.2f}, '
                 f'vq loss {training_loop_reports["vq_loss"]:.4f}, '
                 f'activation {training_loop_reports["activation"]:.1f}')
+
+        if accelerator.is_main_process and wandb_run is not None:
+            wandb_run.log(
+                {
+                    'train/time/epoch_seconds': training_time,
+                    'train/steps_per_epoch': training_loop_reports['counter'],
+                    'train/epoch': epoch,
+                },
+                step=training_loop_reports['global_step'],
+            )
 
         global_step = training_loop_reports["global_step"]
         reached_max_steps = training_loop_reports.get("reached_max_steps", False)
@@ -648,7 +836,8 @@ def main(dict_config, config_file_path):
                                             optimizer=optimizer,
                                             scheduler=scheduler, configs=configs,
                                             logging=logging, global_step=global_step,
-                                            writer=valid_writer, result_path=result_path)
+                                            writer=valid_writer, result_path=result_path,
+                                            wandb_run=wandb_run if accelerator.is_main_process else None)
             end_time = time.time()
             valid_time = end_time - start_time
             accelerator.wait_for_everyone()
@@ -669,6 +858,15 @@ def main(dict_config, config_file_path):
                     f'vq loss {valid_loop_reports["vq_loss"]:.4f}, '
                     f'activation {valid_loop_reports["activation"]:.1f}'
                     # f'lddt {valid_loop_reports["lddt"]:.4f}'
+                )
+
+            if accelerator.is_main_process and wandb_run is not None:
+                wandb_run.log(
+                    {
+                        'eval/time/epoch_seconds': valid_time,
+                        'eval/epoch': epoch,
+                    },
+                    step=global_step,
                 )
 
             # Check valid metric to save the best model
@@ -715,6 +913,8 @@ def main(dict_config, config_file_path):
     if accelerator.is_main_process:
         train_writer.close()
         valid_writer.close()
+        if wandb_run is not None:
+            wandb_run.finish()
 
     accelerator.wait_for_everyone()
     accelerator.free_memory()

--- a/utils/custom_losses.py
+++ b/utils/custom_losses.py
@@ -177,7 +177,7 @@ def adjust_adaptive_coefficients(adaptive_loss_coeffs, global_grad_norms, config
     return adaptive_loss_coeffs
 
 
-def log_per_loss_components(writer, loss_dict, global_step):
+def log_per_loss_components(writer, loss_dict, global_step, phase: str = 'train', wandb_run=None):
     """
     Log individual loss components to TensorBoard with hierarchical naming.
 
@@ -187,16 +187,29 @@ def log_per_loss_components(writer, loss_dict, global_step):
         global_step (int): Current global training step.
     """
     # Log each loss component with hierarchical naming
+    wandb_payload = {}
     for loss_name, loss_value in loss_dict.items():
         if torch.is_tensor(loss_value) and loss_value.numel() == 1:
+            scalar = loss_value.item()
             if loss_name.startswith('unscaled_'):
                 base_name = loss_name[len('unscaled_'):]
-                writer.add_scalar(f'unscaled_step_loss/{base_name}', loss_value.item(), global_step)
+                if writer is not None:
+                    writer.add_scalar(f'unscaled_step_loss/{base_name}', scalar, global_step)
+                if wandb_run is not None:
+                    suffix = base_name[:-5] if base_name.endswith('_loss') else base_name
+                    wandb_payload[f'{phase}/unscaled_step_loss/{suffix}'] = float(scalar)
             else:
-                writer.add_scalar(f'step_loss/{loss_name}', loss_value.item(), global_step)
+                if writer is not None:
+                    writer.add_scalar(f'step_loss/{loss_name}', scalar, global_step)
+                if wandb_run is not None:
+                    suffix = loss_name[:-5] if loss_name.endswith('_loss') else loss_name
+                    wandb_payload[f'{phase}/step_loss/{suffix}'] = float(scalar)
+
+    if wandb_run is not None and wandb_payload:
+        wandb_run.log(wandb_payload, step=global_step)
 
 
-def log_gradient_norms_and_coeffs(writer, global_grad_norms, adaptive_loss_coeffs, global_step):
+def log_gradient_norms_and_coeffs(writer, global_grad_norms, adaptive_loss_coeffs, global_step, phase: str = 'train', wandb_run=None):
     """
     Log gradient norms and adaptive coefficients to TensorBoard.
 
@@ -207,19 +220,30 @@ def log_gradient_norms_and_coeffs(writer, global_grad_norms, adaptive_loss_coeff
         global_step (int): Current global training step.
     """
     # Log gradient norms
+    wandb_payload = {}
     for key, norm in global_grad_norms.items():
-        writer.add_scalar(f'gradient norm/{key}', norm, global_step)
+        if writer is not None:
+            writer.add_scalar(f'gradient norm/{key}', norm, global_step)
+        if wandb_run is not None:
+            wandb_payload[f'{phase}/gradient_norm/{key}'] = float(norm)
 
     # Log adaptive coefficients
     for coeff_name, coeff_val in adaptive_loss_coeffs.items():
-        writer.add_scalar(f'adaptive_coeff/{coeff_name}', coeff_val, global_step)
+        if writer is not None:
+            writer.add_scalar(f'adaptive_coeff/{coeff_name}', coeff_val, global_step)
+        if wandb_run is not None:
+            wandb_payload[f'{phase}/adaptive_coeff/{coeff_name}'] = float(coeff_val)
+
+    if wandb_run is not None and wandb_payload:
+        wandb_run.log(wandb_payload, step=global_step)
 
 
-def log_per_loss_grad_norms(loss_dict, net, configs, writer, accelerator, global_step, adaptive_loss_coeffs):
+def log_per_loss_grad_norms(loss_dict, net, configs, writer, accelerator, global_step, adaptive_loss_coeffs, wandb_run=None):
     """
     Log per-loss gradient norms, individual loss components, and adjust adaptive coefficients based on global gradient norms.
     Only activates when adaptive mode is enabled and warmup period is complete.
-    Logs gradient norms, adaptive coefficients, and individual loss components to TensorBoard with hierarchical naming.
+    Logs gradient norms, adaptive coefficients, and individual loss components to TensorBoard with hierarchical naming and
+    mirrors these values to WandB when enabled.
 
     Args:
         loss_dict (dict): Loss components from calculate_decoder_loss
@@ -229,6 +253,7 @@ def log_per_loss_grad_norms(loss_dict, net, configs, writer, accelerator, global
         accelerator: HuggingFace Accelerator
         global_step (int): Current global training step
         adaptive_loss_coeffs (dict): Current adaptive coefficients
+        wandb_run: Optional WandB run used for logging scalars
 
     Returns:
         dict: Updated adaptive coefficients
@@ -299,9 +324,22 @@ def log_per_loss_grad_norms(loss_dict, net, configs, writer, accelerator, global
 
     if accelerator.is_main_process:
         # Log gradient norms, coefficients, and individual loss components
-        if configs.tensorboard_log:
-            log_gradient_norms_and_coeffs(writer, global_grad_norms, adaptive_loss_coeffs, global_step)
-            log_per_loss_components(writer, loss_dict, global_step)
+        tensorboard_writer = writer if configs.tensorboard_log else None
+        log_gradient_norms_and_coeffs(
+            tensorboard_writer,
+            global_grad_norms,
+            adaptive_loss_coeffs,
+            global_step,
+            phase='train',
+            wandb_run=wandb_run,
+        )
+        log_per_loss_components(
+            tensorboard_writer,
+            loss_dict,
+            global_step,
+            phase='train',
+            wandb_run=wandb_run,
+        )
 
     if (global_step > configs.optimizer.decay.warmup and
             len(local_grad_norms) > 0):  # Only broadcast if we have any losses with adaptive coefficients


### PR DESCRIPTION
## Summary
- add a log.wandb configuration block so runs can set intervals, metadata, and watch preferences for Weights & Biases
- initialize WandB during training and stream structured train/eval losses, metrics, learning rate, timings, and gradient norms with hierarchical keys
- update custom loss logging utilities to mirror tensorboard data to WandB when enabled

## Testing
- python -m compileall train.py utils/custom_losses.py

------
https://chatgpt.com/codex/tasks/task_b_68df0b4d26448323b97b8dc1ce613b7c