### PR TITLE
Refactor training loop to be step-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ Configure your training parameters in `configs/config_vqvae.yaml` and run:
 
 Note:
 - Training expects datasets in the HDF5 layout defined in [HDF5 format used by this repo](#hdf5-format-used-by-this-repo).
+- `train_settings.num_steps` controls run length by default; set it to `null` when you prefer to stop after `num_epochs` instead.
+- Step-based intervals (logging, checkpoints, validation, PDB export) can optionally be overridden with epoch values by setting the corresponding `epochs` field in the YAML.
+- The training dataloader now iterates over the full dataset each epoch and reshuffles automatically when `shuffle: true`.
 
 ```bash
 # Set up accelerator configuration for multi-GPU training

--- a/configs/config_vqvae.yaml
+++ b/configs/config_vqvae.yaml
@@ -1,11 +1,11 @@
 fix_seed: 0  # Integer seed applied to NumPy and PyTorch for reproducible training runs
 checkpoints_every:
-  steps: null  # Interval in optimizer steps for writing checkpoints (overrides epochs when set)
-  epochs: 256  # Interval in epochs at which checkpoints are written to disk
+  steps: 20000  # Interval in optimizer steps for writing checkpoints (set to null to disable)
+  epochs: null  # Optional epoch-based checkpoint interval (overrides steps when provided)
 log:
   interval:
-    steps: null  # Interval in optimizer steps for aggregated logs (overrides epochs when set)
-    epochs: 1  # Interval in epochs for aggregated logs when step interval is not provided
+    steps: 500  # Interval in optimizer steps for aggregated logs (set to null to use epochs)
+    epochs: null  # Optional epoch-based logging interval used when steps is null
   wandb:
     enabled: False  # Enable logging scalars to Weights & Biases when True
     project: null  # WandB project name
@@ -87,22 +87,22 @@ model:  # Settings controlling model construction
 
 train_settings:  # Parameters that control the training loop
   data_path: ../../datasets/vqvae/uniref_50/  # Directory containing HDF5 training data
-  num_epochs: 32  # Total number of epochs to train for
-  num_steps: null  # Optional total number of optimizer steps to run; overrides num_epochs when provided
+  num_epochs: null  # Optional total number of epochs to train for (used when num_steps is null)
+  num_steps: 100000  # Total number of optimizer steps to run (set to null to rely on num_epochs instead)
   sample_weighting:  # Curriculum weighting on samples by sequence length
     enabled: True  # Turn dynamic sample weighting on or off
     min_weight: 1.0  # Minimum weight assigned to any training example
     max_weight: 4.0  # Maximum weight a long sequence can receive
     threshold_length: 384  # Sequence length from which weights start increasing
-  shuffle: False  # Shuffle dataset between epochs when True
+  shuffle: True  # Shuffle dataset between epochs when True
   mixed_precision: bf16  # Mixed precision policy passed to Accelerate (options: no, fp16, bf16, fp8)
   save_pdb_every:
-    steps: null  # Frequency in optimizer steps to export predicted structures (overrides epochs when set)
-    epochs: 8  # Frequency in epochs to export predicted structures as PDB files
+    steps: 5000  # Frequency in optimizer steps to export predicted structures (set null to use epochs)
+    epochs: null  # Optional frequency in epochs to export predicted structures as PDB files
   batch_size: 16  # Batch size per device before gradient accumulation
   num_workers: 8  # Number of worker processes for the training dataloader
   grad_accumulation: 1  # Gradient accumulation steps used to form an effective batch
-  max_task_samples: 200000  # Limit on how many samples to draw from the dataset per epoch
+  max_task_samples: null  # Optional limit on the number of samples loaded from disk
   profile_train_loop: False  # Enable PyTorch profiler around the training loop when debugging
   cutoff_augmentation:  # Randomly truncate sequences to shorter lengths
     enabled: False  # Activate cutoff augmentation when True
@@ -154,11 +154,11 @@ train_settings:  # Parameters that control the training loop
 valid_settings:  # Parameters for validation data loading and evaluation
   data_path: ../../datasets/vqvae/whole_validation_2048_h5/  # Directory containing validation HDF5 files
   do_every:
-    steps: null  # Run validation once every N optimizer steps when provided
-    epochs: 1  # Run validation once every N training epochs when steps is null
+    steps: 2000  # Run validation once every N optimizer steps (set to null to use epochs)
+    epochs: null  # Optional epoch-based validation frequency used when steps is null
   save_pdb_every:
-    steps: null  # Dump validation reconstructions every N validation steps when provided
-    epochs: 1  # Dump validation reconstructions as PDB files at this epoch interval
+    steps: 2000  # Dump validation reconstructions every N validation steps when provided
+    epochs: null  # Optional epoch-based interval for dumping validation reconstructions
   batch_size: 8  # Validation batch size per device
   num_workers: 0  # Number of worker processes for the validation dataloader
 

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -352,7 +352,11 @@ class GCPNetDataset(Dataset):
         if self.mode == 'train':
             random.shuffle(self.h5_samples)
 
-        self.h5_samples = self.h5_samples[:kwargs['configs'].train_settings.max_task_samples]
+        max_task_samples = getattr(
+            kwargs['configs'].train_settings, 'max_task_samples', None
+        )
+        if max_task_samples is not None:
+            self.h5_samples = self.h5_samples[:max_task_samples]
 
         self.top_k = top_k
         self.num_positional_embeddings = num_positional_embeddings

--- a/train.py
+++ b/train.py
@@ -157,7 +157,7 @@ def parse_interval(interval_config):
     Returns:
         tuple[str | None, int | None]: (mode, value) where mode is ``"steps"`` or
         ``"epochs"`` when configured. ``value`` is ``None`` when no valid interval is
-        provided.
+        provided. Bare integers are interpreted as step-based intervals.
     """
 
     if interval_config is None:
@@ -165,7 +165,7 @@ def parse_interval(interval_config):
 
     if isinstance(interval_config, Number):
         value = int(interval_config)
-        return ("epochs", value) if value > 0 else (None, None)
+        return ("steps", value) if value > 0 else (None, None)
 
     steps = _extract_interval_value(interval_config, "steps")
     epochs = _extract_interval_value(interval_config, "epochs")
@@ -713,11 +713,17 @@ def main(configs, raw_config, config_file_path):
             raise ValueError('train_settings.num_steps must be a positive integer when provided.')
         if accelerator.is_main_process:
             logging.info(
-                'Training duration configured for %s optimizer steps; this overrides num_epochs.',
+                'Training duration configured for %s optimizer steps; this overrides num_epochs when set.',
                 f'{max_steps:,}'
             )
 
-    total_epochs = int(getattr(configs.train_settings, 'num_epochs', 0))
+    total_epochs = getattr(configs.train_settings, 'num_epochs', None)
+    if total_epochs is not None:
+        total_epochs = int(total_epochs)
+        if total_epochs <= 0:
+            raise ValueError('train_settings.num_epochs must be a positive integer when provided.')
+    if max_steps is None and total_epochs is None:
+        raise ValueError('Configure either train_settings.num_steps or train_settings.num_epochs to run training.')
 
     # Maybe monitor resource usage during training.
     prof = None
@@ -752,8 +758,11 @@ def main(configs, raw_config, config_file_path):
     best_valid_metrics = {'gdtts': 0.0, 'mae': 1000.0, 'rmsd': 1000.0, 'lddt': 0.0, 'loss': 1000.0, 'tm_score': 0.0,
                           'perplexity': 1000.0}
     epoch = 0
+    reached_max_steps = False
     while True:
-        if max_steps is None and epoch >= total_epochs:
+        if total_epochs is not None and epoch >= total_epochs:
+            break
+        if max_steps is not None and reached_max_steps:
             break
         epoch += 1
         start_time = time.time()
@@ -891,13 +900,15 @@ def main(configs, raw_config, config_file_path):
                 logging.info(f'\tsaving the best models in {model_path}')
                 logging.info(f'\tbest valid rmsd: {best_valid_metrics["rmsd"]:.4f}')
 
-        if max_steps is not None and reached_max_steps:
-            if accelerator.is_main_process:
-                logging.info(
-                    'Reached the configured maximum number of training steps (%s); ending training loop.',
-                    f'{max_steps:,}'
-                )
-            break
+    if max_steps is not None and reached_max_steps:
+        if accelerator.is_main_process:
+            logging.info(
+                'Reached the configured maximum number of training steps (%s); ending training loop.',
+                f'{max_steps:,}'
+            )
+    elif total_epochs is not None and epoch >= total_epochs:
+        if accelerator.is_main_process:
+            logging.info('Completed the configured number of epochs (%s); ending training loop.', total_epochs)
 
     logging.info("Training is completed!\n")
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -352,6 +352,10 @@ def prepare_optimizer(net, configs, num_train_samples, logging):
         if configured_num_steps is not None:
             total_training_steps = int(configured_num_steps)
         else:
+            if getattr(configs.train_settings, 'num_epochs', None) is None:
+                raise ValueError(
+                    'train_settings.num_epochs must be provided when train_settings.num_steps is null.'
+                )
             total_training_steps = int(np.ceil(steps_per_epoch * configs.train_settings.num_epochs))
 
         if total_training_steps <= 0:


### PR DESCRIPTION
## Summary
- default the configuration to step-based scheduling while keeping epoch overrides available
- refactor the training loop utilities to respect step-driven intervals and remove partial-dataset epochs
- document the new behavior and guard scheduler setup when only epoch counts are provided

## Testing
- python -m compileall train.py data/dataset.py utils/utils.py

------
https://chatgpt.com/codex/tasks/task_b_68df6a88b19c83239dfa31ccbb4a4905