### PR TITLE
Refactor GCPNet configuration schema

### DIFF
--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -28,22 +28,37 @@ omitted the defaults listed below are applied by the underlying dataclasses.
 
 ### `model.gcp` – GCP encoder (`GCPNetConfig`)
 
-| key | default | description |
-| --- | --- | --- |
-| `node_scalar_dim` | `6` | Input scalar feature channels per residue. |
-| `node_vector_dim` | `3` | Input vector feature channels per residue. |
-| `edge_scalar_dim` | `8` | Scalar features attached to each edge. |
-| `edge_scalar_input_dim` | `null` | Optional raw dimensionality of edge scalar features (defaults to `edge_scalar_dim`). |
-| `edge_vector_dim` | `1` | Vector features per edge. |
-| `hidden_scalar_dim` | `128` | Scalar width of the hidden representations. |
-| `hidden_vector_dim` | `16` | Vector channel count inside the GCP blocks. |
-| `latent_dim` | `256` | Output embedding dimension fed to the Transformer. |
-| `layers` | `6` | Number of stacked GCP convolution layers. |
-| `dropout` | `0.0` | Dropout applied within the convolutions. |
-| `displacement_head` | `False` | Enables an auxiliary displacement prediction head. |
-| `init` | `"random"` | Select `"random"` for fresh weights or `"pretrained"` to load from a checkpoint. |
-| `init_checkpoint` | `null` | Filesystem path to the checkpoint containing pretrained GCPNet weights. |
-| `strict_init` | `True` | Whether to enforce an exact key match when loading weights. |
+The encoder settings are organised into nested blocks:
+
+- `embedding`
+  - `node_scalar_dim` (`49`): input scalar channels per residue.
+  - `node_vector_dim` (`2`): input vector channels per residue.
+  - `edge_scalar_dim` (`9`): scalar edge features produced by preprocessing.
+  - `edge_scalar_input_dim` (`8`): raw edge scalar dimensionality; defaults to the preprocessor output when omitted.
+  - `edge_vector_dim` (`1`): vector channels per edge.
+  - `edge_vector_input_dim` (`1`): raw edge vector dimensionality; defaults to `edge_vector_dim`.
+  - `output.scalar` (`128`) / `output.vector` (`16`): widths of the projected node features.
+- `message_passing`
+  - `width.scalar` (`128`) / `width.vector` (`16`): working representation sizes inside the interaction blocks.
+  - `scalar_bottleneck_factor` (`0.5`): fraction used for the inner scalar bottleneck in the residual message passing stack.
+  - `vector_bottleneck_factor` (`0.5`): analogous factor for vector channels.
+  - `pooling` (`"mean"`): aggregation mode used when forming skip connections (`"mean"` or `"sum"`).
+- `feed_forward`
+  - `width.scalar` (`256`) / `width.vector` (`16`): hidden widths for the residual feed-forward stack.
+
+Additional top-level options control auxiliary behaviour:
+
+- `latent_dim` (`128`): encoder output width fed into the transformer stack.
+- `num_layers` (`6`): number of stacked interaction layers.
+- `dropout` (`0.0`): scalar/vector dropout probability within the GCP blocks.
+- `vector_gate` (`True`): enables scalar-gated vector updates.
+- `enable_e3_equivariance` (`True`): keeps vector updates E(3)-equivariant.
+- `node_inputs` (`True`): whether to include node features in message updates.
+- `predict_node_positions` (`False`): exposes the optional displacement head when `True`.
+- `predict_node_rep` (`False`): placeholder controlling auxiliary representation heads.
+- `use_gcp_dropout` (`True`): selects coupled scalar/vector dropout; disable to fall back to independent dropout.
+- `norm_pos_diff` (`False`): toggles normalisation of positional differences.
+- `init` (`"random"`), `init_checkpoint` (`null`), `strict_init` (`True`): checkpoint initialisation controls.
 
 ### `model.adapter` – Latent projection (`LatentAdapterConfig`)
 

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -10,13 +10,36 @@ data:
 
 model:
   gcp:
-    hidden_scalar_dim: 128
-    hidden_vector_dim: 16
-    edge_scalar_dim: 32
-    edge_scalar_input_dim: 8
-    edge_vector_dim: 1
-    latent_dim: 256
-    layers: 6
+    embedding:
+      node_scalar_dim: 49
+      node_vector_dim: 2
+      edge_scalar_dim: 9
+      edge_scalar_input_dim: 8
+      edge_vector_dim: 1
+      output:
+        scalar: 128
+        vector: 16
+    message_passing:
+      width:
+        scalar: 128
+        vector: 16
+      scalar_bottleneck_factor: 0.5
+      vector_bottleneck_factor: 0.5
+      pooling: mean
+    feed_forward:
+      width:
+        scalar: 256
+        vector: 16
+    latent_dim: 128
+    num_layers: 6
+    dropout: 0.0
+    vector_gate: true
+    enable_e3_equivariance: true
+    node_inputs: true
+    predict_node_positions: false
+    predict_node_rep: false
+    use_gcp_dropout: true
+    norm_pos_diff: false
     init: random
     init_checkpoint: null
     strict_init: true

