### PR TITLE
Default configs load pretrained GCPNet weights

### DIFF
--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -31,11 +31,17 @@ omitted the defaults listed below are applied by the underlying dataclasses.
 The encoder settings are organised into nested blocks:
 
 - `embedding`
-  - `node_scalar_dim` (`49`): input scalar channels per residue.
+- `node_scalar_dim` (`49`): input scalar channels per residue.  Packaged training
+  configurations set this to `74` to match the provided pretrained encoder
+  weights.
   - `node_vector_dim` (`2`): input vector channels per residue.
-  - `edge_scalar_dim` (`9`): scalar edge features produced by preprocessing.
-  - `edge_scalar_input_dim` (`8`): raw edge scalar dimensionality; defaults to the preprocessor output when omitted.
-  - `edge_vector_dim` (`1`): vector channels per edge.
+- `edge_scalar_dim` (`9`): scalar edge features produced by preprocessing.  The
+  packaged configs use `32` in order to consume the released checkpoint.
+- `edge_scalar_input_dim` (`8`): raw edge scalar dimensionality; defaults to the preprocessor output when omitted.  The packaged
+  configs reduce this to `6` so that `edge_scalar_dim + num_rbf` aligns with the
+  pretrained weights.
+- `edge_vector_dim` (`1`): vector channels per edge.  The packaged configs
+  increase this to `4` to mirror the pretrained encoder.
   - `edge_vector_input_dim` (`1`): raw edge vector dimensionality; defaults to `edge_vector_dim`.
   - `output.scalar` (`128`) / `output.vector` (`16`): widths of the projected node features.
 - `message_passing`
@@ -58,7 +64,10 @@ Additional top-level options control auxiliary behaviour:
 - `predict_node_rep` (`False`): placeholder controlling auxiliary representation heads.
 - `use_gcp_dropout` (`True`): selects coupled scalar/vector dropout; disable to fall back to independent dropout.
 - `norm_pos_diff` (`False`): toggles normalisation of positional differences.
-- `init` (`"random"`), `init_checkpoint` (`null`), `strict_init` (`True`): checkpoint initialisation controls.
+- `init` (`"random"`), `init_checkpoint` (`null`), `strict_init` (`True`): checkpoint initialisation controls.  The packaged
+  training configurations default to `init: "pretrained"` with
+  `init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"`; override
+  these fields to fall back to random initialisation or to use a custom encoder checkpoint.
 
 ### `model.adapter` – Latent projection (`LatentAdapterConfig`)
 

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -11,11 +11,11 @@ data:
 model:
   gcp:
     embedding:
-      node_scalar_dim: 49
+      node_scalar_dim: 74
       node_vector_dim: 2
-      edge_scalar_dim: 9
-      edge_scalar_input_dim: 8
-      edge_vector_dim: 1
+      edge_scalar_dim: 32
+      edge_scalar_input_dim: 6
+      edge_vector_dim: 4
       output:
         scalar: 128
         vector: 16
@@ -40,9 +40,9 @@ model:
     predict_node_rep: false
     use_gcp_dropout: true
     norm_pos_diff: false
-    init: random
-    init_checkpoint: null
-    strict_init: true
+    init: pretrained            # set to "random" to disable checkpoint initialisation
+    init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"
+    strict_init: false
   vq:
     num_codes: 4096
     dim: 256

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -9,11 +9,11 @@ data:
 model:
   gcp:
     embedding:
-      node_scalar_dim: 49
+      node_scalar_dim: 74
       node_vector_dim: 2
-      edge_scalar_dim: 9
-      edge_scalar_input_dim: 8
-      edge_vector_dim: 1
+      edge_scalar_dim: 32
+      edge_scalar_input_dim: 6
+      edge_vector_dim: 4
       output:
         scalar: 128
         vector: 16
@@ -38,9 +38,9 @@ model:
     predict_node_rep: false
     use_gcp_dropout: true
     norm_pos_diff: false
-    init: random
-    init_checkpoint: null
-    strict_init: true
+    init: pretrained            # set to "random" to disable checkpoint initialisation
+    init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"
+    strict_init: false
   adapter:
     enabled: true
     output_dim: 128

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -10,11 +10,11 @@ data:
 model:
   gcp:
     embedding:
-      node_scalar_dim: 49
+      node_scalar_dim: 74
       node_vector_dim: 2
-      edge_scalar_dim: 9
-      edge_scalar_input_dim: 8
-      edge_vector_dim: 1
+      edge_scalar_dim: 32
+      edge_scalar_input_dim: 6
+      edge_vector_dim: 4
       output:
         scalar: 128
         vector: 16
@@ -39,9 +39,9 @@ model:
     predict_node_rep: false
     use_gcp_dropout: true
     norm_pos_diff: false
-    init: random
-    init_checkpoint: null
-    strict_init: true
+    init: pretrained            # set to "random" to disable checkpoint initialisation
+    init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"
+    strict_init: false
   adapter:
     enabled: true
     output_dim: 16

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -164,8 +164,15 @@ class GCPVQVAE(nn.Module):
                 "'gcp_state', 'model_state', 'state_dict', or a raw state dict"
             )
 
