### PR TITLE
Refactor GCPNet encoder preprocessing to use ProteinBatch

### DIFF
--- a/src/gcpvqvae/data/batch.py
+++ b/src/gcpvqvae/data/batch.py
@@ -1,0 +1,264 @@
+"""Lightweight batch container mirroring the :mod:`torch_geometric` API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, Mapping, MutableMapping, Optional
+
+import torch
+
+try:  # pragma: no cover - torch_geometric is optional in the test env
+    from torch_geometric.data import Batch as _PyGBatch  # type: ignore
+except Exception:  # pragma: no cover - fallback to a simple object base class
+    _PyGBatch = object  # type: ignore[misc, assignment]
+
+Tensor = torch.Tensor
+
+
+@dataclass
+class EdgeStorage:
+    """Container holding per-relation edge features."""
+
+    edge_index: Tensor
+    scalars: Tensor
+    vectors: Tensor
+    frames: Optional[Tensor] = None
+    batch: Optional[Tensor] = None
+    name: str = "knn_k"
+
+    def clone(self) -> "EdgeStorage":
+        frames = None if self.frames is None else self.frames.clone()
+        batch = None if self.batch is None else self.batch.clone()
+        return EdgeStorage(
+            edge_index=self.edge_index.clone(),
+            scalars=self.scalars.clone(),
+            vectors=self.vectors.clone(),
+            frames=frames,
+            batch=batch,
+            name=self.name,
+        )
+
+    def to(
+        self,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> "EdgeStorage":
+        kwargs = {"device": device}
+        if dtype is not None and self.scalars.dtype.is_floating_point:
+            kwargs["dtype"] = dtype
+
+        scalars = self.scalars.to(**kwargs)
+        vectors = self.vectors.to(**kwargs)
+        frames = None if self.frames is None else self.frames.to(**kwargs)
+
+        batch_tensor = self.batch
+        if batch_tensor is not None:
+            batch_tensor = batch_tensor.to(device=device)
+
+        return EdgeStorage(
+            edge_index=self.edge_index.to(device=device),
+            scalars=scalars,
+            vectors=vectors,
+            frames=frames,
+            batch=batch_tensor,
+            name=self.name,
+        )
+
+
+class ProteinBatch(_PyGBatch):
+    """Minimal batch object understood by :class:`GCPNetEncoder`."""
+
+    def __init__(
+        self,
+        *,
+        h: Tensor,
+        chi: Tensor,
+        e: Mapping[str, EdgeStorage] | EdgeStorage,
+        xi: Tensor,
+        batch: Tensor,
+        ptr: Tensor,
+        mask: Optional[Tensor] = None,
+        **extras: Tensor,
+    ) -> None:
+        super().__init__()  # type: ignore[misc]
+        self.h = h
+        self.chi = chi
+        if isinstance(e, EdgeStorage):
+            self.e: MutableMapping[str, EdgeStorage] = {e.name: e}
+        else:
+            self.e = dict(e)
+        self.xi = xi
+        self.batch = batch
+        self.ptr = ptr
+        self.mask = mask
+        self.centroids: Optional[Tensor] = None
+        self.edge_frames: Optional[Tensor] = None
+        for key, value in extras.items():
+            setattr(self, key, value)
+
+    # ------------------------------------------------------------------ helpers
+    def num_graphs(self) -> int:
+        return int(self.ptr.numel() - 1)
+
+    def __len__(self) -> int:  # pragma: no cover - compatibility shim
+        return self.h.shape[0]
+
+    def items(self) -> Iterable[tuple[str, Tensor]]:  # pragma: no cover - shim
+        for key, value in self.__dict__.items():
+            if isinstance(value, Tensor):
+                yield key, value
+
+    def clone(self) -> "ProteinBatch":
+        edges = {name: storage.clone() for name, storage in self.e.items()}
+        mask = None if self.mask is None else self.mask.clone()
+        extras: Dict[str, Tensor] = {}
+        for key, value in self.__dict__.items():
+            if key in {"h", "chi", "e", "xi", "batch", "ptr", "mask", "centroids", "edge_frames"}:
+                continue
+            if isinstance(value, Tensor):
+                extras[key] = value.clone()
+        clone = ProteinBatch(
+            h=self.h.clone(),
+            chi=self.chi.clone(),
+            e=edges,
+            xi=self.xi.clone(),
+            batch=self.batch.clone(),
+            ptr=self.ptr.clone(),
+            mask=mask,
+            **extras,
+        )
+        if self.centroids is not None:
+            clone.centroids = self.centroids.clone()
+        if self.edge_frames is not None:
+            clone.edge_frames = self.edge_frames.clone()
+        return clone
+
+    def to(
+        self,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> "ProteinBatch":
+        kwargs = {"device": device}
+        if dtype is not None and self.h.dtype.is_floating_point:
+            kwargs["dtype"] = dtype
+
+        h = self.h.to(**kwargs)
+        chi = self.chi.to(**kwargs)
+        xi = self.xi.to(**kwargs)
+        mask = None if self.mask is None else self.mask.to(device=device)
+        batch = self.batch.to(device=device)
+        ptr = self.ptr.to(device=device)
+
+        edges = {name: storage.to(device=device, dtype=dtype) for name, storage in self.e.items()}
+
+        extras: Dict[str, Tensor] = {}
+        for key, value in self.__dict__.items():
+            if key in {"h", "chi", "e", "xi", "batch", "ptr", "mask", "centroids", "edge_frames"}:
+                continue
+            if isinstance(value, Tensor):
+                if dtype is not None and value.dtype.is_floating_point:
+                    extras[key] = value.to(device=device, dtype=dtype)
+                else:
+                    extras[key] = value.to(device=device)
+
+        out = ProteinBatch(
+            h=h,
+            chi=chi,
+            e=edges,
+            xi=xi,
+            batch=batch,
+            ptr=ptr,
+            mask=mask,
+            **extras,
+        )
+
+        if self.centroids is not None:
+            out.centroids = self.centroids.to(**kwargs)
+        if self.edge_frames is not None:
+            out.edge_frames = self.edge_frames.to(**kwargs)
+
+        return out
+
+
+def protein_batch_from_graph_dict(
+    batch: Mapping[str, Tensor],
+    *,
+    relation_name: str = "knn_k",
+) -> ProteinBatch:
+    """Construct a :class:`ProteinBatch` from a collated mini-batch."""
+
+    if "node_scalars" not in batch or "node_vectors" not in batch:
+        raise KeyError("Batch dictionary must contain node features")
+
+    node_scalars = batch["node_scalars"]
+    node_vectors = batch["node_vectors"]
+    coords = batch["coords"]
+    mask = batch["mask"].to(torch.bool)
+    if "nan_mask" in batch and isinstance(batch["nan_mask"], Tensor):
+        mask = mask & ~batch["nan_mask"].to(torch.bool)
+
+    batch_size, max_len = node_scalars.shape[:2]
+    flat_nodes = batch_size * max_len
+
+    flat_h = node_scalars.reshape(flat_nodes, -1)
+    flat_chi = node_vectors.reshape(flat_nodes, node_vectors.shape[-2], node_vectors.shape[-1])
+    flat_xi = coords[:, :, 1, :].reshape(flat_nodes, 3)
+    flat_mask = mask.reshape(-1)
+
+    valid_indices = torch.nonzero(flat_mask, as_tuple=False).squeeze(-1)
+    h = flat_h.index_select(0, valid_indices)
+    chi = flat_chi.index_select(0, valid_indices)
+    xi = flat_xi.index_select(0, valid_indices)
+
+    lengths = batch["lengths"]
+    node_batch = torch.repeat_interleave(
+        torch.arange(batch_size, device=lengths.device, dtype=torch.long), lengths
+    )
+    ptr = torch.zeros((batch_size + 1,), dtype=torch.long, device=lengths.device)
+    ptr[1:] = torch.cumsum(lengths, dim=0)
+
+    edge_index = batch["edge_index"]
+    edge_scalars = batch["edge_scalars"]
+    edge_vectors = batch["edge_vectors"]
+    edge_frames = batch.get("edge_frames")
+    edge_batch = batch.get("edge_batch")
+
+    storage = EdgeStorage(
+        edge_index=edge_index,
+        scalars=edge_scalars,
+        vectors=edge_vectors,
+        frames=edge_frames,
+        batch=edge_batch,
+        name=relation_name,
+    )
+
+    extras: Dict[str, Tensor] = {}
+    for key in ("coords", "atom_mask", "backbone_vectors", "torsion_angles", "rotations", "translations"):
+        if key in batch and isinstance(batch[key], Tensor):
+            extras[key] = batch[key]
+
+    protein_batch = ProteinBatch(
+        h=h,
+        chi=chi,
+        e={relation_name: storage},
+        xi=xi,
+        batch=node_batch,
+        ptr=ptr,
+        mask=torch.ones_like(node_batch, dtype=torch.bool),
+        **extras,
+    )
+    protein_batch.lengths = lengths
+    protein_batch.valid_indices = valid_indices
+    protein_batch.full_mask = mask
+    protein_batch.batch_size = batch_size
+    protein_batch.max_length = max_len
+    if "metadata" in batch:
+        protein_batch.metadata = batch["metadata"]  # type: ignore[attr-defined]
+    if "sequences" in batch:
+        protein_batch.sequences = batch["sequences"]  # type: ignore[attr-defined]
+    return protein_batch
+
+
+__all__ = ["EdgeStorage", "ProteinBatch", "protein_batch_from_graph_dict"]
+

--- a/src/gcpvqvae/geometry/ops.py
+++ b/src/gcpvqvae/geometry/ops.py
@@ -1,0 +1,166 @@
+"""Geometry utilities used for batched graph preprocessing."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional, Tuple
+
+import torch
+
+try:  # pragma: no cover - torch_scatter is optional at runtime
+    from torch_scatter import scatter_sum
+except Exception:  # pragma: no cover - provide a functional fallback
+
+    def scatter_sum(
+        src: torch.Tensor,
+        index: torch.Tensor,
+        dim: int = 0,
+        dim_size: Optional[int] = None,
+    ) -> torch.Tensor:
+        if dim != 0:
+            raise NotImplementedError("Fallback scatter_sum only supports dim=0")
+        if dim_size is None:
+            dim_size = int(index.max().item() + 1) if index.numel() else 0
+        out_shape = (dim_size,) + src.shape[1:]
+        out = torch.zeros(out_shape, dtype=src.dtype, device=src.device)
+        if index.numel():
+            out.index_add_(0, index, src)
+        return out
+
+from gcpvqvae.geometry.frames import build_local_frames
+
+Tensor = torch.Tensor
+
+_IDENTITY_CACHE = {}
+
+
+def _scatter_count(index: Tensor, *, dim_size: int, device: torch.device, dtype: torch.dtype) -> Tensor:
+    ones = torch.ones((index.shape[0], 1), dtype=dtype, device=device)
+    counts = scatter_sum(ones, index, dim=0, dim_size=dim_size)
+    return torch.clamp(counts, min=1.0)
+
+
+def centralize(
+    positions: Tensor,
+    batch: Tensor,
+    *,
+    mask: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor]:
+    """Return centralised coordinates and per-graph centroids."""
+
+    if positions.ndim != 2 or positions.size(-1) != 3:
+        raise ValueError("positions must have shape (N, 3)")
+
+    if positions.shape[0] != batch.shape[0]:
+        raise ValueError("positions and batch must align in the first dimension")
+
+    device = positions.device
+    dtype = positions.dtype
+    num_graphs = int(batch.max().item() + 1) if batch.numel() else 0
+
+    weights: Tensor
+    weighted_pos: Tensor
+    if mask is not None:
+        mask = mask.to(device=device, dtype=dtype).unsqueeze(-1)
+        weights = scatter_sum(mask, batch, dim=0, dim_size=num_graphs)
+        weighted_pos = scatter_sum(positions * mask, batch, dim=0, dim_size=num_graphs)
+    else:
+        ones = torch.ones((positions.shape[0], 1), dtype=dtype, device=device)
+        weights = scatter_sum(ones, batch, dim=0, dim_size=num_graphs)
+        weighted_pos = scatter_sum(positions, batch, dim=0, dim_size=num_graphs)
+
+    weights = torch.clamp(weights, min=1.0)
+    centroids = weighted_pos / weights
+    centered = positions - centroids.index_select(0, batch)
+    return centered, centroids
+
+
+def decentralize(positions: Tensor, centroids: Tensor, batch: Tensor) -> Tensor:
+    """Undo :func:`centralize` for a subset of nodes."""
+
+    if positions.ndim != 2 or positions.size(-1) != 3:
+        raise ValueError("positions must have shape (N, 3)")
+    if centroids.ndim != 2 or centroids.size(-1) != 3:
+        raise ValueError("centroids must have shape (G, 3)")
+
+    return positions + centroids.index_select(0, batch)
+
+
+def localize(vectors: Tensor, frames: Tensor) -> Tensor:
+    """Express ``vectors`` in the coordinate system defined by ``frames``."""
+
+    if frames.ndim != 3 or frames.shape[-2:] != (3, 3):
+        raise ValueError("frames must have shape (E, 3, 3)")
+
+    if vectors.size(0) != frames.size(0):
+        raise ValueError("vectors and frames must agree on the first dimension")
+
+    if vectors.ndim == 2:
+        return torch.einsum("eji,ej->ei", frames, vectors)
+    if vectors.ndim == 3:
+        return torch.einsum("eji,eci->ecj", frames, vectors)
+    raise ValueError("vectors must have shape (E, 3) or (E, C, 3)")
+
+
+def _cached_identity(count: int, device: torch.device, dtype: torch.dtype) -> Tensor:
+    key = (device, dtype)
+    cached = _IDENTITY_CACHE.get(key)
+    if cached is None or cached.shape[0] < count:
+        identity = torch.eye(3, device=device, dtype=dtype)
+        cached = identity.unsqueeze(0).repeat(max(count, 1), 1, 1)
+        _IDENTITY_CACHE[key] = cached
+    return cached[:count]
+
+
+def ensure_edge_frames(
+    positions: Tensor,
+    edge_index: Tensor,
+    *,
+    edge_batch: Optional[Tensor] = None,
+    node_batch: Optional[Tensor] = None,
+    mask: Optional[Tensor] = None,
+) -> Tensor:
+    """Return rotation frames for each edge, computing them lazily if needed."""
+
+    if edge_index.ndim != 2 or edge_index.size(0) != 2:
+        raise ValueError("edge_index must have shape (2, E)")
+
+    num_edges = edge_index.size(1)
+    if num_edges == 0:
+        return _cached_identity(0, positions.device, positions.dtype)
+
+    if node_batch is None:
+        if positions.shape[0] == 0:
+            raise ValueError("node_batch is required when positions are empty")
+        node_batch = positions.new_zeros((positions.shape[0],), dtype=torch.long)
+
+    if edge_batch is None:
+        src, _ = edge_index
+        edge_batch = node_batch.index_select(0, src)
+
+    num_graphs = int(node_batch.max().item() + 1) if node_batch.numel() else 0
+    frames = positions.new_empty((num_edges, 3, 3))
+
+    for graph in range(num_graphs):
+        node_mask = node_batch == graph
+        edge_mask = edge_batch == graph
+        if edge_mask.sum().item() == 0:
+            continue
+
+        offset = int(node_mask.nonzero(as_tuple=False)[0].item()) if node_mask.any() else 0
+        local_nodes = positions[node_mask]
+        local_edges = edge_index[:, edge_mask] - offset
+        local_mask = mask[node_mask] if mask is not None else None
+
+        if local_nodes.size(0) == 0:
+            frames[edge_mask] = _cached_identity(int(edge_mask.sum()), positions.device, positions.dtype)
+            continue
+
+        local_frames = build_local_frames(local_nodes, local_edges, mask=local_mask)
+        frames[edge_mask] = local_frames.to(device=positions.device, dtype=positions.dtype)
+
+    return frames
+
+
+__all__ = ["centralize", "decentralize", "localize", "ensure_edge_frames"]
+