--- a/src/gcpvqvae/configs/gcpnet_pretrain.yaml
+++ b/src/gcpvqvae/configs/gcpnet_pretrain.yaml
@@ -10,13 +10,36 @@ data:
 
 model:
   gcp:
-    hidden_scalar_dim: 128
-    hidden_vector_dim: 16
-    edge_scalar_dim: 32
-    edge_scalar_input_dim: 8
-    edge_vector_dim: 1
-    latent_dim: 256
-    layers: 6
+    embedding:
+      node_scalar_dim: 49
+      node_vector_dim: 2
+      edge_scalar_dim: 9
+      edge_scalar_input_dim: 8
+      edge_vector_dim: 1
+      output:
+        scalar: 128
+        vector: 16
+    message_passing:
+      width:
+        scalar: 128
+        vector: 16
+      scalar_bottleneck_factor: 0.5
+      vector_bottleneck_factor: 0.5
+      pooling: mean
+    feed_forward:
+      width:
+        scalar: 256
+        vector: 16
+    latent_dim: 128
+    num_layers: 6
+    dropout: 0.0
+    vector_gate: true
+    enable_e3_equivariance: true
+    node_inputs: true
+    predict_node_positions: false
+    predict_node_rep: false
+    use_gcp_dropout: true
+    norm_pos_diff: false
   rotation:
     input_dim: null
     translation_scale: 1.0

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -8,13 +8,36 @@ data:
 
 model:
   gcp:
-    hidden_scalar_dim: 128
-    hidden_vector_dim: 16
-    edge_scalar_dim: 32
-    edge_scalar_input_dim: 8
-    edge_vector_dim: 1
-    latent_dim: 256
-    layers: 6
+    embedding:
+      node_scalar_dim: 49
+      node_vector_dim: 2
+      edge_scalar_dim: 9
+      edge_scalar_input_dim: 8
+      edge_vector_dim: 1
+      output:
+        scalar: 128
+        vector: 16
+    message_passing:
+      width:
+        scalar: 128
+        vector: 16
+      scalar_bottleneck_factor: 0.5
+      vector_bottleneck_factor: 0.5
+      pooling: mean
+    feed_forward:
+      width:
+        scalar: 256
+        vector: 16
+    latent_dim: 128
+    num_layers: 6
+    dropout: 0.0
+    vector_gate: true
+    enable_e3_equivariance: true
+    node_inputs: true
+    predict_node_positions: false
+    predict_node_rep: false
+    use_gcp_dropout: true
+    norm_pos_diff: false
     init: random
     init_checkpoint: null
     strict_init: true

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -9,13 +9,36 @@ data:
 
 model:
   gcp:
-    hidden_scalar_dim: 128
-    hidden_vector_dim: 16
-    edge_scalar_dim: 32
-    edge_scalar_input_dim: 8
-    edge_vector_dim: 1
-    latent_dim: 256
-    layers: 6
+    embedding:
+      node_scalar_dim: 49
+      node_vector_dim: 2
+      edge_scalar_dim: 9
+      edge_scalar_input_dim: 8
+      edge_vector_dim: 1
+      output:
+        scalar: 128
+        vector: 16
+    message_passing:
+      width:
+        scalar: 128
+        vector: 16
+      scalar_bottleneck_factor: 0.5
+      vector_bottleneck_factor: 0.5
+      pooling: mean
+    feed_forward:
+      width:
+        scalar: 256
+        vector: 16
+    latent_dim: 128
+    num_layers: 6
+    dropout: 0.0
+    vector_gate: true
+    enable_e3_equivariance: true
+    node_inputs: true
+    predict_node_positions: false
+    predict_node_rep: false
+    use_gcp_dropout: true
+    norm_pos_diff: false
     init: random
     init_checkpoint: null
     strict_init: true

--- a/src/gcpvqvae/models/gcpnet.py
+++ b/src/gcpvqvae/models/gcpnet.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Optional, Tuple, Union
 
 import torch
@@ -150,6 +150,33 @@ class GCPDropout(nn.Module):
         return ScalarVector(scalars, vectors)
 
 
+class IdentityGCPDropout(nn.Module):
+    """No-op replacement for :class:`GCPDropout`."""
+
+    def forward(self, features: ScalarVector) -> ScalarVector:  # pragma: no cover - simple passthrough
+        return features
+
+
+class StandardGCPDropout(nn.Module):
+    """Fallback dropout that treats scalar/vector components independently."""
+
+    def __init__(self, p: float) -> None:
+        super().__init__()
+        self.scalar = nn.Dropout(p) if p > 0.0 else None
+        self.vector = nn.Dropout(p) if p > 0.0 else None
+
+    def forward(self, features: ScalarVector) -> ScalarVector:
+        scalars = features.scalars
+        vectors = features.vectors
+        if self.scalar is not None:
+            scalars = self.scalar(scalars)
+        if self.vector is not None and vectors.numel() > 0:
+            shape = vectors.shape
+            dropped = self.vector(vectors.view(shape[0], -1))
+            vectors = dropped.view(shape)
+        return ScalarVector(scalars, vectors)
+
+
 class GCPEmbedding(nn.Module):
     """Project raw node and edge features to the working feature spaces."""
 
