### PR TITLE
Add regression test for loading GCPNet reference checkpoint

### DIFF
--- a/src/gcpvqvae/utils/checkpoint.py
+++ b/src/gcpvqvae/utils/checkpoint.py
@@ -16,10 +16,19 @@ def save_checkpoint(state: dict[str, Any], path: str | Path) -> None:
     torch.save(state, path_obj)
 
 
-def load_checkpoint(path: str | Path, *, map_location: Optional[str | torch.device] = None) -> dict[str, Any]:
+def load_checkpoint(
+    path: str | Path,
+    *,
+    map_location: Optional[str | torch.device] = None,
+) -> dict[str, Any]:
     """Load and return a previously saved training state."""
 
-    return torch.load(Path(path), map_location=map_location)
+    # ``torch.load`` defaulted ``weights_only`` to ``False`` prior to PyTorch 2.6,
+    # which allowed arbitrary Python objects (such as OmegaConf ``DictConfig``
+    # instances) to be deserialised.  The reference checkpoints for the GCPNet
+    # encoder store their configuration in this format, so we explicitly request
+    # the legacy behaviour to preserve compatibility with those files.
+    return torch.load(Path(path), map_location=map_location, weights_only=False)
 
 
 __all__ = ["save_checkpoint", "load_checkpoint"]

--- a/tests/test_gcpnet.py
+++ b/tests/test_gcpnet.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import torch
 
 from gcpvqvae.data.batch import EdgeStorage, ProteinBatch
@@ -11,7 +13,9 @@ from gcpvqvae.models.gcpnet import (
     GCPWidthConfig,
     ScalarVector,
 )
+from gcpvqvae.models.gcpvqvae import GCPVQVAE
 from gcpvqvae.system.train_gcpnet import _prepare_model_config
+from gcpvqvae.utils.checkpoint import load_checkpoint
 
 
 def test_gcpnet_encoder_projects_edge_scalars_with_default_input_dim() -> None:
@@ -132,3 +136,27 @@ def test_gcpnet_encoder_supports_bfloat16_inputs() -> None:
     assert outputs["node_embedding"].dtype is torch.bfloat16
     assert outputs["node_scalars"].dtype is torch.bfloat16
     assert outputs["node_vectors"].dtype is torch.bfloat16
+
+
+def test_gcpnet_reference_checkpoint_loads() -> None:
+    checkpoint_path = (
+        Path(__file__)
+        .resolve()
+        .parents[1]
+        / "models"
+        / "checkpoints"
+        / "structure_denoising"
+        / "gcpnet"
+        / "last.ckpt"
+    )
+
+    state = load_checkpoint(checkpoint_path, map_location="cpu")
+    state_dict = GCPVQVAE._extract_gcp_state_dict(state)
+
+    assert state_dict is not None
+    assert state_dict, "checkpoint should contain reference parameters"
+
+    encoder = GCPNetEncoder(GCPNetConfig())
+    model_state = encoder.state_dict()
+
+    assert isinstance(model_state, dict)


### PR DESCRIPTION
## Summary
- ensure torch.load keeps backwards-compatible behaviour for checkpoints containing OmegaConf objects
- add a regression test that loads the packaged GCPNet reference checkpoint and verifies the weights map is accessible

## Testing
- pytest tests/test_gcpnet.py::test_gcpnet_reference_checkpoint_loads

------
https://chatgpt.com/codex/tasks/task_b_68dfc4a5203c8323bbde50bf6cb16bd5