### PR TITLE
Add PDB chain extraction helpers for HDF5 preprocessing

### DIFF
--- a/src/gcpvqvae/data/pdb_hdf5.py
+++ b/src/gcpvqvae/data/pdb_hdf5.py
@@ -1,0 +1,181 @@
+"""Helpers for loading and filtering PDB/mmCIF structures for HDF5 export."""
+
+from __future__ import annotations
+
+import gzip
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from Bio import pairwise2
+from Bio.PDB import MMCIFParser, PDBParser, PPBuilder
+from Bio.PDB.Chain import Chain
+from Bio.PDB.Residue import Residue
+
+
+# Shared residue mapping used across workers.  The dictionary covers the 20
+# canonical amino acids together with the common ambiguity codes and rare
+# residues observed in the PDB archive.  Any residue not listed here defaults
+# to ``"X"`` which signals an unknown residue in downstream processing.
+THREE_TO_ONE: Dict[str, str] = {
+    "ALA": "A",
+    "ARG": "R",
+    "ASN": "N",
+    "ASP": "D",
+    "CYS": "C",
+    "GLN": "Q",
+    "GLU": "E",
+    "GLY": "G",
+    "HIS": "H",
+    "ILE": "I",
+    "LEU": "L",
+    "LYS": "K",
+    "MET": "M",
+    "PHE": "F",
+    "PRO": "P",
+    "SER": "S",
+    "THR": "T",
+    "TRP": "W",
+    "TYR": "Y",
+    "VAL": "V",
+    "ASX": "B",
+    "GLX": "Z",
+    "PYL": "O",
+    "SEC": "U",
+}
+
+
+@dataclass
+class ChainMetadata:
+    """Description of a single protein chain extracted from a structure."""
+
+    chain_id: str
+    chain: Chain
+    residues: List[Residue]
+    sequence: str
+    ca_count: int
+
+
+@dataclass
+class ChainExtractionStats:
+    """Counters describing how a structure was filtered."""
+
+    total_chains: int = 0
+    dropped_short: int = 0
+    deduplicated: int = 0
+    complexes: int = 0
+    missing_chain_a: int = 0
+
+
+def _global_identity(seq_a: str, seq_b: str) -> float:
+    """Return the global sequence identity between two chains."""
+
+    if not seq_a or not seq_b:
+        return 0.0
+    score = pairwise2.align.globalxx(seq_a, seq_b, one_alignment_only=True, score_only=True)
+    max_len = max(len(seq_a), len(seq_b))
+    if max_len == 0:
+        return 0.0
+    return float(score) / float(max_len)
+
+
+def _parse_structure(path: Path):
+    """Parse ``path`` with the appropriate Biopython parser and return a structure."""
+
+    suffixes = [suffix.lower() for suffix in path.suffixes]
+    compressed = suffixes and suffixes[-1] == ".gz"
+    if compressed:
+        suffixes = suffixes[:-1]
+    suffix = suffixes[-1] if suffixes else path.suffix.lower()
+    if suffix in {".cif", ".mmcif"}:
+        parser = MMCIFParser(QUIET=True, auth_chains=False)
+    else:
+        parser = PDBParser(QUIET=True)
+    if compressed:
+        with gzip.open(path, "rt", encoding="utf-8", errors="ignore") as handle:
+            return parser.get_structure(path.stem, handle)
+    return parser.get_structure(path.stem, str(path))
+
+
+def _first_model(structure):
+    models = list(structure.get_models())
+    if not models:
+        raise ValueError("Structure does not contain any models")
+    return models[0]
+
+
+def _build_chain_metadata(chains: Iterable[Chain], *, min_len: int) -> Tuple[List[ChainMetadata], ChainExtractionStats]:
+    builder = PPBuilder()
+    stats = ChainExtractionStats()
+    initial_chain_ids: List[str] = []
+    metadata: List[ChainMetadata] = []
+
+    for chain in chains:
+        chain_id = chain.id
+        initial_chain_ids.append(chain_id)
+        peptides = builder.build_peptides(chain, aa_only=False)
+        residues: List[Residue] = []
+        for peptide in peptides:
+            residues.extend(list(peptide))
+        if not residues:
+            residues = [res for res in chain.get_residues() if res.id[0] == " "]
+        if not residues:
+            continue
+
+        sequence_chars: List[str] = []
+        for residue in residues:
+            name = residue.get_resname().upper()
+            sequence_chars.append(THREE_TO_ONE.get(name, "X"))
+
+        sequence = "".join(sequence_chars)
+        stats.total_chains += 1
+        if len(sequence) < min_len:
+            stats.dropped_short += 1
+            continue
+
+        ca_count = sum(1 for residue in residues if residue.has_id("CA"))
+        metadata.append(ChainMetadata(chain_id=chain_id, chain=chain, residues=residues, sequence=sequence, ca_count=ca_count))
+
+    if len(initial_chain_ids) > 1:
+        stats.complexes = 1
+
+    # Deduplicate highly similar chains by global identity.
+    filtered: List[ChainMetadata] = []
+    for candidate in metadata:
+        duplicate_idx = None
+        for idx, existing in enumerate(filtered):
+            identity = _global_identity(candidate.sequence, existing.sequence)
+            if identity >= 0.90:
+                duplicate_idx = idx
+                break
+
+        if duplicate_idx is None:
+            filtered.append(candidate)
+            continue
+
+        stats.deduplicated += 1
+        existing = filtered[duplicate_idx]
+        if candidate.ca_count > existing.ca_count:
+            filtered[duplicate_idx] = candidate
+
+    kept_ids = {item.chain_id for item in filtered}
+    if "A" in initial_chain_ids and "A" not in kept_ids:
+        stats.missing_chain_a = 1
+
+    return filtered, stats
+
+
+def extract_chains(path: str | Path, *, min_len: int = 0) -> Tuple[List[ChainMetadata], ChainExtractionStats]:
+    """Load ``path`` and return filtered chain metadata with processing stats."""
+
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise FileNotFoundError(path)
+
+    structure = _parse_structure(path_obj)
+    model = _first_model(structure)
+    chains = list(model.get_chains())
+    return _build_chain_metadata(chains, min_len=min_len)
+
+
+__all__ = ["THREE_TO_ONE", "ChainMetadata", "ChainExtractionStats", "extract_chains"]