@@ -157,20 +184,30 @@ class GCPEmbedding(nn.Module):
         super().__init__()
 
         self.config = config
+        embedding_cfg = config.embedding
+        output_scalar = embedding_cfg.output.scalar
+        output_vector = embedding_cfg.output.vector
+        if output_scalar is None or output_vector is None:
+            raise ValueError("Embedding output widths must be initialised before encoder construction")
+
         self.edge_scalar_in_dim = (
-            config.edge_scalar_input_dim if config.edge_scalar_input_dim is not None else config.edge_scalar_dim
+            embedding_cfg.edge_scalar_input_dim
+            if embedding_cfg.edge_scalar_input_dim is not None
+            else embedding_cfg.edge_scalar_dim
         )
         self.edge_vector_in_dim = (
-            config.edge_vector_input_dim if config.edge_vector_input_dim is not None else config.edge_vector_dim
+            embedding_cfg.edge_vector_input_dim
+            if embedding_cfg.edge_vector_input_dim is not None
+            else embedding_cfg.edge_vector_dim
         )
 
         self.node_scalar_proj = nn.Linear(
-            config.node_scalar_dim,
-            config.hidden_scalar_dim,
+            embedding_cfg.node_scalar_dim,
+            output_scalar,
             bias=False,
         )
         self.node_vector_proj = nn.Parameter(
-            torch.randn(config.hidden_vector_dim, config.node_vector_dim) * 0.02
+            torch.randn(output_vector, embedding_cfg.node_vector_dim) * 0.02
         )
 
         self.num_rbf = 16
@@ -180,11 +217,11 @@ class GCPEmbedding(nn.Module):
 
         self.edge_scalar_proj = nn.Linear(
             self.edge_scalar_in_dim + self.num_rbf,
-            config.edge_scalar_dim,
+            embedding_cfg.edge_scalar_dim,
             bias=False,
         )
         self.edge_vector_proj = nn.Parameter(
-            torch.randn(config.edge_vector_dim, self.edge_vector_in_dim) * 0.02
+            torch.randn(embedding_cfg.edge_vector_dim, self.edge_vector_in_dim) * 0.02
         )
 
     def _gaussian_rbf(self, distances: Tensor) -> Tensor:
@@ -468,8 +505,17 @@ class GCPMessagePassing(nn.Module):
         edge_scalar_dim = config.edge_scalar_dim
         edge_vector_dim = config.edge_vector_dim
 
