### PR TITLE
Add gating and stats aggregation to reference preprocessing

### DIFF
--- a/src/gcpvqvae/cli.py
+++ b/src/gcpvqvae/cli.py
@@ -128,7 +128,7 @@ def preprocess_dataset_command(
     from gcpvqvae.data.reference_preprocessing import preprocess_reference_dataset
 
     try:
-        manifest_path = preprocess_reference_dataset(
+        result = preprocess_reference_dataset(
             input,
             output,
             max_len=max_len,
@@ -141,6 +141,14 @@ def preprocess_dataset_command(
     except (OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
 
+    if isinstance(result, tuple):
+        manifest_path, stats = result
+    else:  # pragma: no cover - backwards compatibility
+        manifest_path = result
+        stats = None
+
+    if stats:
+        click.echo(f"Summary: {stats}")
     click.echo(f"Preprocessed dataset written to {manifest_path}")
 
 

--- a/src/gcpvqvae/data/reference/preprocessing.py
+++ b/src/gcpvqvae/data/reference/preprocessing.py
@@ -15,6 +15,12 @@ from gcpvqvae.data.mmcif import THREE_TO_ONE
 
 _BACKBONE_ATOMS: Tuple[str, ...] = ("N", "CA", "C", "O")
 
+# Missing-data thresholds applied during preprocessing.  AlphaFold structures
+# occasionally contain short unresolved segments; we accept those while
+# filtering chains with large gaps or pervasive missing coordinates.
+_MAX_MISSING_RATIO = 0.20
+_MAX_MISSING_BLOCK = 15
+
 
 @dataclass
 class PreprocessedChain:
@@ -36,6 +42,71 @@ class PreprocessedChain:
             raise ValueError("coords and plddt must have matching length")
         if len(self.protein_seq) != self.coords.shape[0]:
             raise ValueError("protein_seq length must match coordinate length")
+
+
+def _missing_mask(chain: PreprocessedChain) -> np.ndarray:
+    """Return a boolean mask marking residues without valid Cα positions."""
+
+    # Missing residues manifest either through explicit NaNs introduced when the
+    # raw residue lacked a backbone atom, or through gap padding when a jump in
+    # the residue numbering indicated an unresolved stretch.
+    ca_coords = chain.coords[:, 1, :]
+    return np.isnan(ca_coords).any(axis=1)
+
+
+def _longest_missing_block(mask: np.ndarray) -> int:
+    """Compute the maximum length of a contiguous missing segment."""
+
+    if mask.size == 0:
+        return 0
+
+    longest = 0
+    current = 0
+    for missing in mask:
+        if bool(missing):
+            current += 1
+            if current > longest:
+                longest = current
+        else:
+            current = 0
+    return longest
+
+
+def _validate_length(
+    length: int,
+    *,
+    min_len: Optional[int],
+    max_len: Optional[int],
+) -> Tuple[bool, Optional[str]]:
+    """Check whether a chain length satisfies the configured bounds."""
+
+    if min_len is not None and length < min_len:
+        return False, "chains_too_short"
+    if max_len is not None and length > max_len:
+        return False, "chains_too_long"
+    return True, None
+
+
+def _validate_missing_thresholds(
+    chain: PreprocessedChain,
+    *,
+    max_missing_ratio: float = _MAX_MISSING_RATIO,
+    max_missing_block: int = _MAX_MISSING_BLOCK,
+) -> Tuple[bool, Optional[str], float, int]:
+    """Validate missing-coordinate statistics after gap padding."""
+
+    mask = _missing_mask(chain)
+    if mask.size == 0:
+        return True, None, 0.0, 0
+
+    missing_ratio = float(mask.mean())
+    longest_block = _longest_missing_block(mask)
+
+    if missing_ratio > max_missing_ratio:
+        return False, "missing_ratio_exceeded", missing_ratio, longest_block
+    if longest_block > max_missing_block:
+        return False, "missing_block_exceeded", missing_ratio, longest_block
+    return True, None, missing_ratio, longest_block
 
 
 def _load_structure(path: Path) -> gemmi.Structure:

--- a/src/gcpvqvae/data/reference_preprocessing.py
+++ b/src/gcpvqvae/data/reference_preprocessing.py
@@ -2,10 +2,172 @@
 
 from __future__ import annotations
 
+import json
+from collections import Counter
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Sequence, Tuple
 
-from .preprocessing import preprocess_dataset
+import gemmi
+
+from gcpvqvae.data.mmcif import THREE_TO_ONE
+
+from .reference.preprocessing import (
+    _load_structure,
+    _validate_length,
+    _validate_missing_thresholds,
+    preprocess_chain,
+)
+
+
+_MANIFEST_NAME = "preprocessed_reference_dataset.json"
+_FILE_INDEX_NAME = "file_index.json"
+
+
+@dataclass
+class _ChainRecord:
+    """Summary of a successfully preprocessed chain."""
+
+    source_path: str
+    chain_id: str
+    length: int
+    sequence: str
+    missing_residues: int
+    missing_ratio: float
+    longest_missing_block: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_path": self.source_path,
+            "chain_id": self.chain_id,
+            "length": self.length,
+            "sequence": self.sequence,
+            "missing_residues": self.missing_residues,
+            "missing_ratio": self.missing_ratio,
+            "longest_missing_block": self.longest_missing_block,
+        }
+
+
+def _discover_structure_files(input_root: Path, *, use_cif: bool) -> List[Path]:
+    if input_root.is_file():
+        return [input_root]
+
+    if use_cif:
+        patterns = ["*.cif", "*.cif.gz", "*.mmcif", "*.mmcif.gz"]
+    else:
+        patterns = [
+            "*.cif",
+            "*.cif.gz",
+            "*.mmcif",
+            "*.mmcif.gz",
+            "*.pdb",
+            "*.pdb.gz",
+            "*.ent",
+            "*.ent.gz",
+        ]
+
+    files: List[Path] = []
+    for pattern in patterns:
+        files.extend(sorted(input_root.rglob(pattern)))
+    return files
+
+
+def _is_polymer_chain(chain: gemmi.Chain) -> bool:
+    residues = [res for res in chain.get_polymer() if THREE_TO_ONE.get(res.name.upper())]
+    return bool(residues)
+
+
+def _process_structure_file(
+    file_path: Path,
+    *,
+    min_len: Optional[int],
+    max_len: Optional[int],
+    gap_threshold: Optional[float],
+) -> Tuple[List[_ChainRecord], Counter]:
+    stats = Counter()
+    stats["files_total"] += 1
+
+    try:
+        structure = _load_structure(file_path)
+    except Exception:
+        stats["parsing_errors"] += 1
+        return [], stats
+
+    polymer_chains: List[gemmi.Chain] = []
+    if structure:
+        model = structure[0]
+        for chain in model:
+            if _is_polymer_chain(chain):
+                polymer_chains.append(chain)
+
+    if not polymer_chains:
+        stats["missing_coordinates"] += 1
+        return [], stats
+
+    if len({chain.name for chain in polymer_chains}) > 1:
+        stats["complexes"] += 1
+        return [], stats
+
+    records: List[_ChainRecord] = []
+    for chain in polymer_chains:
+        stats["chains_total"] += 1
+        processed = preprocess_chain(chain, gap_threshold=gap_threshold)
+        if processed.missing_residues:
+            stats["missing_coordinates"] += 1
+
+        length = int(processed.coords.shape[0])
+        length_ok, length_reason = _validate_length(
+            length, min_len=min_len, max_len=max_len
+        )
+        if not length_ok:
+            stats[length_reason] += 1  # type: ignore[index]
+            continue
+
+        missing_ok, missing_reason, ratio, longest = _validate_missing_thresholds(processed)
+        if not missing_ok:
+            stats[missing_reason] += 1  # type: ignore[index]
+            continue
+
+        stats["chains_written"] += 1
+        record = _ChainRecord(
+            source_path=str(file_path),
+            chain_id=chain.name,
+            length=length,
+            sequence=processed.protein_seq,
+            missing_residues=processed.missing_residues,
+            missing_ratio=ratio,
+            longest_missing_block=longest,
+        )
+        records.append(record)
+
+    return records, stats
+
+
+def _write_manifest(
+    output_dir: Path,
+    *,
+    entries: Sequence[_ChainRecord],
+    stats: Counter,
+    input_root: Path,
+) -> Path:
+    manifest = {
+        "input_root": str(input_root.resolve()),
+        "num_chains": len(entries),
+        "stats": dict(stats),
+        "chains": [entry.to_dict() for entry in entries],
+    }
+    manifest_path = output_dir / _MANIFEST_NAME
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+    return manifest_path
+
+
+def _write_file_index(output_dir: Path, files: Sequence[Path]) -> None:
+    index_path = output_dir / _FILE_INDEX_NAME
+    payload = {"files": [str(path) for path in files]}
+    with index_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
 
 
 def preprocess_reference_dataset(
@@ -19,22 +181,64 @@ def preprocess_reference_dataset(
     file_index: bool = True,
     gap_threshold: Optional[float] = None,
 ):
-    """Temporarily back the reference CLI with the legacy implementation."""
+    """Preprocess AlphaFold-style structures into backbone summaries."""
 
-    # The legacy preprocessing pipeline does not yet implement the reference-only
-    # options. They are accepted for forward compatibility but ignored for now.
-    # ``max_len`` maps onto the existing ``length_cap`` parameter.
-    kwargs = {}
-    if max_len is not None:
-        kwargs["length_cap"] = max_len
+    files = _discover_structure_files(input_root, use_cif=use_cif)
+    if not files:
+        raise ValueError(f"No structure files found under {input_root}")
 
-    return preprocess_dataset(
-        input_root,
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    entries: List[_ChainRecord] = []
+    stats = Counter()
+
+    worker_count: Optional[int]
+    if max_workers is None:
+        worker_count = None
+    elif max_workers <= 1:
+        worker_count = 1
+    else:
+        worker_count = max_workers
+
+    if worker_count in (None, 1):
+        for file_path in files:
+            file_entries, file_stats = _process_structure_file(
+                file_path,
+                min_len=min_len,
+                max_len=max_len,
+                gap_threshold=gap_threshold,
+            )
+            entries.extend(file_entries)
+            stats.update(file_stats)
+    else:
+        with ProcessPoolExecutor(max_workers=worker_count) as executor:
+            futures = [
+                executor.submit(
+                    _process_structure_file,
+                    file_path,
+                    min_len=min_len,
+                    max_len=max_len,
+                    gap_threshold=gap_threshold,
+                )
+                for file_path in files
+            ]
+            for future in as_completed(futures):
+                file_entries, file_stats = future.result()
+                entries.extend(file_entries)
+                stats.update(file_stats)
+
+    manifest_path = _write_manifest(
         output_dir,
-        overwrite=False,
-        progress=True,
-        **kwargs,
+        entries=entries,
+        stats=stats,
+        input_root=input_root,
     )
+
+    if file_index:
+        _write_file_index(output_dir, files)
+
+    return manifest_path, stats
 
 
 __all__ = ["preprocess_reference_dataset"]
+

--- a/tests/test_cli_preprocess.py
+++ b/tests/test_cli_preprocess.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -54,7 +55,7 @@ def test_preprocess_dataset_invokes_reference_driver(monkeypatch, tmp_path):
         manifest = output_path / "preprocessed_dataset.json"
         output_path.mkdir(parents=True, exist_ok=True)
         manifest.write_text("{}", encoding="utf-8")
-        return manifest
+        return manifest, Counter({"chains_written": 1})
 
     monkeypatch.setattr(
         "gcpvqvae.data.reference_preprocessing.preprocess_reference_dataset",
@@ -91,6 +92,7 @@ def test_preprocess_dataset_invokes_reference_driver(monkeypatch, tmp_path):
         "file_index": False,
         "gap_threshold": 1.5,
     }
+    assert "Summary: Counter({'chains_written': 1})" in result.output
     assert "Preprocessed dataset written to" in result.output
 
 

--- a/tests/test_reference_preprocessing_module.py
+++ b/tests/test_reference_preprocessing_module.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import gemmi
+import numpy as np
+import pytest
+
+from gcpvqvae.data.reference.preprocessing import (
+    PreprocessedChain,
+    _validate_length,
+    _validate_missing_thresholds,
+)
+from gcpvqvae.data.reference_preprocessing import preprocess_reference_dataset
+
+
+def _make_chain(mask: Iterable[bool]) -> PreprocessedChain:
+    mask_array = np.asarray(list(mask), dtype=bool)
+    length = int(mask_array.shape[0])
+    coords = np.zeros((length, 4, 3), dtype=np.float64)
+    plddt = np.full((length,), 80.0, dtype=np.float64)
+
+    for idx, missing in enumerate(mask_array):
+        if missing:
+            coords[idx, :, :] = np.nan
+            plddt[idx] = np.nan
+        else:
+            base = float(idx)
+            coords[idx, 0] = (base, 0.0, 0.0)
+            coords[idx, 1] = (base + 1.2, 0.1, 0.0)
+            coords[idx, 2] = (base + 2.3, 0.2, 0.0)
+            coords[idx, 3] = (base + 3.5, 0.3, 0.0)
+
+    sequence = "A" * length
+    missing_residues = int(mask_array.sum())
+    return PreprocessedChain(sequence, coords, plddt, missing_residues)
+
+
+def _add_atom(residue: gemmi.Residue, name: str, position, occ: float = 1.0) -> None:
+    atom = gemmi.Atom()
+    atom.name = name
+    atom.pos = gemmi.Position(*position)
+    atom.occ = occ
+    atom.b_iso = 50.0
+    residue.add_atom(atom)
+
+
+def _write_structure(
+    path: Path,
+    *,
+    num_residues: int,
+    chain_ids: Iterable[str] = ("A",),
+    missing_ca: Iterable[int] | None = None,
+) -> None:
+    missing_set = set(missing_ca or [])
+
+    structure = gemmi.Structure()
+    structure.cell = gemmi.UnitCell(30.0, 30.0, 30.0, 90.0, 90.0, 90.0)
+
+    model = gemmi.Model("0")
+    for chain_offset, chain_id in enumerate(chain_ids):
+        chain = gemmi.Chain(chain_id)
+        for idx in range(num_residues):
+            residue = gemmi.Residue()
+            residue.name = "ALA"
+            residue.het_flag = " "
+            residue.seqid = gemmi.SeqId(str(idx + 1))
+
+            base = 3.8 * (idx + chain_offset * num_residues)
+            _add_atom(residue, "N", (base, 0.0, 0.0))
+            if idx not in missing_set:
+                _add_atom(residue, "CA", (base + 1.2, 0.0, 0.0))
+            _add_atom(residue, "C", (base + 2.4, 0.0, 0.0))
+            _add_atom(residue, "O", (base + 3.5, 0.0, 0.0))
+
+            chain.add_residue(residue)
+        model.add_chain(chain)
+
+    structure.add_model(model)
+    structure.setup_entities()
+    doc = structure.make_mmcif_document()
+    doc.write_file(str(path))
+
+
+def test_validate_length_bounds() -> None:
+    chain = _make_chain([False] * 10)
+    ok, reason = _validate_length(len(chain.protein_seq), min_len=5, max_len=12)
+    assert ok and reason is None
+
+    ok, reason = _validate_length(len(chain.protein_seq), min_len=12, max_len=None)
+    assert not ok and reason == "chains_too_short"
+
+    ok, reason = _validate_length(len(chain.protein_seq), min_len=None, max_len=5)
+    assert not ok and reason == "chains_too_long"
+
+
+def test_validate_missing_thresholds() -> None:
+    mask = [False] * 8 + [True, True]
+    chain = _make_chain(mask)
+    ok, reason, ratio, longest = _validate_missing_thresholds(chain)
+    assert ok and reason is None
+    assert pytest.approx(ratio) == 0.2
+    assert longest == 2
+
+    excessive_ratio_chain = _make_chain([False] * 7 + [True, True, True])
+    ok, reason, ratio, longest = _validate_missing_thresholds(excessive_ratio_chain)
+    assert not ok and reason == "missing_ratio_exceeded"
+    assert pytest.approx(ratio) == 0.3
+    assert longest == 3
+
+    long_block_mask = [False] * 64 + [True] * 16
+    long_block_chain = _make_chain(long_block_mask)
+    ok, reason, ratio, longest = _validate_missing_thresholds(long_block_chain)
+    assert not ok and reason == "missing_block_exceeded"
+    assert pytest.approx(ratio) == 0.2
+    assert longest == 16
+
+
+def test_preprocess_reference_dataset_collects_stats(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+
+    _write_structure(input_dir / "valid.cif", num_residues=10)
+    _write_structure(input_dir / "short.cif", num_residues=4)
+    _write_structure(input_dir / "ratio.cif", num_residues=10, missing_ca={7, 8, 9})
+    _write_structure(
+        input_dir / "block.cif",
+        num_residues=80,
+        missing_ca=set(range(10, 26)),
+    )
+
+    _write_structure(input_dir / "too_long.cif", num_residues=110)
+
+    complex_path = input_dir / "complex.cif"
+    _write_structure(complex_path, num_residues=6, chain_ids=["A", "B"])
+
+    (input_dir / "invalid.cif").write_text("not a cif", encoding="utf-8")
+
+    output_dir = tmp_path / "output"
+    manifest_path, stats = preprocess_reference_dataset(
+        input_dir,
+        output_dir,
+        max_len=90,
+        min_len=5,
+        max_workers=2,
+        use_cif=True,
+        file_index=True,
+    )
+
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["num_chains"] == 1
+    assert len(manifest["chains"]) == 1
+    entry = manifest["chains"][0]
+    assert entry["chain_id"] == "A"
+    assert entry["length"] == 10
+    assert entry["missing_residues"] == 0
+
+    index_path = output_dir / "file_index.json"
+    assert index_path.exists()
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+    assert len(index_payload["files"]) == 7
+
+    assert stats["files_total"] == 7
+    assert stats["parsing_errors"] == 1
+    assert stats["complexes"] == 1
+    assert stats["chains_total"] == 5
+    assert stats["chains_written"] == 1
+    assert stats["chains_too_short"] == 1
+    assert stats["chains_too_long"] == 1
+    assert stats["missing_ratio_exceeded"] == 1
+    assert stats["missing_block_exceeded"] == 1
+    assert stats["missing_coordinates"] == 2


### PR DESCRIPTION
## Summary
- add length and missing-coordinate validation helpers to the reference preprocessing pipeline
- collect per-file counters while preprocessing reference structures and surface them via the CLI
- cover the new gating and statistics behaviour with targeted unit tests

## Testing
- pytest tests/test_cli_preprocess.py tests/test_reference_preprocessing_module.py

------
https://chatgpt.com/codex/tasks/task_b_68e04d40c04c83238719491e10219321