### PR TITLE
Adopt vector-quantize-pytorch backend for the VQ layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "torch>=2.3",
     "numpy",
     "einops",
+    "vector-quantize-pytorch==1.23.2",
     "scipy",
     "gemmi",
     "biopython",

--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -96,14 +96,19 @@ Additional top-level options control auxiliary behaviour:
 | key | default | description |
 | --- | --- | --- |
 | `num_codes` | `4096` | Size of the codebook. |
-| `dim` | `256` | Codebook embedding dimension. |
+| `dim` | `128` | Codebook embedding dimension. |
 | `beta` | `0.25` | Commitment loss weight. |
 | `decay` | `0.99` | EMA decay for codebook updates. |
 | `epsilon` | `1e-5` | Numerical stability constant. |
-| `kmeans_iters` | `10` | Initial K-means refinement iterations. |
+| `kmeans_init` | `True` | Enables k-means initialisation of the codebook. |
+| `kmeans_iters` | `10` | Initial k-means refinement iterations. |
+| `stochastic_sample_codes` | `True` | Samples neighbouring codes during training for exploration. |
+| `sample_codebook_temp` | `1.0` | Temperature applied when sampling alternative codes. |
 | `rotation_trick` | `True` | Enables the rotation trick from VQ-VAE v2. |
 | `orthogonal_reg_weight` | `0.0` | Strength of the optional orthogonality penalty. |
 | `orthogonal_reg_max_codes` | `512` | Maximum codes used when computing the penalty. |
+| `orthogonal_reg_active_codes_only` | `True` | Restricts the penalty to codes activated in the batch. |
+| `return_zeros_for_masked_padding` | `True` | Pads masked tokens with zeros instead of inputs. |
 
 ### `model.rotation` – Rigid-frame decoder (`RotationHeadConfig`)
 

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -45,12 +45,17 @@ model:
     strict_init: false
   vq:
     num_codes: 4096
-    dim: 256
-    beta: 0.5
+    dim: 128
+    beta: 0.25
     decay: 0.99
+    kmeans_init: true
     kmeans_iters: 10
+    stochastic_sample_codes: true
+    sample_codebook_temp: 1.0
     orthogonal_reg_weight: 10.0
     orthogonal_reg_max_codes: 512
+    orthogonal_reg_active_codes_only: true
+    return_zeros_for_masked_padding: true
   encoder:
     model_dim: 1024
     num_layers: 12

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -17,7 +17,7 @@ from gcpvqvae.models.decoder import RotationDecoder
 from gcpvqvae.models.gcpnet import GCPNetConfig, GCPNetEncoder
 from gcpvqvae.models.losses import reconstruction_loss
 from gcpvqvae.models.transformer import GCPTokensTransformer, TransformerConfig
-from gcpvqvae.models.vq import VectorQuantizer
+from gcpvqvae.models.vq import VectorQuantizer, VectorQuantizerOptions
 from gcpvqvae.utils.checkpoint import load_checkpoint
 
 
@@ -34,14 +34,19 @@ class VectorQuantizerConfig:
     """Configuration for the latent codebook."""
 
     num_codes: int = 4096
-    dim: int = 256
+    dim: int = 128
     beta: float = 0.25
     decay: float = 0.99
     epsilon: float = 1e-5
+    kmeans_init: bool = True
     kmeans_iters: int = 10
+    stochastic_sample_codes: bool = True
+    sample_codebook_temp: float = 1.0
     rotation_trick: bool = True
     orthogonal_reg_weight: float = 0.0
     orthogonal_reg_max_codes: int = 512
+    orthogonal_reg_active_codes_only: bool = True
+    return_zeros_for_masked_padding: bool = True
 
 
 @dataclass
@@ -123,16 +128,24 @@ class GCPVQVAE(nn.Module):
         else:
             self.latent_adapter = None
         self.encoder_transformer = GCPTokensTransformer(self.config.encoder)