+        target_state = self.encoder_gcp.state_dict()
+        coerced = self._coerce_gcp_state_dict(state_dict, target_state)
+        if not coerced:
+            raise ValueError(
+                "Checkpoint does not contain compatible GCPNet parameters for the current configuration"
+            )
+
         missing, unexpected = self.encoder_gcp.load_state_dict(
-            state_dict, strict=getattr(self.config.gcp, "strict_init", True)
+            coerced, strict=getattr(self.config.gcp, "strict_init", True)
         )
         if missing or unexpected:
             warnings.warn(
@@ -197,6 +204,38 @@ class GCPVQVAE(nn.Module):
             return {k: v for k, v in state.items() if isinstance(v, torch.Tensor)}
 
         return None
+
+    @staticmethod
+    def _coerce_gcp_state_dict(
+        source: Mapping[str, Tensor], target: Mapping[str, Tensor]
+    ) -> Dict[str, Tensor]:
+        coerced: Dict[str, Tensor] = {}
+        for key, tensor in source.items():
+            if key in target and isinstance(tensor, torch.Tensor):
+                if tensor.shape == target[key].shape:
+                    coerced[key] = tensor
+
+        rename_map = {
+            "embedding.node_scalar_proj.weight": "encoder.gcp_embedding.node_embedding.scalar_out.weight",
+            "embedding.node_vector_proj": "encoder.gcp_embedding.node_embedding.vector_down.weight",
+            "embedding.edge_scalar_proj.weight": "encoder.gcp_embedding.edge_embedding.scalar_out.weight",
+            "embedding.edge_vector_proj": "encoder.gcp_embedding.edge_embedding.vector_down.weight",
+        }
+
+        for new_key, old_key in rename_map.items():
+            if new_key in coerced:
+                continue
+            tensor = source.get(old_key)
+            target_tensor = target.get(new_key)
+            if tensor is None or target_tensor is None:
+                continue
+            if not isinstance(tensor, torch.Tensor):
+                continue
+            if tensor.shape != target_tensor.shape:
+                continue
+            coerced[new_key] = tensor
+
+        return coerced
 
     def _device(self) -> torch.device:
         return next(self.parameters()).device

--- a/tests/test_gcpnet.py
+++ b/tests/test_gcpnet.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from pathlib import Path
 
+import pytest
 import torch
 
 from gcpvqvae.data.batch import EdgeStorage, ProteinBatch
@@ -14,8 +16,22 @@ from gcpvqvae.models.gcpnet import (
     ScalarVector,
 )
 from gcpvqvae.models.gcpvqvae import GCPVQVAE
+from gcpvqvae.system.configuration import build_model_config, compose_overrides
 from gcpvqvae.system.train_gcpnet import _prepare_model_config
 from gcpvqvae.utils.checkpoint import load_checkpoint
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECKPOINT_PATH = (
+    _REPO_ROOT
+    / "models"
+    / "checkpoints"
+    / "gcpnet"
+    / "structure_denoising"
+    / "ca_bb"
+    / "last.ckpt"
+)
+_CONFIG_DIR = _REPO_ROOT / "src" / "gcpvqvae" / "configs"
 
 
 def test_gcpnet_encoder_projects_edge_scalars_with_default_input_dim() -> None:
@@ -139,18 +155,7 @@ def test_gcpnet_encoder_supports_bfloat16_inputs() -> None:
 
 
 def test_gcpnet_reference_checkpoint_loads() -> None:
-    checkpoint_path = (
-        Path(__file__)
-        .resolve()
-        .parents[1]
-        / "models"
-        / "checkpoints"
-        / "structure_denoising"
-        / "gcpnet"
-        / "last.ckpt"
-    )
-
-    state = load_checkpoint(checkpoint_path, map_location="cpu")
+    state = load_checkpoint(_CHECKPOINT_PATH, map_location="cpu")
     state_dict = GCPVQVAE._extract_gcp_state_dict(state)
 
     assert state_dict is not None
@@ -160,3 +165,25 @@ def test_gcpnet_reference_checkpoint_loads() -> None:
     model_state = encoder.state_dict()
 
     assert isinstance(model_state, dict)
+
+
+@pytest.mark.parametrize("config_name", ["base", "small", "xsmall"])
+def test_packaged_configs_initialize_gcpnet_from_pretrained_weights(config_name: str) -> None:
+    raw = compose_overrides(_CONFIG_DIR / f"{config_name}.yaml", ())
+    model_config = build_model_config(raw.get("model"))
+
+    model = GCPVQVAE(model_config)
+
+    raw_state = load_checkpoint(_CHECKPOINT_PATH, map_location="cpu")
+    extracted = GCPVQVAE._extract_gcp_state_dict(raw_state)
+    assert extracted is not None
+
+    model_state = model.encoder_gcp.state_dict()
+    mapped = GCPVQVAE._coerce_gcp_state_dict(extracted, model_state)
+
+    assert mapped, "expected pretrained weights to map onto the encoder"
+    assert "embedding.node_scalar_proj.weight" in mapped
+
+    for key, tensor in mapped.items():
+        assert key in model_state
+        assert torch.equal(model_state[key], tensor)


### PR DESCRIPTION
## Summary
- point the packaged configs at the released structure-denoising checkpoint and match the encoder feature dimensions
- load legacy GCPNet checkpoints by remapping compatible parameters during model initialisation
- add regression coverage that instantiating each packaged config pulls weights from the checkpoint

## Testing
- pytest tests/test_gcpnet.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e06c96a7d48323b6c8a7b46ca969e1