### PR TITLE
Refactor config loading to support Hydra overrides

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import yaml
 import shutil
@@ -11,7 +12,13 @@ from accelerate import Accelerator, DataLoaderConfiguration
 from accelerate.utils import broadcast_object_list
 import csv
 
-from utils.utils import load_configs, save_backbone_pdb_inference, load_checkpoints_simple, get_logging
+from utils.utils import (
+    load_configs,
+    load_config_with_overrides,
+    save_backbone_pdb_inference,
+    load_checkpoints_simple,
+    get_logging,
+)
 from utils.custom_losses import calculate_aligned_mse_loss
 from data.dataset import GCPNetDataset, custom_collate_pretrained_gcp
 from models.super_model import prepare_model
@@ -143,12 +150,7 @@ def evaluate_structures(pdb_dir, original_pdb_dir, result_dir, logger):
         logger.error("No structures were successfully evaluated")
 
 
-def main():
-    # Load inference configuration
-    with open("configs/evaluation_config.yaml") as f:
-        infer_cfg = yaml.full_load(f)
-    infer_cfg = Box(infer_cfg)
-
+def main(infer_cfg: Box):
     dataloader_config = DataLoaderConfiguration(
         # dispatch_batches=True,
         # non_blocking=False,
@@ -331,4 +333,14 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description="Evaluate a trained VQ-VAE model.")
+    parser.add_argument(
+        "--config_path", "-c", help="Path to evaluation_config.yaml",
+        default='./configs/evaluation_config.yaml'
+    )
+    args, unknown_overrides = parser.parse_known_args()
+
+    raw_cfg = load_config_with_overrides(args.config_path, unknown_overrides)
+    infer_cfg = Box(raw_cfg)
+
+    main(infer_cfg)

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,7 @@ pip install tmtools
 pip install jaxtyping
 pip install beartype
 pip install omegaconf
+pip install hydra-core
 pip install ndlinear
 pip install torch_tb_profiler
 pip install tqdm

--- a/train.py
+++ b/train.py
@@ -1,6 +1,5 @@
 import argparse
 import numpy as np
-import yaml
 import os
 import torch
 from collections.abc import Mapping
@@ -10,6 +9,7 @@ from utils.custom_losses import calculate_decoder_loss, log_per_loss_grad_norms
 from utils.utils import (
     save_backbone_pdb,
     load_configs,
+    load_config_with_overrides,
     load_checkpoints,
     prepare_saving_dir,
     get_logging,
@@ -597,8 +597,7 @@ def valid_loop(net, valid_loader, epoch, **kwargs):
     return return_dict
 
 
-def main(dict_config, config_file_path):
-    configs = load_configs(dict_config)
+def main(configs, raw_config, config_file_path):
     if isinstance(configs.fix_seed, int):
         torch.manual_seed(configs.fix_seed)
         torch.random.manual_seed(configs.fix_seed)
@@ -652,7 +651,7 @@ def main(dict_config, config_file_path):
     wandb_run = None
     wandb_settings = getattr(log_config, 'wandb', None) if log_config is not None else None
     if accelerator.is_main_process:
-        wandb_run, wandb_settings = _init_wandb_run(configs, dict_config, result_path, logging=logging)
+        wandb_run, wandb_settings = _init_wandb_run(configs, raw_config, result_path, logging=logging)
     accelerator.wait_for_everyone()
 
     train_dataloader, valid_dataloader = prepare_gcpnet_vqvae_dataloaders(
@@ -925,12 +924,14 @@ def main(dict_config, config_file_path):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Train a VQ-VAE models.")
-    parser.add_argument("--config_path", "-c", help="The location of config file",
-                        default='./configs/config_vqvae.yaml')
-    args = parser.parse_args()
+    parser.add_argument(
+        "--config_path", "-c", help="The location of config file",
+        default='./configs/config_vqvae.yaml'
+    )
+    args, unknown_overrides = parser.parse_known_args()
     config_path = args.config_path
 
-    with open(config_path) as file:
-        config_file = yaml.full_load(file)
+    raw_config = load_config_with_overrides(config_path, unknown_overrides)
+    configs = load_configs(raw_config)
 
-    main(config_file, config_path)
+    main(configs, raw_config, config_path)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -6,6 +6,7 @@ import ast
 import logging as log
 from collections import OrderedDict
 from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
 from box import Box
 from torch.utils.tensorboard import SummaryWriter
 import torch
@@ -19,10 +20,15 @@ import yaml
 import h5py
 from io import StringIO
 try:  # Optional dependency retained for legacy workflows
-    from hydra import compose, initialize  # type: ignore
+    from hydra import compose, initialize, initialize_config_dir  # type: ignore
+    from hydra.core.global_hydra import GlobalHydra  # type: ignore
+    from omegaconf import OmegaConf  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - fallback when Hydra is unavailable
     compose = None  # type: ignore
     initialize = None  # type: ignore
+    initialize_config_dir = None  # type: ignore
+    GlobalHydra = None  # type: ignore
+    OmegaConf = None  # type: ignore
 from Bio.PDB import PDBIO
 
 
@@ -69,6 +75,48 @@ def get_nb_trainable_parameters(model):
             trainable_params += num_params
 
     return trainable_params, all_param
+
+
+def load_config_with_overrides(config_path: str, overrides: Optional[Sequence[str]] = None) -> Dict[str, Any]:
+    """Load a configuration file and apply Hydra style overrides.
+
+    Args:
+        config_path: Absolute or relative path to the YAML configuration file.
+        overrides: Optional sequence of Hydra-formatted override strings (e.g.
+            ``["optimizer.lr=1e-4", "train_settings.num_epochs=5"]``).
+
+    Returns:
+        The resolved configuration as a plain ``dict`` suitable for wrapping in a
+        :class:`python_box.Box` or similar container.
+
+    Raises:
+        RuntimeError: If Hydra is not available in the current environment.
+        ValueError: If the configuration cannot be resolved into a mapping.
+    """
+
+    if compose is None or initialize_config_dir is None or GlobalHydra is None or OmegaConf is None:
+        raise RuntimeError(
+            "Hydra is required to load configs with overrides; install hydra-core to enable this feature."
+        )
+
+    overrides = list(overrides) if overrides else []
+    config_abspath = os.path.abspath(config_path)
+    config_dir = os.path.dirname(config_abspath)
+    config_name = os.path.splitext(os.path.basename(config_abspath))[0]
+
+    # Hydra keeps global state about the current configuration; ensure we start from
+    # a clean slate when composing configs programmatically.
+    GlobalHydra.instance().clear()
+
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(config_name=config_name, overrides=overrides)
+
+    cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+    if not isinstance(cfg_dict, dict):
+        raise ValueError("Resolved configuration must be a mapping at the top level.")
+
+    cfg_dict.setdefault("config_path", config_abspath)
+    return cfg_dict
 
 
 def print_trainable_parameters(model, logging, description=""):


### PR DESCRIPTION
## Summary
- add a Hydra-backed config loader that applies dot-notation overrides before building Box configs
- update the training and evaluation entrypoints to accept Hydra overrides while remaining compatible with accelerate launch
- include hydra-core in the install script so the dependency is available

## Testing
- python -m compileall train.py evaluation.py utils/utils.py

------
https://chatgpt.com/codex/tasks/task_b_68df2155e9ec8323a2df42fb98940d7c