+        vq_options = VectorQuantizerOptions(
+            kmeans_init=self.config.vq.kmeans_init,
+            kmeans_iters=self.config.vq.kmeans_iters,
+            stochastic_sample_codes=self.config.vq.stochastic_sample_codes,
+            sample_codebook_temp=self.config.vq.sample_codebook_temp,
+            orthogonal_reg_active_codes_only=self.config.vq.orthogonal_reg_active_codes_only,
+            return_zeros_for_masked_padding=self.config.vq.return_zeros_for_masked_padding,
+        )
         self.vq = VectorQuantizer(
             self.config.vq.num_codes,
             self.config.vq.dim,
             beta=self.config.vq.beta,
             decay=self.config.vq.decay,
             epsilon=self.config.vq.epsilon,
-            kmeans_iters=self.config.vq.kmeans_iters,
             rotation_trick=self.config.vq.rotation_trick,
             orthogonal_reg_weight=self.config.vq.orthogonal_reg_weight,
             orthogonal_reg_max_codes=self.config.vq.orthogonal_reg_max_codes,
+            options=vq_options,
         )
         self.decoder_transformer = GCPTokensTransformer(self.config.decoder)
         self.rotation_decoder = RotationDecoder(
@@ -473,7 +486,8 @@ class GCPVQVAE(nn.Module):
             valid = mask_tensor & (tokens_tensor >= 0)
             if valid.any():
                 flat_indices = tokens_tensor[valid]
-                dequant[valid] = self.vq.embedding.index_select(0, flat_indices).to(dtype)
+                decoded = self.vq.get_output_from_indices(flat_indices)
+                dequant[valid] = decoded.to(dtype)
 
             dec_hidden = self.decoder_transformer(dequant, mask=mask_tensor)
             coords_central, final_pose = self.rotation_decoder(

--- a/src/gcpvqvae/models/vq.py
+++ b/src/gcpvqvae/models/vq.py
@@ -1,95 +1,37 @@
-"""Vector quantization layers and codebook management."""
+"""Wrapper around :mod:`vector_quantize_pytorch` for project-specific usage."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
 from torch import Tensor, nn
 
-
-def _safe_normalize(vec: Tensor, eps: float = 1e-8) -> Tensor:
-    norm = torch.linalg.norm(vec, dim=-1, keepdim=True)
-    return vec / torch.clamp(norm, min=eps)
-
-
-def _orthogonal_basis(vec: Tensor) -> Tensor:
-    """Return vectors orthogonal to ``vec`` (batched)."""
-
-    if vec.ndim != 2:
-        raise ValueError("vec must be of shape (N, D)")
-    n, d = vec.shape
-    if n == 0:
-        return vec
-    basis = torch.zeros_like(vec)
-    # Select the axis with smallest magnitude to avoid degeneracy.
-    indices = torch.argmin(torch.abs(vec), dim=-1)
-    basis[torch.arange(n, device=vec.device), indices] = 1.0
-    basis = basis - (basis * vec).sum(dim=-1, keepdim=True) * vec
-    return _safe_normalize(basis)
+try:  # pragma: no cover - import guarded for clearer error messages
+    from vector_quantize_pytorch import VectorQuantize
+    from vector_quantize_pytorch import vector_quantize_pytorch as vqp
+except ImportError as exc:  # pragma: no cover - tested indirectly via wrapper
+    raise ImportError(
+        "vector-quantize-pytorch is required. Install v1.23.2 or add it to your"
+        " environment dependencies."
+    ) from exc
 
 
-def _rotation_trick_gradient(grad: Tensor, inputs: Tensor, codes: Tensor, eps: float) -> Tensor:
-    """Apply the rotation-trick Jacobian to ``grad``.
+@dataclass
+class VectorQuantizerOptions:
+    """Options controlling the behaviour of :class:`VectorQuantizer`."""
 
-    The operation is vectorised over the leading dimension of the tensors and
-    works for arbitrary latent dimensionality.  For degenerate inputs (e.g.
-    zero-norm latents) the fallback reduces to simple rescaling which matches
-    the behaviour of the straight-through estimator.
-    """
-
-    if grad.numel() == 0:
-        return grad
-
-    z_norm = torch.linalg.norm(inputs, dim=-1, keepdim=True)
-    c_norm = torch.linalg.norm(codes, dim=-1, keepdim=True)
-
-    scale = c_norm / torch.clamp(z_norm, min=eps)
-
-    a_hat = torch.where(z_norm > eps, inputs / torch.clamp(z_norm, min=eps), _orthogonal_basis(codes))
-    b_hat = torch.where(c_norm > eps, codes / torch.clamp(c_norm, min=eps), _orthogonal_basis(inputs))
-
-    cos_theta = torch.clamp((a_hat * b_hat).sum(dim=-1, keepdim=True), -1.0, 1.0)
-    proj = b_hat - cos_theta * a_hat
-    sin_theta = torch.linalg.norm(proj, dim=-1, keepdim=True)
-
-    u = torch.where(sin_theta > eps, proj / torch.clamp(sin_theta, min=eps), _orthogonal_basis(a_hat))
-
-    dot_ga = (grad * a_hat).sum(dim=-1, keepdim=True)
-    dot_gu = (grad * u).sum(dim=-1, keepdim=True)
-
-    term1 = sin_theta * (dot_gu * a_hat - dot_ga * u)
-    term2 = (cos_theta - 1.0) * (dot_ga * a_hat + dot_gu * u)
-
-    rotated_grad = grad + term1 + term2
-    return scale * rotated_grad
-
-
-class _RotateTrickPass(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, inputs: Tensor, quantized: Tensor, mask: Tensor, eps: float) -> Tensor:
-        ctx.save_for_backward(inputs, quantized, mask)
-        ctx.eps = eps
-        return quantized
-
-    @staticmethod
-    def backward(ctx, grad_output: Tensor) -> Tuple[Tensor, None, None, None]:
-        inputs, quantized, mask = ctx.saved_tensors
-        mask = mask.to(torch.bool)
-
-        grad_inputs = torch.zeros_like(inputs)
-        if mask.any():
-            grad = grad_output[mask]
-            inp = inputs[mask]
-            codes = quantized[mask]
-            grad_inputs[mask] = _rotation_trick_gradient(grad, inp, codes, ctx.eps)
-
-        return grad_inputs, None, None, None
+    kmeans_init: bool = True
+    kmeans_iters: int = 10
+    stochastic_sample_codes: bool = True
+    sample_codebook_temp: float = 1.0
+    orthogonal_reg_active_codes_only: bool = True
+    return_zeros_for_masked_padding: bool = True
 
 
 class VectorQuantizer(nn.Module):
-    """Vector quantisation module with EMA codebook updates."""
+    """Thin wrapper around :class:`~vector_quantize_pytorch.VectorQuantize`."""
 
     def __init__(
         self,
@@ -99,70 +41,40 @@ class VectorQuantizer(nn.Module):
         beta: float = 0.25,
         decay: float = 0.99,
         epsilon: float = 1e-5,
-        kmeans_iters: int = 0,
         rotation_trick: bool = True,
         orthogonal_reg_weight: float = 0.0,
-        orthogonal_reg_max_codes: int = 512,
+        orthogonal_reg_max_codes: Optional[int] = 512,
+        options: Optional[VectorQuantizerOptions] = None,
     ) -> None:
         super().__init__()
-
         if num_codes <= 0:
             raise ValueError("num_codes must be positive")
         if dim <= 0:
             raise ValueError("dim must be positive")
 
+        opts = options or VectorQuantizerOptions()
+
         self.num_codes = num_codes
         self.dim = dim
-        self.beta = beta
-        self.decay = decay
-        self.eps = epsilon
-        self.kmeans_iters = kmeans_iters
-        self.rotation_trick = rotation_trick
+        self.commitment_weight = beta
         self.orthogonal_reg_weight = orthogonal_reg_weight
-        self.orthogonal_reg_max_codes = orthogonal_reg_max_codes
 
-        self.embedding = nn.Parameter(torch.randn(num_codes, dim))
-
-        self.register_buffer("ema_cluster_size", torch.zeros(num_codes))
-        self.register_buffer("ema_codebook", torch.zeros(num_codes, dim))
-        self.register_buffer("usage", torch.zeros(num_codes))
-
-        self._pending_codebook: Optional[Tensor] = None
-
-        self._initialised = False
-
-    @staticmethod
-    def _zero_loss_like(tensor: Tensor) -> Tensor:
-        zero = torch.zeros((), device=tensor.device, dtype=tensor.dtype)
-        if tensor.requires_grad:
-            zero = zero.requires_grad_()
-        return zero
-
-    def _initialise_codebook(self, samples: Tensor) -> None:
-        if self._initialised or samples.numel() == 0:
-            return
-
-        num_samples = samples.shape[0]
-        if num_samples < self.num_codes:
-            repeats = (self.num_codes + num_samples - 1) // num_samples
-            samples = samples.repeat(repeats, 1)
-        centroids = samples[: self.num_codes].clone()
-
-        for _ in range(self.kmeans_iters):
-            distances = (
-                torch.sum(samples**2, dim=1, keepdim=True)
-                + torch.sum(centroids**2, dim=1)
-                - 2.0 * samples @ centroids.t()
-            )
-            assignment = distances.argmin(dim=1)
-            for k in range(self.num_codes):
-                mask = assignment == k
-                if mask.any():
-                    centroids[k] = samples[mask].mean(dim=0)
-
-        with torch.no_grad():
-            self.embedding.copy_(centroids[: self.num_codes])
-        self._initialised = True
+        self._vq = VectorQuantize(
+            dim=dim,
+            codebook_size=num_codes,
+            commitment_weight=beta,
+            decay=decay,
+            eps=epsilon,
+            kmeans_init=opts.kmeans_init,
+            kmeans_iters=opts.kmeans_iters,
+            stochastic_sample_codes=opts.stochastic_sample_codes,
+            sample_codebook_temp=opts.sample_codebook_temp,
+            orthogonal_reg_weight=orthogonal_reg_weight,
+            orthogonal_reg_active_codes_only=opts.orthogonal_reg_active_codes_only,
+            orthogonal_reg_max_codes=orthogonal_reg_max_codes,
+            rotation_trick=rotation_trick,
+            return_zeros_for_masked_padding=opts.return_zeros_for_masked_padding,
+        )
 
     def forward(
         self,
@@ -170,116 +82,89 @@ class VectorQuantizer(nn.Module):
         *,
         mask: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Tensor, Dict[str, Tensor]]:
-        if self._pending_codebook is not None:
-            self.commit_pending_codebook()
+        """Quantise ``latents`` and return embeddings, indices, and loss terms."""
 
         if latents.size(-1) != self.dim:
             raise ValueError(f"Expected latent dim {self.dim}, got {latents.size(-1)}")
 
-        original_shape = latents.shape
-        flat_latents = latents.reshape(-1, self.dim)
-
-        if mask is not None:
-            mask = mask.to(torch.bool).reshape(-1)
-        else:
-            mask = torch.ones(flat_latents.shape[0], dtype=torch.bool, device=latents.device)
-
-        valid_latents = flat_latents[mask]
-
-        if self.training and self.kmeans_iters > 0 and not self._initialised:
-            self._initialise_codebook(valid_latents.detach())
-
-        if valid_latents.numel() == 0:
-            quantized = torch.zeros_like(flat_latents)
-            indices = torch.full((flat_latents.shape[0],), -1, dtype=torch.long, device=latents.device)
-            zero_loss = self._zero_loss_like(flat_latents)
-            losses = {
-                "commitment": self.beta * zero_loss,
-                "codebook": zero_loss,
-                "orthogonality": zero_loss,
-                "perplexity": torch.tensor(0.0, device=latents.device, dtype=latents.dtype),
-            }
-            quantized = quantized.reshape(original_shape)
-            indices = indices.reshape(original_shape[:-1])
-            return quantized, indices, losses
-
-        distances = (
-            torch.sum(valid_latents**2, dim=1, keepdim=True)
-            + torch.sum(self.embedding**2, dim=1)
-            - 2.0 * valid_latents @ self.embedding.t()
+        mask_tensor = mask.to(torch.bool) if mask is not None else None
+        quantized, indices, total_loss, breakdown = self._vq(
+            latents,
+            mask=mask_tensor,
+            return_loss_breakdown=True,
         )
-        assignment = distances.argmin(dim=1)
-        quantized_valid = self.embedding.index_select(0, assignment)
 
-        full_quantized = torch.zeros_like(flat_latents)
-        full_quantized[mask] = quantized_valid
+        indices = indices.to(torch.long)
+        if indices.ndim > latents.ndim - 1:
+            indices = indices.squeeze(-1)
 
-        indices = torch.full((flat_latents.shape[0],), -1, dtype=torch.long, device=latents.device)
-        indices[mask] = assignment
-
-        full_quantized = torch.where(mask.unsqueeze(-1), full_quantized, flat_latents)
-
-        diff = flat_latents - full_quantized.detach()
-        commitment = (diff[mask] ** 2).mean()
-        codebook_loss = ((flat_latents.detach() - full_quantized)[mask] ** 2).mean()
-
-        if self.orthogonal_reg_weight > 0:
-            num_codes = min(self.orthogonal_reg_max_codes, self.num_codes)
-            codes = self.embedding[:num_codes]
-            gram = codes @ codes.t()
-            identity = torch.eye(num_codes, device=latents.device, dtype=latents.dtype)
-            orth_loss = ((gram - identity) ** 2).mean()
-        else:
-            orth_loss = self._zero_loss_like(self.embedding)
-
-        if self.training and self.decay < 1.0:
-            with torch.no_grad():
-                one_hot = F.one_hot(assignment, num_classes=self.num_codes).to(latents.dtype)
-                cluster_size = one_hot.sum(dim=0)
-                embed_sum = one_hot.t() @ valid_latents
-
-                self.ema_cluster_size.mul_(self.decay).add_(cluster_size, alpha=1.0 - self.decay)
-                self.ema_codebook.mul_(self.decay).add_(embed_sum, alpha=1.0 - self.decay)
-
-                cluster_size = self.ema_cluster_size + self.eps
-                n = cluster_size.sum()
-                cluster_size = cluster_size / (n + self.num_codes * self.eps) * n
-                self._pending_codebook = self.ema_codebook / cluster_size.unsqueeze(1)
-
-        one_hot = F.one_hot(assignment, num_classes=self.num_codes).to(latents.dtype)
-        avg_probs = one_hot.mean(dim=0)
-        nonzero = avg_probs > 0
-        if nonzero.any():
-            perplexity = torch.exp(-(avg_probs[nonzero] * torch.log(avg_probs[nonzero])).sum())
-        else:
-            perplexity = torch.tensor(0.0, device=latents.device, dtype=latents.dtype)
-        self.usage.copy_(avg_probs)
-
-        if self.rotation_trick:
-            full_quantized = _RotateTrickPass.apply(flat_latents, full_quantized, mask, self.eps)
-        else:
-            full_quantized = flat_latents + (full_quantized - flat_latents).detach()
-
-        quantized = full_quantized.reshape(original_shape)
-        indices = indices.reshape(original_shape[:-1])
-
-        losses = {
-            "commitment": self.beta * commitment,
-            "codebook": codebook_loss,
-            "orthogonality": self.orthogonal_reg_weight * orth_loss,
-            "perplexity": perplexity,
-        }
+        losses = self._build_loss_dict(total_loss, breakdown)
+        losses["perplexity"] = self._perplexity(indices, mask_tensor, latents.dtype)
 
         return quantized, indices, losses
 
+    def freeze_codebook(self) -> None:
+        """Prevent further codebook updates."""
+
+        self._vq.freeze_codebook = True
+
+    def unfreeze_codebook(self) -> None:
+        """Re-enable codebook updates."""
+
+        self._vq.freeze_codebook = False
+
     def commit_pending_codebook(self) -> None:
-        """Apply any queued EMA codebook update."""
+        """Retained for backwards compatibility; no-op with library backend."""
 
-        if self._pending_codebook is None:
-            return
-        with torch.no_grad():
-            self.embedding.copy_(self._pending_codebook)
-        self._pending_codebook = None
+        return None
+
+    def get_output_from_indices(self, indices: Tensor) -> Tensor:
+        """Decode quantised embeddings given integer ``indices``."""
+
+        return self._vq.get_output_from_indices(indices)
+
+    # ------------------------------------------------------------------ helpers
+    def _build_loss_dict(
+        self, total_loss: Tensor, breakdown: vqp.LossBreakdown
+    ) -> Dict[str, Tensor]:
+        commit = breakdown.commitment * self.commitment_weight
+        orth = breakdown.orthogonal_reg * self.orthogonal_reg_weight
+        codebook = total_loss - commit - orth
+        losses: Dict[str, Tensor] = {
+            "total": total_loss,
+            "commitment": commit,
+            "codebook": codebook,
+            "orthogonality": orth,
+        }
+        if hasattr(breakdown, "codebook_diversity"):
+            losses["codebook_diversity"] = (
+                breakdown.codebook_diversity * self._vq.codebook_diversity_loss_weight
+            )
+        if hasattr(breakdown, "inplace_optimize"):
+            losses["inplace_optimize"] = breakdown.inplace_optimize
+        return losses
+
+    def _perplexity(
+        self,
+        indices: Tensor,
+        mask: Optional[Tensor],
+        dtype: torch.dtype,
+    ) -> Tensor:
+        if mask is None:
+            mask = indices >= 0
+        else:
+            mask = mask & (indices >= 0)
+
+        if not mask.any():
+            return torch.zeros((), device=indices.device, dtype=dtype)
+
+        flat = indices[mask]
+        counts = torch.bincount(flat, minlength=self.num_codes).to(dtype=torch.float32)
+        probs = counts / counts.sum()
+        nonzero = probs > 0
+        entropy = -(probs[nonzero] * probs[nonzero].log()).sum()
+        perplexity = torch.exp(entropy)
+        return perplexity.to(dtype=dtype)
 
 
-__all__ = ["VectorQuantizer"]
+__all__ = ["VectorQuantizer", "VectorQuantizerOptions"]

--- a/tests/test_vq.py
+++ b/tests/test_vq.py
@@ -1,143 +1,74 @@
-"""Unit tests for vector quantisation components."""
+"""Unit tests for the vector-quantisation wrapper."""
 
 from __future__ import annotations
 
-import pytest
 import torch
 
-from gcpvqvae.models.vq import VectorQuantizer, _rotation_trick_gradient
+from gcpvqvae.models.vq import VectorQuantizer, VectorQuantizerOptions
 
 
-def test_vector_quantizer_assigns_nearest_codes() -> None:
-    vq = VectorQuantizer(num_codes=3, dim=3, beta=0.25, decay=1.0, rotation_trick=True)
-    with torch.no_grad():
-        vq.embedding.copy_(
-            torch.tensor(
-                [
-                    [1.0, 0.0, 0.0],
-                    [0.0, 1.0, 0.0],
-                    [0.0, 0.0, 1.0],
-                ]
-            )
-        )
-
-    latents = torch.tensor(
-        [
-            [0.9, 0.1, 0.0],
-            [0.0, 0.8, 0.2],
-            [0.0, 0.2, 0.7],
-        ],
-        requires_grad=True,
-        dtype=torch.float32,
+def _make_vq(dim: int, num_codes: int) -> VectorQuantizer:
+    options = VectorQuantizerOptions(
+        kmeans_init=False,
+        kmeans_iters=1,
+        stochastic_sample_codes=False,
+        sample_codebook_temp=1.0,
+    )
+    return VectorQuantizer(
+        num_codes=num_codes,
+        dim=dim,
+        beta=0.25,
+        decay=0.99,
+        epsilon=1e-5,
+        rotation_trick=True,
+        orthogonal_reg_weight=0.0,
+        orthogonal_reg_max_codes=num_codes,
+        options=options,
     )
 
+
+def test_vector_quantizer_forward_shapes() -> None:
+    batch, length, dim, num_codes = 2, 4, 3, 8
+    torch.manual_seed(0)
+    vq = _make_vq(dim, num_codes)
+
+    latents = torch.randn(batch, length, dim, requires_grad=True)
     quantized, indices, losses = vq(latents)
 
-    assert indices.tolist() == [0, 1, 2]
-    assert torch.all(indices >= 0)
-    assert torch.all(indices < vq.num_codes)
-    expected = torch.tensor(
-        [
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-        ]
-    )
-    assert torch.allclose(quantized, expected)
-    assert {"commitment", "codebook", "orthogonality", "perplexity"} <= set(losses.keys())
+    assert quantized.shape == (batch, length, dim)
+    assert indices.shape == (batch, length)
+    assert {"commitment", "codebook", "orthogonality", "perplexity"} <= set(losses)
 
-    loss = quantized.sum() + losses["commitment"] + losses["codebook"]
-    loss.backward()
-    assert latents.grad is not None
+    total_loss = losses["commitment"] + losses["codebook"] + losses["orthogonality"]
+    total_loss.backward()
     assert torch.isfinite(latents.grad).all()
 
 
 def test_vector_quantizer_supports_masks() -> None:
-    vq = VectorQuantizer(num_codes=2, dim=2, beta=0.25, decay=1.0, rotation_trick=False)
-    with torch.no_grad():
-        vq.embedding.copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
+    batch, length, dim, num_codes = 1, 6, 4, 16
+    torch.manual_seed(1)
+    vq = _make_vq(dim, num_codes)
 
-    latents = torch.tensor([[0.9, 0.1], [0.0, 1.2]], requires_grad=True)
-    mask = torch.tensor([True, False])
+    latents = torch.randn(batch, length, dim, requires_grad=True)
+    mask = torch.tensor([[True, True, False, True, False, False]])
 
-    quantized, indices, _ = vq(latents, mask=mask)
+    quantized, indices, losses = vq(latents, mask=mask)
 
-    assert indices.tolist() == [0, -1]
-    assert torch.allclose(quantized[0], torch.tensor([1.0, 0.0]))
-    assert torch.allclose(quantized[1], latents[1])  # straight-through when masked
-
-
-def test_rotation_trick_gradient_matches_closed_form() -> None:
-    torch.manual_seed(0)
-    vq = VectorQuantizer(num_codes=4, dim=3, beta=0.25, decay=1.0, rotation_trick=True)
-    with torch.no_grad():
-        vq.embedding.copy_(torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [-1.0, 0.0, 0.0]]))
-
-    latents = torch.tensor(
-        [
-            [0.8, 0.3, 0.1],
-            [0.0, 0.9, 0.4],
-            [0.2, 0.1, 0.9],
-            [-0.7, 0.2, 0.1],
-        ],
-        requires_grad=True,
-        dtype=torch.float32,
-    )
-
-    quantized, _indices, _ = vq(latents)
-    upstream = torch.randn_like(quantized)
-    quantized.backward(upstream)
-
-    expected = _rotation_trick_gradient(upstream, latents.detach(), quantized.detach(), vq.eps)
-    assert torch.allclose(latents.grad, expected, atol=1e-5)
+    assert quantized.shape == (batch, length, dim)
+    assert torch.equal(indices[~mask], torch.full((3,), -1, dtype=torch.long))
+    assert losses["perplexity"].item() >= 1.0
 
 
-def test_vector_quantizer_perplexity_increases_after_updates() -> None:
-    torch.manual_seed(0)
-    vq = VectorQuantizer(num_codes=4, dim=2, beta=0.1, decay=0.8, rotation_trick=False, kmeans_iters=0)
-    with torch.no_grad():
-        vq.embedding.zero_()
-
-    uniform = torch.zeros(12, 2)
-    vq.train()
-    _, _, losses_before = vq(uniform)
-
-    cluster_a = torch.tensor([[1.0, 0.0], [1.1, 0.1], [0.9, -0.1]])
-    cluster_b = torch.tensor([[-1.0, 0.2], [-0.9, -0.2], [-1.2, 0.0]])
-    cluster_c = torch.tensor([[0.0, 1.0], [0.2, 1.1], [-0.1, 0.8]])
-
-    for _ in range(30):
-        latents = torch.cat([cluster_a, cluster_b, cluster_c], dim=0)
-        noise = 0.05 * torch.randn_like(latents)
-        vq(latents + noise)
-
+def test_get_output_from_indices_matches_quantized_vectors() -> None:
+    batch, length, dim, num_codes = 2, 5, 3, 32
+    torch.manual_seed(2)
+    vq = _make_vq(dim, num_codes)
     vq.eval()
-    _, _, losses_after = vq(torch.cat([cluster_a, cluster_b, cluster_c], dim=0))
 
-    assert losses_before["perplexity"].item() == pytest.approx(1.0, abs=1e-5)
-    assert losses_after["perplexity"].item() > 2.0
+    latents = torch.randn(batch, length, dim)
+    with torch.no_grad():
+        quantized, indices, _ = vq(latents)
 
-
-def test_vector_quantizer_supports_orthogonal_regularisation_with_ema() -> None:
-    torch.manual_seed(0)
-    vq = VectorQuantizer(
-        num_codes=8,
-        dim=4,
-        beta=0.25,
-        decay=0.95,
-        rotation_trick=False,
-        orthogonal_reg_weight=1.0,
-    )
-
-    latents = torch.randn(2, 16, 4, requires_grad=True)
-    vq.train()
-    _, _, losses = vq(latents)
-    total = losses["commitment"] + losses["codebook"] + losses["orthogonality"]
-
-    total.backward()
-    assert latents.grad is not None
-    assert torch.isfinite(latents.grad).all()
-
-    # Applying the EMA update should not raise and should clear the pending tensor.
-    vq.commit_pending_codebook()
-    assert vq._pending_codebook is None
+    recovered = vq.get_output_from_indices(indices.reshape(-1))
+    assert recovered.shape == (batch * length, dim)
+    assert torch.allclose(recovered.view_as(quantized), quantized, atol=1e-5)


### PR DESCRIPTION
## Summary
- add vector-quantize-pytorch as a dependency and wrap it with a minimal VectorQuantizer interface
- update the model configuration and decode path to use the library codebook utilities
- refresh documentation defaults and unit tests for the new quantiser behaviour

## Testing
- pytest tests/test_vq.py
- pytest tests/test_end_to_end.py::test_vq_decoder_pipeline_runs


------
https://chatgpt.com/codex/tasks/task_b_68e0a25a92988323811f3f4de8b0f11e