--- a/src/gcpvqvae/models/gcpnet.py
+++ b/src/gcpvqvae/models/gcpnet.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import torch
 from torch import Tensor, nn
 
 from .gcpcore import apply_gating, safe_norm, vector_linear
+from gcpvqvae.data.batch import EdgeStorage, ProteinBatch
+from gcpvqvae.geometry.ops import centralize, ensure_edge_frames, localize
 
 
 # Default number of scalar edge features produced by the featurisation pipeline.
@@ -287,38 +289,67 @@ class GCPNetEncoder(nn.Module):
         else:
             self.displacement_head = None
 
-    def forward(
-        self,
-        node_scalars: Tensor,
-        node_vectors: Tensor,
-        edge_index: Tensor,
-        edge_scalars: Tensor,
-        edge_vectors: Tensor,
-        edge_frames: Tensor,
-        *,
-        mask: Optional[Tensor] = None,
-    ) -> Dict[str, Tensor]:
-        if node_scalars.ndim != 2:
-            raise ValueError("node_scalars must have shape (N, F)")
-        if node_vectors.ndim != 3:
-            raise ValueError("node_vectors must have shape (N, C, 3)")
+    def forward(self, batch: ProteinBatch) -> Dict[str, Union[Tensor, ProteinBatch]]:
+        if not isinstance(batch, ProteinBatch):
+            raise TypeError("GCPNetEncoder.forward expects a ProteinBatch")
 