--- a/tests/test_pdb_hdf5.py
+++ b/tests/test_pdb_hdf5.py
@@ -1,0 +1,146 @@
+from pathlib import Path
+
+import gemmi
+
+from gcpvqvae.data.pdb_hdf5 import (
+    THREE_TO_ONE,
+    ChainMetadata,
+    ChainExtractionStats,
+    extract_chains,
+)
+
+
+def _add_atom(residue: gemmi.Residue, name: str, position) -> None:
+    atom = gemmi.Atom()
+    atom.name = name
+    atom.pos = gemmi.Position(*position)
+    atom.occ = 1.0
+    atom.b_iso = 10.0
+    residue.add_atom(atom)
+
+
+def _write_structure(path: Path, *, models: int = 1, duplicate: bool = False) -> None:
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(20.0, 20.0, 20.0, 90.0, 90.0, 90.0)
+
+    for model_index in range(models):
+        model = gemmi.Model(str(model_index))
+
+        chain_a = gemmi.Chain("A")
+        for idx, name in enumerate(["ALA", "GLY", "SER"], start=1):
+            residue = gemmi.Residue()
+            residue.name = name
+            residue.het_flag = " "
+            residue.seqid = gemmi.SeqId(str(idx))
+            offset = float(idx - 1)
+            _add_atom(residue, "N", (offset, 0.0, 0.0))
+            _add_atom(residue, "CA", (offset + 0.5, 0.5, 0.0))
+            _add_atom(residue, "C", (offset + 1.0, 0.2, 0.3))
+            chain_a.add_residue(residue)
+
+        model.add_chain(chain_a)
+
+        chain_b = gemmi.Chain("B")
+        for idx, name in enumerate(["VAL", "TYR", "LEU"], start=1):
+            residue = gemmi.Residue()
+            residue.name = name
+            residue.het_flag = " "
+            residue.seqid = gemmi.SeqId(str(idx))
+            offset = float(idx - 1)
+            _add_atom(residue, "N", (offset, 2.0, 0.0))
+            _add_atom(residue, "CA", (offset + 0.6, 2.5, 0.1))
+            _add_atom(residue, "C", (offset + 1.1, 2.1, 0.4))
+            chain_b.add_residue(residue)
+
+        if duplicate:
+            chain_c = gemmi.Chain("C")
+            for idx, name in enumerate(["ALA", "GLY", "SER"], start=1):
+                residue = gemmi.Residue()
+                residue.name = name
+                residue.het_flag = " "
+                residue.seqid = gemmi.SeqId(str(idx))
+                offset = float(idx - 1)
+                _add_atom(residue, "N", (offset, 3.0, 0.0))
+                if idx != 1:
+                    _add_atom(residue, "CA", (offset + 0.5, 3.5, 0.0))
+                _add_atom(residue, "C", (offset + 1.0, 3.2, 0.3))
+                chain_c.add_residue(residue)
+            model.add_chain(chain_c)
+        else:
+            # Add a short chain to test filtering.
+            chain_short = gemmi.Chain("D")
+            residue = gemmi.Residue()
+            residue.name = "ALA"
+            residue.het_flag = " "
+            residue.seqid = gemmi.SeqId("1")
+            _add_atom(residue, "N", (0.0, 4.0, 0.0))
+            _add_atom(residue, "CA", (0.5, 4.5, 0.0))
+            _add_atom(residue, "C", (1.0, 4.2, 0.3))
+            chain_short.add_residue(residue)
+            model.add_chain(chain_short)
+
+        model.add_chain(chain_b)
+        structure.add_model(model)
+
+    structure.setup_entities()
+    if path.suffix.lower() in {".pdb", ".ent"}:
+        structure.write_minimal_pdb(str(path))
+    else:
+        doc = structure.make_mmcif_document()
+        doc.write_file(str(path))
+
+
+def test_three_to_one_contains_expected_mappings():
+    assert THREE_TO_ONE["ALA"] == "A"
+    assert THREE_TO_ONE["GLX"] == "Z"
+    assert THREE_TO_ONE.get("UNK", "X") == "X"
+
+
+def test_extract_chains_filters_and_tracks_stats(tmp_path):
+    path = tmp_path / "structure.cif"
+    _write_structure(path)
+
+    chains, stats = extract_chains(path, min_len=2)
+
+    assert isinstance(stats, ChainExtractionStats)
+    assert stats.total_chains == len(chains)
+    assert stats.dropped_short == 0
+    assert stats.complexes == 1
+    assert stats.missing_chain_a == 0
+
+    assert len(chains) == 2
+    identifiers = {chain.chain_id[0] for chain in chains}
+    assert identifiers == {"A", "B"}
+    for chain in chains:
+        assert isinstance(chain, ChainMetadata)
+        if chain.chain_id.startswith("A"):
+            assert chain.sequence == "AGS"
+        else:
+            assert chain.sequence == "VYL"
+        assert chain.ca_count == 3
+
+
+def test_extract_chains_prefers_chain_with_more_ca_atoms(tmp_path):
+    path = tmp_path / "structure_duplicate.cif"
+    _write_structure(path, duplicate=True)
+
+    chains, stats = extract_chains(path, min_len=1)
+
+    assert stats.deduplicated == 1
+    assert len(chains) == 2
+    identifiers = {chain.chain_id[0] for chain in chains}
+    assert identifiers == {"A", "B"}
+    chain_a = next(chain for chain in chains if chain.chain_id.startswith("A"))
+    chain_b = next(chain for chain in chains if chain.chain_id.startswith("B"))
+    assert chain_a.ca_count == 3
+    assert chain_b.ca_count == 3
+
+
+def test_only_first_model_is_used(tmp_path):
+    path = tmp_path / "multi_model.cif"
+    _write_structure(path, models=2)
+
+    chains, _ = extract_chains(path, min_len=1)
+
+    ids = {chain.chain_id[0] for chain in chains}
+    assert ids == {"A", "B"}


### PR DESCRIPTION
## Summary
- add a Bio.PDB-backed loader that normalises residue mapping and only keeps the first model
- implement chain filtering with PPBuilder peptides, min-length checks, deduplication, and stats counters
- add unit tests covering mapping, deduplication preferences, and first-model handling

## Testing
- pytest tests/test_pdb_hdf5.py

------
https://chatgpt.com/codex/tasks/task_b_68e0474142088323a72052eb6c5d9f91