-        bottleneck_scalar = max(1, scalar_dim // 2)
-        bottleneck_vector = max(1, vector_dim // 2)
+        mp_cfg = config.message_passing
+        if mp_cfg.scalar_bottleneck_factor > 0.0:
+            bottleneck_scalar = max(1, int(round(scalar_dim * mp_cfg.scalar_bottleneck_factor)))
+        else:
+            bottleneck_scalar = scalar_dim
+        if mp_cfg.vector_bottleneck_factor > 0.0:
+            bottleneck_vector = max(1, int(round(vector_dim * mp_cfg.vector_bottleneck_factor)))
+        else:
+            bottleneck_vector = vector_dim
+
+        self.pooling = mp_cfg.pooling
 
         self.layers = nn.ModuleList(
             [
@@ -555,12 +601,16 @@ class GCPMessagePassing(nn.Module):
 
         scalar_input = features.scalars.to(compute_dtype)
         agg_scalars = torch.sparse.mm(adjacency, scalar_input)
-        agg_scalars = (agg_scalars / degree).to(dtype)
+        if self.pooling == "mean":
+            agg_scalars = agg_scalars / degree
+        agg_scalars = agg_scalars.to(dtype)
 
         vector_shape = features.vectors.shape
         vectors_flat = features.vectors.reshape(num_nodes, -1).to(compute_dtype)
         agg_vectors_flat = torch.sparse.mm(adjacency, vectors_flat)
-        agg_vectors_flat = (agg_vectors_flat / degree).to(features.vectors.dtype)
+        if self.pooling == "mean":
+            agg_vectors_flat = agg_vectors_flat / degree
+        agg_vectors_flat = agg_vectors_flat.to(features.vectors.dtype)
         agg_vectors = agg_vectors_flat.view(vector_shape)
 
         if mask is not None:
@@ -588,26 +638,165 @@ class GCPMessagePassing(nn.Module):
 
 
 @dataclass
-class GCPNetConfig:
-    node_scalar_dim: int = 6
-    node_vector_dim: int = 3
-    edge_scalar_dim: int = 32
+class GCPWidthConfig:
+    """Scalar/vector width pair used across the encoder."""
+
+    scalar: Optional[int] = None
+    vector: Optional[int] = None
+
+
+@dataclass
+class GCPEmbeddingConfig:
+    """Input and projection dimensions for the embedding stage."""
+
+    node_scalar_dim: int = 49
+    node_vector_dim: int = 2
+    edge_scalar_dim: int = 9
     edge_scalar_input_dim: Optional[int] = DEFAULT_EDGE_SCALAR_INPUT_DIM
-    edge_vector_dim: int = 4
+    edge_vector_dim: int = 1
     edge_vector_input_dim: Optional[int] = 1
-    hidden_scalar_dim: int = 128
-    hidden_vector_dim: int = 16
-    latent_dim: int = 256
-    layers: int = 6
+    output: GCPWidthConfig = field(default_factory=GCPWidthConfig)
+
+
+@dataclass
+class GCPMessagePassingConfig:
+    """Widths and aggregation behaviour for message passing blocks."""
+
+    width: GCPWidthConfig = field(default_factory=lambda: GCPWidthConfig(scalar=128, vector=16))
+    scalar_bottleneck_factor: float = 0.5
+    vector_bottleneck_factor: float = 0.5
+    pooling: str = "mean"
+
+
+@dataclass
+class GCPFeedForwardConfig:
+    """Hidden widths inside the residual feed-forward stack."""
+
+    width: GCPWidthConfig = field(default_factory=GCPWidthConfig)
+
+
+@dataclass
+class GCPNetConfig:
+    embedding: GCPEmbeddingConfig = field(default_factory=GCPEmbeddingConfig)
+    message_passing: GCPMessagePassingConfig = field(default_factory=GCPMessagePassingConfig)
+    feed_forward: GCPFeedForwardConfig = field(default_factory=GCPFeedForwardConfig)
+    latent_dim: int = 128
+    num_layers: int = 6
     dropout: float = 0.0
     vector_gate: bool = True
     enable_e3_equivariance: bool = True
     node_inputs: bool = True
-    displacement_head: bool = False
+    predict_node_positions: bool = False
+    predict_node_rep: bool = False
+    use_gcp_dropout: bool = True
+    norm_pos_diff: bool = False
     prenorm: bool = True
     init: str = "random"
     init_checkpoint: Optional[str] = None
     strict_init: bool = True
+
+    def __post_init__(self) -> None:
+        if self.message_passing.width.scalar is None:
+            self.message_passing.width.scalar = 128
+        if self.message_passing.width.vector is None:
+            self.message_passing.width.vector = 16
+        if self.embedding.output.scalar is None:
+            self.embedding.output.scalar = self.message_passing.width.scalar
+        if self.embedding.output.vector is None:
+            self.embedding.output.vector = self.message_passing.width.vector
+        if self.feed_forward.width.scalar is None:
+            self.feed_forward.width.scalar = self.message_passing.width.scalar * 2
+        if self.feed_forward.width.vector is None:
+            self.feed_forward.width.vector = self.message_passing.width.vector
+        if self.embedding.edge_scalar_input_dim is None:
+            self.embedding.edge_scalar_input_dim = self.embedding.edge_scalar_dim
+        if self.embedding.edge_vector_input_dim is None:
+            self.embedding.edge_vector_input_dim = self.embedding.edge_vector_dim
+
+        if self.embedding.output.scalar != self.message_passing.width.scalar:
+            raise ValueError("embedding.output.scalar must match message_passing.width.scalar")
+        if self.embedding.output.vector != self.message_passing.width.vector:
+            raise ValueError("embedding.output.vector must match message_passing.width.vector")
+
+        if self.embedding.node_scalar_dim <= 0:
+            raise ValueError("embedding.node_scalar_dim must be positive")
+        if self.embedding.node_vector_dim <= 0:
+            raise ValueError("embedding.node_vector_dim must be positive")
+        if self.embedding.edge_scalar_dim <= 0:
+            raise ValueError("embedding.edge_scalar_dim must be positive")
+        if self.embedding.edge_vector_dim <= 0:
+            raise ValueError("embedding.edge_vector_dim must be positive")
+        if self.embedding.output.scalar is None or self.embedding.output.scalar <= 0:
+            raise ValueError("embedding.output.scalar must be a positive integer")
+        if self.embedding.output.vector is None or self.embedding.output.vector <= 0:
+            raise ValueError("embedding.output.vector must be a positive integer")
+        if self.message_passing.width.scalar is None or self.message_passing.width.scalar <= 0:
+            raise ValueError("message_passing.width.scalar must be a positive integer")
+        if self.message_passing.width.vector is None or self.message_passing.width.vector <= 0:
+            raise ValueError("message_passing.width.vector must be a positive integer")
+        if self.feed_forward.width.scalar is None or self.feed_forward.width.scalar <= 0:
+            raise ValueError("feed_forward.width.scalar must be a positive integer")
+        if self.feed_forward.width.vector is None or self.feed_forward.width.vector <= 0:
+            raise ValueError("feed_forward.width.vector must be a positive integer")
+        if self.latent_dim <= 0:
+            raise ValueError("latent_dim must be positive")
+        if self.num_layers <= 0:
+            raise ValueError("num_layers must be positive")
+
+        pooling = self.message_passing.pooling.lower()
+        if pooling not in {"mean", "sum"}:
+            raise ValueError("message_passing.pooling must be either 'mean' or 'sum'")
+        self.message_passing.pooling = pooling
+
+    @property
+    def node_scalar_dim(self) -> int:
+        return self.embedding.node_scalar_dim
+
+    @property
+    def node_vector_dim(self) -> int:
+        return self.embedding.node_vector_dim
+
+    @property
+    def edge_scalar_dim(self) -> int:
+        return self.embedding.edge_scalar_dim
+
+    @property
+    def edge_scalar_input_dim(self) -> int:
+        value = self.embedding.edge_scalar_input_dim
+        return value if value is not None else self.embedding.edge_scalar_dim
+
+    @property
+    def edge_vector_dim(self) -> int:
+        return self.embedding.edge_vector_dim
+
+    @property
+    def edge_vector_input_dim(self) -> int:
+        value = self.embedding.edge_vector_input_dim
+        return value if value is not None else self.embedding.edge_vector_dim
+
+    @property
+    def hidden_scalar_dim(self) -> int:
+        assert self.message_passing.width.scalar is not None
+        return self.message_passing.width.scalar
+
+    @property
+    def hidden_vector_dim(self) -> int:
+        assert self.message_passing.width.vector is not None
+        return self.message_passing.width.vector
+
+    @property
+    def feed_forward_scalar_dim(self) -> int:
+        assert self.feed_forward.width.scalar is not None
+        return self.feed_forward.width.scalar
+
+    @property
+    def feed_forward_vector_dim(self) -> int:
+        assert self.feed_forward.width.vector is not None
+        return self.feed_forward.width.vector
+
+    @property
+    def layers(self) -> int:
+        return self.num_layers
 
 
 class GCPInteractions(nn.Module):
@@ -625,7 +814,13 @@ class GCPInteractions(nn.Module):
         ) if self.prenorm else None
 
         self.message_passing = GCPMessagePassing(config)
-        self.residual_dropout = GCPDropout(config.dropout)
+        if config.dropout > 0.0:
+            if config.use_gcp_dropout:
+                self.residual_dropout: nn.Module = GCPDropout(config.dropout)
+            else:
+                self.residual_dropout = StandardGCPDropout(config.dropout)
+        else:
+            self.residual_dropout = IdentityGCPDropout()
 
         self.skip_proj = nn.Linear(config.hidden_scalar_dim * 2, config.hidden_scalar_dim, bias=False)
         self.skip_vector_proj = nn.Parameter(
@@ -639,8 +834,8 @@ class GCPInteractions(nn.Module):
                     config.hidden_vector_dim,
                     edge_scalar_dim=config.edge_scalar_dim,
                     edge_vector_channels=config.edge_vector_dim,
-                    hidden_scalar_dim=config.hidden_scalar_dim * 2,
-                    hidden_vector_channels=config.hidden_vector_dim,
+                    hidden_scalar_dim=config.feed_forward_scalar_dim,
+                    hidden_vector_channels=config.feed_forward_vector_dim,
                     dropout=config.dropout,
                     vector_gate=config.vector_gate,
                     enable_e3_equivariance=config.enable_e3_equivariance,
@@ -651,8 +846,8 @@ class GCPInteractions(nn.Module):
                     config.hidden_vector_dim,
                     edge_scalar_dim=config.edge_scalar_dim,
                     edge_vector_channels=config.edge_vector_dim,
-                    hidden_scalar_dim=config.hidden_scalar_dim * 2,
-                    hidden_vector_channels=config.hidden_vector_dim,
+                    hidden_scalar_dim=config.feed_forward_scalar_dim,
+                    hidden_vector_channels=config.feed_forward_vector_dim,
                     dropout=config.dropout,
                     vector_gate=config.vector_gate,
                     enable_e3_equivariance=config.enable_e3_equivariance,
@@ -661,9 +856,15 @@ class GCPInteractions(nn.Module):
             ]
         )
 
-        self.feedforward_dropout = GCPDropout(config.dropout)
+        if config.dropout > 0.0:
+            if config.use_gcp_dropout:
+                self.feedforward_dropout: nn.Module = GCPDropout(config.dropout)
+            else:
+                self.feedforward_dropout = StandardGCPDropout(config.dropout)
+        else:
+            self.feedforward_dropout = IdentityGCPDropout()
 
-        if config.displacement_head:
+        if config.predict_node_positions:
             self.node_position_head = nn.Linear(config.hidden_scalar_dim, 3, bias=False)
         else:
             self.node_position_head = None
@@ -734,13 +935,13 @@ class GCPNetEncoder(nn.Module):
 
         self.config = config or GCPNetConfig()
 
-        if self.config.edge_scalar_input_dim is None:
-            self.config.edge_scalar_input_dim = self.config.edge_scalar_dim
-        if self.config.edge_vector_input_dim is None:
-            self.config.edge_vector_input_dim = self.config.edge_vector_dim
+        if self.config.embedding.edge_scalar_input_dim is None:
+            self.config.embedding.edge_scalar_input_dim = self.config.embedding.edge_scalar_dim
+        if self.config.embedding.edge_vector_input_dim is None:
+            self.config.embedding.edge_vector_input_dim = self.config.embedding.edge_vector_dim
 
         self.embedding = GCPEmbedding(self.config)
-        num_layers = self.config.layers if self.config.layers is not None else 6
+        num_layers = self.config.num_layers
         self.interactions = nn.ModuleList(
             [GCPInteractions(self.config) for _ in range(num_layers)]
         )
@@ -847,6 +1048,10 @@ class GCPNetEncoder(nn.Module):
 __all__ = [
     "GCPNetEncoder",
     "GCPNetConfig",
+    "GCPWidthConfig",
+    "GCPEmbeddingConfig",
+    "GCPMessagePassingConfig",
+    "GCPFeedForwardConfig",
     "GCPConv",
     "GCPLayerNorm",
     "GCPDropout",

--- a/src/gcpvqvae/system/configuration.py
+++ b/src/gcpvqvae/system/configuration.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised when hydra is absent
 
 import yaml
 
+from gcpvqvae.models.gcpnet import GCPNetConfig
 from gcpvqvae.models.gcpvqvae import GCPVQVAEConfig
 
 
@@ -29,11 +30,50 @@ DEFAULT_TRAIN_CONFIG_PATH = _CONFIG_DIR / "base.yaml"
 DEFAULT_GCPNET_PRETRAIN_CONFIG_PATH = _CONFIG_DIR / "gcpnet_pretrain.yaml"
 
 
+def _migrate_gcpnet_config(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Upgrade legacy flat keys to the nested GCPNet configuration schema."""
+
+    mapping: Dict[str, tuple[str, ...]] = {
+        "node_scalar_dim": ("embedding", "node_scalar_dim"),
+        "node_vector_dim": ("embedding", "node_vector_dim"),
+        "edge_scalar_dim": ("embedding", "edge_scalar_dim"),
+        "edge_vector_dim": ("embedding", "edge_vector_dim"),
+        "edge_scalar_input_dim": ("embedding", "edge_scalar_input_dim"),
+        "edge_vector_input_dim": ("embedding", "edge_vector_input_dim"),
+        "hidden_scalar_dim": ("message_passing", "width", "scalar"),
+        "hidden_vector_dim": ("message_passing", "width", "vector"),
+        "layers": ("num_layers",),
+        "displacement_head": ("predict_node_positions",),
+    }
+
+    upgraded = dict(data)
+    for legacy_key, path in mapping.items():
+        if legacy_key not in upgraded:
+            continue
+        value = upgraded.pop(legacy_key)
+        cursor = upgraded
+        for part in path[:-1]:
+            existing = cursor.get(part)
+            if existing is None or not isinstance(existing, dict):
+                existing = {}
+                cursor[part] = existing
+            cursor = existing
+        final_key = path[-1]
+        if final_key in cursor:
+            continue
+        cursor[final_key] = value
+
+    return upgraded
+
+
 def update_dataclass(instance: Any, updates: Dict[str, Any]) -> Any:
     """Recursively apply ``updates`` to a dataclass ``instance``."""
 
     if not dataclasses.is_dataclass(instance) or not isinstance(updates, dict):
         return instance
+
+    if isinstance(instance, GCPNetConfig):
+        updates = _migrate_gcpnet_config(dict(updates))
 
     for key, value in updates.items():
         if not hasattr(instance, key):
@@ -56,6 +96,8 @@ def build_model_config(raw: Optional[Dict[str, Any]]) -> GCPVQVAEConfig:
                 continue
             current = getattr(config, key)
             if dataclasses.is_dataclass(current):
+                if key == "gcp" and isinstance(value, dict):
+                    value = _migrate_gcpnet_config(value)
                 setattr(config, key, update_dataclass(current, value))
             else:
                 setattr(config, key, value)

--- a/tests/test_cli_config_validation.py
+++ b/tests/test_cli_config_validation.py
@@ -23,12 +23,17 @@ def _base_config() -> dict:
         },
         "model": {
             "gcp": {
-                "hidden_scalar_dim": 32,
-                "hidden_vector_dim": 8,
-                "edge_scalar_dim": 4,
-                "edge_vector_dim": 1,
+                "embedding": {
+                    "node_scalar_dim": 6,
+                    "node_vector_dim": 3,
+                    "edge_scalar_dim": 4,
+                    "edge_vector_dim": 1,
+                    "output": {"scalar": 32, "vector": 8},
+                },
+                "message_passing": {"width": {"scalar": 32, "vector": 8}},
+                "feed_forward": {"width": {"scalar": 64, "vector": 8}},
                 "latent_dim": 64,
-                "layers": 2,
+                "num_layers": 2,
             },
             "vq": {
                 "num_codes": 32,

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -11,9 +11,15 @@ from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
 from gcpvqvae.geometry.frames import kabsch_align
 from gcpvqvae.geometry.metrics import rmsd
 from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.gcpnet import (
+    GCPEmbeddingConfig,
+    GCPFeedForwardConfig,
+    GCPMessagePassingConfig,
+    GCPNetConfig,
+    GCPWidthConfig,
+)
 from gcpvqvae.models.gcpvqvae import (
     DataPipelineConfig,
-    GCPNetConfig,
     GCPVQVAE,
     GCPVQVAEConfig,
     RotationHeadConfig,
@@ -59,12 +65,17 @@ def _build_roundtrip_structure(path: Path) -> None:
 
 def _make_small_config() -> GCPVQVAEConfig:
     gcp_cfg = GCPNetConfig(
-        hidden_scalar_dim=32,
-        hidden_vector_dim=4,
-        edge_scalar_dim=8,
-        edge_vector_dim=1,
+        embedding=GCPEmbeddingConfig(
+            node_scalar_dim=6,
+            node_vector_dim=3,
+            edge_scalar_dim=8,
+            edge_vector_dim=1,
+            output=GCPWidthConfig(scalar=32, vector=4),
+        ),
+        message_passing=GCPMessagePassingConfig(width=GCPWidthConfig(scalar=32, vector=4)),
+        feed_forward=GCPFeedForwardConfig(width=GCPWidthConfig(scalar=64, vector=4)),
         latent_dim=32,
-        layers=2,
+        num_layers=2,
     )
     vq_cfg = VectorQuantizerConfig(num_codes=16, dim=32, beta=0.25, decay=0.9, kmeans_iters=1)
     enc_cfg = TransformerConfig(

--- a/tests/test_gcpnet.py
+++ b/tests/test_gcpnet.py
@@ -4,8 +4,11 @@ from gcpvqvae.data.batch import EdgeStorage, ProteinBatch
 from gcpvqvae.models.gcpnet import (
     DEFAULT_EDGE_SCALAR_INPUT_DIM,
     GCPConv,
+    GCPFeedForwardConfig,
+    GCPMessagePassingConfig,
     GCPNetConfig,
     GCPNetEncoder,
+    GCPWidthConfig,
     ScalarVector,
 )
 from gcpvqvae.system.train_gcpnet import _prepare_model_config
@@ -63,8 +66,8 @@ def test_gcpconv_supports_bfloat16_inputs() -> None:
         config.hidden_vector_dim,
         edge_scalar_dim=config.edge_scalar_dim,
         edge_vector_channels=config.edge_vector_dim,
-        hidden_scalar_dim=config.hidden_scalar_dim * 2,
-        hidden_vector_channels=config.hidden_vector_dim,
+        hidden_scalar_dim=config.feed_forward_scalar_dim,
+        hidden_vector_channels=config.feed_forward_vector_dim,
         dropout=config.dropout,
     )
 
@@ -85,7 +88,12 @@ def test_gcpconv_supports_bfloat16_inputs() -> None:
 
 
 def test_gcpnet_encoder_supports_bfloat16_inputs() -> None:
-    config = GCPNetConfig(layers=2, hidden_scalar_dim=16, hidden_vector_dim=8, latent_dim=32)
+    config = GCPNetConfig(
+        message_passing=GCPMessagePassingConfig(width=GCPWidthConfig(scalar=16, vector=8)),
+        feed_forward=GCPFeedForwardConfig(width=GCPWidthConfig(scalar=32, vector=8)),
+        latent_dim=32,
+        num_layers=2,
+    )
     encoder = GCPNetEncoder(config)
 
     num_nodes = 5

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -8,7 +8,13 @@ import torch
 
 from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
 from gcpvqvae.data.mmcif import BackboneRecord, write_mmcif
-from gcpvqvae.models.gcpnet import GCPNetConfig
+from gcpvqvae.models.gcpnet import (
+    GCPEmbeddingConfig,
+    GCPFeedForwardConfig,
+    GCPMessagePassingConfig,
+    GCPNetConfig,
+    GCPWidthConfig,
+)
 from gcpvqvae.models.gcpvqvae import (
     DataPipelineConfig,
     GCPVQVAE,
@@ -77,10 +83,17 @@ def _build_test_structure(path: Path) -> None:
 
 def _make_config() -> GCPVQVAEConfig:
     gcp_cfg = GCPNetConfig(
-        hidden_scalar_dim=64,
-        hidden_vector_dim=8,
+        embedding=GCPEmbeddingConfig(
+            node_scalar_dim=6,
+            node_vector_dim=3,
+            edge_scalar_dim=8,
+            edge_vector_dim=1,
+            output=GCPWidthConfig(scalar=64, vector=8),
+        ),
+        message_passing=GCPMessagePassingConfig(width=GCPWidthConfig(scalar=64, vector=8)),
+        feed_forward=GCPFeedForwardConfig(width=GCPWidthConfig(scalar=128, vector=8)),
         latent_dim=32,
-        layers=2,
+        num_layers=2,
     )
     vq_cfg = VectorQuantizerConfig(num_codes=32, dim=24, beta=0.25, decay=0.9, kmeans_iters=1)
     enc_cfg = TransformerConfig(
@@ -170,13 +183,18 @@ def test_latent_adapter_projects_embeddings(tmp_path) -> None:
     batch = collate_backbones([dataset[0]])
 
     gcp_cfg = GCPNetConfig(
-        hidden_scalar_dim=128,
-        hidden_vector_dim=16,
-        edge_scalar_dim=32,
-        edge_scalar_input_dim=8,
-        edge_vector_dim=1,
+        embedding=GCPEmbeddingConfig(
+            node_scalar_dim=6,
+            node_vector_dim=3,
+            edge_scalar_dim=8,
+            edge_scalar_input_dim=8,
+            edge_vector_dim=1,
+            output=GCPWidthConfig(scalar=128, vector=16),
+        ),
+        message_passing=GCPMessagePassingConfig(width=GCPWidthConfig(scalar=128, vector=16)),
+        feed_forward=GCPFeedForwardConfig(width=GCPWidthConfig(scalar=256, vector=16)),
         latent_dim=256,
-        layers=3,
+        num_layers=3,
     )
     adapter_cfg = LatentAdapterConfig(enabled=True, output_dim=32, bias=True)
     vq_cfg = VectorQuantizerConfig(num_codes=16, dim=24, beta=0.25, decay=0.9, kmeans_iters=1)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -61,12 +61,17 @@ def test_training_harness_runs_single_stage(tmp_path):
         },
         "model": {
             "gcp": {
-                "hidden_scalar_dim": 32,
-                "hidden_vector_dim": 4,
-                "edge_scalar_dim": 8,
-                "edge_vector_dim": 1,
+                "embedding": {
+                    "node_scalar_dim": 6,
+                    "node_vector_dim": 3,
+                    "edge_scalar_dim": 8,
+                    "edge_vector_dim": 1,
+                    "output": {"scalar": 32, "vector": 4},
+                },
+                "message_passing": {"width": {"scalar": 32, "vector": 4}},
+                "feed_forward": {"width": {"scalar": 64, "vector": 4}},
                 "latent_dim": 64,
-                "layers": 2,
+                "num_layers": 2,
             },
             "vq": {
                 "num_codes": 64,
@@ -140,12 +145,17 @@ def test_training_with_preprocessed_dataset(tmp_path):
         },
         "model": {
             "gcp": {
-                "hidden_scalar_dim": 32,
-                "hidden_vector_dim": 4,
-                "edge_scalar_dim": 8,
-                "edge_vector_dim": 1,
+                "embedding": {
+                    "node_scalar_dim": 6,
+                    "node_vector_dim": 3,
+                    "edge_scalar_dim": 8,
+                    "edge_vector_dim": 1,
+                    "output": {"scalar": 32, "vector": 4},
+                },
+                "message_passing": {"width": {"scalar": 32, "vector": 4}},
+                "feed_forward": {"width": {"scalar": 64, "vector": 4}},
                 "latent_dim": 64,
-                "layers": 2,
+                "num_layers": 2,
             },
             "vq": {
                 "num_codes": 64,
@@ -215,12 +225,17 @@ def test_training_on_cif_dataset_decreases_loss(tmp_path, monkeypatch):
         },
         "model": {
             "gcp": {
-                "hidden_scalar_dim": 16,
-                "hidden_vector_dim": 4,
-                "edge_scalar_dim": 8,
-                "edge_vector_dim": 1,
+                "embedding": {
+                    "node_scalar_dim": 6,
+                    "node_vector_dim": 3,
+                    "edge_scalar_dim": 8,
+                    "edge_vector_dim": 1,
+                    "output": {"scalar": 16, "vector": 4},
+                },
+                "message_passing": {"width": {"scalar": 16, "vector": 4}},
+                "feed_forward": {"width": {"scalar": 32, "vector": 4}},
                 "latent_dim": 16,
-                "layers": 2,
+                "num_layers": 2,
             },
             "vq": {
                 "num_codes": 16,
@@ -302,12 +317,17 @@ def test_training_with_eval_and_export(tmp_path, monkeypatch):
         },
         "model": {
             "gcp": {
-                "hidden_scalar_dim": 16,
-                "hidden_vector_dim": 4,
-                "edge_scalar_dim": 8,
-                "edge_vector_dim": 1,
+                "embedding": {
+                    "node_scalar_dim": 6,
+                    "node_vector_dim": 3,
+                    "edge_scalar_dim": 8,
+                    "edge_vector_dim": 1,
+                    "output": {"scalar": 16, "vector": 4},
+                },
+                "message_passing": {"width": {"scalar": 16, "vector": 4}},
+                "feed_forward": {"width": {"scalar": 32, "vector": 4}},
                 "latent_dim": 16,
-                "layers": 2,
+                "num_layers": 2,
             },
             "vq": {
                 "num_codes": 16,
@@ -434,12 +454,17 @@ def test_multi_stage_training_tracks_global_step(tmp_path, monkeypatch):
         },
         "model": {
             "gcp": {
-                "hidden_scalar_dim": 16,
-                "hidden_vector_dim": 4,
-                "edge_scalar_dim": 8,
-                "edge_vector_dim": 1,
+                "embedding": {
+                    "node_scalar_dim": 6,
+                    "node_vector_dim": 3,
+                    "edge_scalar_dim": 8,
+                    "edge_vector_dim": 1,
+                    "output": {"scalar": 16, "vector": 4},
+                },
+                "message_passing": {"width": {"scalar": 16, "vector": 4}},
+                "feed_forward": {"width": {"scalar": 32, "vector": 4}},
                 "latent_dim": 16,
-                "layers": 2,
+                "num_layers": 2,
             },
             "vq": {
                 "num_codes": 16,


### PR DESCRIPTION
## Summary
- replace the flat GCPNetConfig with nested embedding/message-passing/feed-forward width blocks and expose new flags
- update encoder implementation, configuration utilities, packaged YAML files, and documentation to match the expanded schema and defaults
- refresh unit tests and training helpers to consume the migrated configuration structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68df8b349e80832381b7b2e13a57f82e