-        scalar_proj_dtype = self.scalar_proj.weight.dtype
-        scalars = self.scalar_proj(node_scalars.to(scalar_proj_dtype)).to(node_scalars.dtype)
-        vectors = vector_linear(node_vectors, self.vector_proj).to(node_vectors.dtype)
+        node_scalars = batch.h
+        node_vectors = batch.chi
+        if node_scalars.ndim != 2:
+            raise ValueError("ProteinBatch.h must have shape (N, F)")
+        if node_vectors.ndim != 3:
+            raise ValueError("ProteinBatch.chi must have shape (N, C, 3)")
+
+        mask = batch.mask.to(torch.bool) if batch.mask is not None else None
+
+        batch.xi_raw = batch.xi.clone()
+        centered_positions, centroids = centralize(batch.xi, batch.batch, mask=mask)
+        batch.xi = centered_positions
+        batch.centroids = centroids
+
+        edges: EdgeStorage
+        if isinstance(batch.e, dict):
+            knn_keys = [name for name in batch.e if name.startswith("knn")]
+            if len(knn_keys) != 1:
+                raise ValueError("ProteinBatch must contain exactly one knn relation")
+            edges = batch.e[knn_keys[0]]
+        else:
+            raise ValueError("ProteinBatch.e must be a mapping of edge relations")
+
+        frames = edges.frames
+        if frames is None or frames.shape[0] != edges.edge_index.shape[1]:
+            frames = ensure_edge_frames(
+                batch.xi,
+                edges.edge_index,
+                edge_batch=edges.batch,
+                node_batch=batch.batch,
+                mask=mask,
+            )
+            edges.frames = frames
+        batch.edge_frames = frames
+
+        edge_vectors = edges.vectors
+        if edge_vectors.ndim == 2:
+            edge_vectors = edge_vectors.unsqueeze(1)
+        edge_vectors = localize(edge_vectors, frames).to(node_vectors.dtype)
+
+        node_scalar_dtype = self.scalar_proj.weight.dtype
+        scalars = self.scalar_proj(node_scalars.to(node_scalar_dtype)).to(batch.h.dtype)
+        vectors = vector_linear(node_vectors, self.vector_proj).to(batch.chi.dtype)
 
         if mask is not None:
-            mask = mask.to(torch.bool)
             scalars = scalars * mask.unsqueeze(-1)
             vectors = vectors * mask.unsqueeze(-1).unsqueeze(-1)
 
-        if self.edge_scalar_proj is not None and edge_scalars.numel():
-            proj_dtype = self.edge_scalar_proj.weight.dtype
-            edge_scalars_projected = self.edge_scalar_proj(edge_scalars.to(proj_dtype)).to(edge_scalars.dtype)
-        elif self.edge_scalar_proj is not None:
-            edge_scalars_projected = edge_scalars.new_zeros(
-                (edge_scalars.shape[0], self.config.edge_scalar_dim)
-            )
+        edge_scalars = edges.scalars
+        if self.edge_scalar_proj is not None:
+            if edge_scalars.numel():
+                proj_dtype = self.edge_scalar_proj.weight.dtype
+                edge_scalars_projected = self.edge_scalar_proj(edge_scalars.to(proj_dtype)).to(edge_scalars.dtype)
+            else:
+                edge_scalars_projected = edge_scalars.new_zeros(
+                    (edge_scalars.shape[0], self.config.edge_scalar_dim)
+                )
         else:
             edge_scalars_projected = edge_scalars
 
@@ -326,10 +357,10 @@ class GCPNetEncoder(nn.Module):
             scalars, vectors = layer(
                 scalars,
                 vectors,
-                edge_index,
+                edges.edge_index,
                 edge_scalars_projected,
                 edge_vectors,
-                edge_frames,
+                frames,
             )
             if mask is not None:
                 scalars = scalars * mask.unsqueeze(-1)
@@ -340,11 +371,12 @@ class GCPNetEncoder(nn.Module):
         readout_dtype = self.readout[1].weight.dtype
         embeddings = self.readout(readout_input.to(readout_dtype)).to(scalars.dtype)
 
-        output: Dict[str, Tensor] = {
+        output: Dict[str, Union[Tensor, ProteinBatch]] = {
             "embeddings": embeddings,
             "node_scalars": scalars,
             "node_vectors": vectors,
         }
+        output["batch"] = batch
 
         if self.displacement_head is not None:
             disp_input_dtype = self.displacement_head[1].weight.dtype

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 from torch import Tensor, nn
 
+from gcpvqvae.data.batch import EdgeStorage, ProteinBatch, protein_batch_from_graph_dict
 from gcpvqvae.data.featurize import featurize_backbone
 from gcpvqvae.data.mmcif import PAD_INDEX, BackboneRecord, load_mmcif
 from gcpvqvae.models.decoder import RotationDecoder
@@ -227,28 +228,17 @@ class GCPVQVAE(nn.Module):
             mask = mask & ~batch["nan_mask"].to(torch.bool).to(device)
 
         coords = batch["coords"].to(device=device, dtype=dtype)
-        node_scalars = batch["node_scalars"].to(device=device, dtype=dtype)
-        node_vectors = batch["node_vectors"].to(device=device, dtype=dtype)
-        edge_index = batch["edge_index"].to(device=device)
-        edge_scalars = batch["edge_scalars"].to(device=device, dtype=dtype)
-        edge_vectors = batch["edge_vectors"].to(device=device, dtype=dtype)
-        edge_frames = batch["edge_frames"].to(device=device, dtype=dtype)
+        proto = protein_batch_from_graph_dict(batch)
+        proto = proto.to(device=device, dtype=dtype)
 
-        batch_size, max_len, _ = node_scalars.shape
-        flat_scalars = self._flatten_batch(node_scalars)
-        flat_vectors = self._flatten_batch(node_vectors)
-        flat_mask = mask.reshape(-1)
+        batch_size, max_len, _ = batch["node_scalars"].shape
 
-        gcp_out = self.encoder_gcp(
-            flat_scalars,
-            flat_vectors,
-            edge_index,
-            edge_scalars,
-            edge_vectors,
-            edge_frames,
-            mask=flat_mask,
-        )
-        embeddings = gcp_out["embeddings"].reshape(batch_size, max_len, -1)
+        gcp_out = self.encoder_gcp(proto)
+        flat_embeddings = gcp_out["embeddings"]
+        latent_dim = flat_embeddings.shape[-1]
+        padded = flat_embeddings.new_zeros((batch_size * max_len, latent_dim))
+        padded.index_copy_(0, proto.valid_indices, flat_embeddings)
+        embeddings = padded.reshape(batch_size, max_len, latent_dim)
         projected = self._project_embeddings(embeddings)
 
         enc_hidden = self.encoder_transformer(projected, mask=mask)
@@ -303,6 +293,7 @@ class GCPVQVAE(nn.Module):
         self,
         node_scalars: Tensor,
         node_vectors: Tensor,
+        ca_positions: Tensor,
         edge_index: Tensor,
         edge_scalars: Tensor,
         edge_vectors: Tensor,
@@ -319,16 +310,32 @@ class GCPVQVAE(nn.Module):
         edge_vectors = edge_vectors.to(device=device, dtype=dtype)
         edge_frames = edge_frames.to(device=device, dtype=dtype)
         mask = mask.to(device=device, dtype=torch.bool)
+        ca_positions = ca_positions.to(device=device, dtype=dtype)
 
-        gcp_out = self.encoder_gcp(
-            node_scalars,
-            node_vectors,
-            edge_index,
-            edge_scalars,
-            edge_vectors,
-            edge_frames,
+        proto = ProteinBatch(
+            h=node_scalars,
+            chi=node_vectors,
+            e={
+                "knn_k": EdgeStorage(
+                    edge_index=edge_index,
+                    scalars=edge_scalars,
+                    vectors=edge_vectors,
+                    frames=edge_frames,
+                    batch=None,
+                    name="knn_k",
+                )
+            },
+            xi=ca_positions,
+            batch=torch.zeros(node_scalars.shape[0], dtype=torch.long, device=node_scalars.device),
+            ptr=torch.tensor([0, node_scalars.shape[0]], device=node_scalars.device),
             mask=mask,
         )
+        proto.valid_indices = torch.arange(node_scalars.shape[0], device=node_scalars.device)
+        proto.full_mask = mask.unsqueeze(0)
+        proto.batch_size = 1
+        proto.max_length = node_scalars.shape[0]
+        proto = proto.to(device=device, dtype=dtype)
+        gcp_out = self.encoder_gcp(proto)
         embeddings = gcp_out["embeddings"].unsqueeze(0)
         projected = self._project_embeddings(embeddings)
         enc_hidden = self.encoder_transformer(projected, mask=mask.unsqueeze(0))
@@ -365,6 +372,7 @@ class GCPVQVAE(nn.Module):
             embeddings, enc_hidden, quantized, extras = self._run_encoder(
                 features["node_scalars"],
                 features["node_vectors"],
+                record.coords[:, 1, :],
                 features["edge_index"],
                 features["edge_scalars"],
                 features["edge_vectors"],

--- a/src/gcpvqvae/system/train_gcpnet.py
+++ b/src/gcpvqvae/system/train_gcpnet.py
@@ -19,6 +19,7 @@ from torch.utils.data import DataLoader
 from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
 from gcpvqvae.geometry.metrics import rmsd
 from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.data.batch import protein_batch_from_graph_dict
 from gcpvqvae.models.gcpnet import GCPNetConfig, GCPNetEncoder
 from gcpvqvae.models.gcpvqvae import RotationHeadConfig
 from gcpvqvae.models.losses import reconstruction_loss
@@ -239,28 +240,17 @@ class GCPNetPretrainModule(nn.Module):
             mask = mask & ~batch["nan_mask"].to(torch.bool)
 
         coords = batch["coords"]
-        node_scalars = batch["node_scalars"]
-        node_vectors = batch["node_vectors"]
-        edge_index = batch["edge_index"]
-        edge_scalars = batch["edge_scalars"]
-        edge_vectors = batch["edge_vectors"]
-        edge_frames = batch["edge_frames"]
+        proto = protein_batch_from_graph_dict(batch)
+        proto = proto.to(device=coords.device, dtype=coords.dtype)
 
-        batch_size, max_len, _ = node_scalars.shape
-        flat_scalars = node_scalars.reshape(batch_size * max_len, -1)
-        flat_vectors = node_vectors.reshape(batch_size * max_len, node_vectors.shape[2], node_vectors.shape[3])
-        flat_mask = mask.reshape(-1)
+        batch_size, max_len, _ = batch["node_scalars"].shape
 
-        gcp_out = self.encoder(
-            flat_scalars,
-            flat_vectors,
-            edge_index,
-            edge_scalars,
-            edge_vectors,
-            edge_frames,
-            mask=flat_mask,
-        )
-        embeddings = gcp_out["embeddings"].reshape(batch_size, max_len, -1)
+        gcp_out = self.encoder(proto)
+        flat_embeddings = gcp_out["embeddings"]
+        latent = flat_embeddings.shape[-1]
+        padded = flat_embeddings.new_zeros((batch_size * max_len, latent))
+        padded.index_copy_(0, proto.valid_indices, flat_embeddings)
+        embeddings = padded.reshape(batch_size, max_len, latent)
 
         recon_coords, pose = self.rotation(embeddings, mask=mask)
         rec_loss, rec_components = reconstruction_loss(

--- a/tests/test_gcpnet.py
+++ b/tests/test_gcpnet.py
@@ -1,5 +1,6 @@
 import torch
 
+from gcpvqvae.data.batch import EdgeStorage, ProteinBatch
 from gcpvqvae.models.gcpnet import (
     DEFAULT_EDGE_SCALAR_INPUT_DIM,
     GCPNetConfig,
@@ -22,16 +23,28 @@ def test_gcpnet_encoder_projects_edge_scalars_with_default_input_dim() -> None:
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]], dtype=torch.long)
     edge_scalars = torch.randn(edge_index.shape[1], DEFAULT_EDGE_SCALAR_INPUT_DIM)
     edge_vectors = torch.randn(edge_index.shape[1], config.edge_vector_dim, 3)
-    edge_frames = torch.randn(edge_index.shape[1], 3, 3)
+    edge_frames = torch.eye(3).expand(edge_index.shape[1], 3, 3).clone()
+    positions = torch.randn(num_nodes, 3)
 
-    output = encoder(
-        node_scalars,
-        node_vectors,
-        edge_index,
-        edge_scalars,
-        edge_vectors,
-        edge_frames,
+    proto = ProteinBatch(
+        h=node_scalars,
+        chi=node_vectors,
+        e={
+            "knn_k": EdgeStorage(
+                edge_index=edge_index,
+                scalars=edge_scalars,
+                vectors=edge_vectors,
+                frames=edge_frames,
+                batch=torch.zeros(edge_index.shape[1], dtype=torch.long),
+            )
+        },
+        xi=positions,
+        batch=torch.zeros(num_nodes, dtype=torch.long),
+        ptr=torch.tensor([0, num_nodes], dtype=torch.long),
+        mask=torch.ones(num_nodes, dtype=torch.bool),
     )
+
+    output = encoder(proto)
 
     assert output["embeddings"].shape == (num_nodes, config.latent_dim)
 
@@ -50,7 +63,7 @@ def test_gcpconv_supports_bfloat16_inputs() -> None:
     edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=torch.long)
     edge_scalars = torch.randn(edge_index.shape[1], conv.edge_scalar_dim, dtype=torch.bfloat16)
     edge_vectors = torch.randn(edge_index.shape[1], conv.edge_vector_channels, 3, dtype=torch.bfloat16)
-    edge_frames = torch.randn(edge_index.shape[1], 3, 3, dtype=torch.bfloat16)
+    edge_frames = torch.eye(3, dtype=torch.bfloat16).expand(edge_index.shape[1], 3, 3).clone()
 
     scalars_out, vectors_out = conv(
         node_scalars,
@@ -77,16 +90,28 @@ def test_gcpnet_encoder_supports_bfloat16_inputs() -> None:
     edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=torch.long)
     edge_scalars = torch.randn(num_edges, config.edge_scalar_dim, dtype=torch.bfloat16)
     edge_vectors = torch.randn(num_edges, config.edge_vector_dim, 3, dtype=torch.bfloat16)
-    edge_frames = torch.randn(num_edges, 3, 3, dtype=torch.bfloat16)
+    edge_frames = torch.eye(3, dtype=torch.bfloat16).expand(num_edges, 3, 3).clone()
+    positions = torch.randn(num_nodes, 3, dtype=torch.bfloat16)
 
-    outputs = encoder(
-        node_scalars,
-        node_vectors,
-        edge_index,
-        edge_scalars,
-        edge_vectors,
-        edge_frames,
+    proto = ProteinBatch(
+        h=node_scalars,
+        chi=node_vectors,
+        e={
+            "knn_k": EdgeStorage(
+                edge_index=edge_index,
+                scalars=edge_scalars,
+                vectors=edge_vectors,
+                frames=edge_frames,
+                batch=torch.zeros(num_edges, dtype=torch.long),
+            )
+        },
+        xi=positions,
+        batch=torch.zeros(num_nodes, dtype=torch.long),
+        ptr=torch.tensor([0, num_nodes], dtype=torch.long),
+        mask=torch.ones(num_nodes, dtype=torch.bool),
     )
+
+    outputs = encoder(proto)
 
     assert outputs["embeddings"].dtype is torch.bfloat16
     assert outputs["node_scalars"].dtype is torch.bfloat16


### PR DESCRIPTION
## Summary
- introduce reusable ProteinBatch and geometry utilities for handling batched protein graphs
- update the GCPNet encoder and model stack to preprocess ProteinBatch inputs, centralise coordinates, and scatter outputs back to padded layouts
- adapt training helpers and unit tests to build ProteinBatch instances and cover the new interface

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68df7cf3d6c88323b1319b726db4c77b