### PR TITLE
Refine transformer bridge API for mask handling

### DIFF
--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -271,19 +271,61 @@ class GCPVQVAE(nn.Module):
         return self.latent_adapter(embeddings)
 
     # ----------------------------------------------------------------- forward
-    def forward(self, batch: Dict[str, Tensor]) -> Dict[str, Tensor]:
+    def forward(
+        self,
+        batch: Dict[str, Tensor],
+        *,
+        decoder_only: bool = False,
+        return_vq_layer: bool = False,
+        mask: Optional[Tensor] = None,
+        nan_mask: Optional[Tensor] = None,
+    ) -> Dict[str, Tensor]:
         device = self._device()
         dtype = self._dtype()
 
-        mask = batch["mask"].to(torch.bool).to(device)
-        if "nan_mask" in batch:
-            mask = mask & ~batch["nan_mask"].to(torch.bool).to(device)
+        mask_tensor = mask if mask is not None else batch["mask"]
+        mask_tensor = mask_tensor.to(device=device, dtype=torch.bool)
+
+        if nan_mask is not None:
+            nan_mask_tensor = nan_mask.to(device=device, dtype=torch.bool)
+        elif "nan_mask" in batch:
+            nan_mask_tensor = ~batch["nan_mask"].to(torch.bool).to(device)
+        else:
+            nan_mask_tensor = None
+
+        valid = mask_tensor if nan_mask_tensor is None else mask_tensor & nan_mask_tensor
+
+        batch_size, max_len = mask_tensor.shape
+        latent_dim = self.config.vq.dim
+
+        if decoder_only:
+            indices = batch["indices"].to(device=device, dtype=torch.long)
+            if indices.ndim == 1:
+                indices = indices.unsqueeze(0)
+
+            quantized = torch.zeros((batch_size, max_len, latent_dim), device=device, dtype=dtype)
+            if valid.any():
+                decoded = self.vq.get_output_from_indices(indices[valid])
+                quantized[valid] = decoded.to(dtype)
+
+            dec_hidden = self.decoder_transformer(quantized, mask=valid)
+            recon_coords, final_pose = self.rotation_decoder(dec_hidden, mask=valid)
+
+            return {
+                "quantized": quantized,
+                "indices": indices,
+                "decoded": recon_coords,
+                "mask": mask_tensor,
+                "valid_mask": valid,
+                "pose": final_pose,
+                "vq_loss": torch.zeros((), device=device, dtype=dtype),
+                "vq_metrics": {},
+            }
 
         coords = batch["coords"].to(device=device, dtype=dtype)
         proto = protein_batch_from_graph_dict(batch)
         proto = proto.to(device=device, dtype=dtype)
-
-        batch_size, max_len, _ = batch["node_scalars"].shape
+        proto.full_mask = valid
 
         gcp_out = self.encoder_gcp(proto)
         flat_embeddings = gcp_out["node_embedding"]
@@ -293,23 +335,33 @@ class GCPVQVAE(nn.Module):
         embeddings = padded.reshape(batch_size, max_len, latent_dim)
         projected = self._project_embeddings(embeddings)
 
-        enc_hidden = self.encoder_transformer(projected, mask=mask)
-        quantized, indices, vq_losses = self.vq(enc_hidden, mask=mask)
+        enc_hidden = self.encoder_transformer(projected, mask=valid)
+        vq_out = self.vq(enc_hidden, mask=valid, return_metrics=True)
+        quantized, indices, vq_loss, vq_metrics = vq_out
 
-        dec_hidden = self.decoder_transformer(quantized, mask=mask)
-        recon_coords, final_pose = self.rotation_decoder(dec_hidden, mask=mask)
+        if return_vq_layer:
+            return {
+                "gcp_embeddings": embeddings,
+                "encoder_hidden": enc_hidden,
+                "quantized": quantized,
+                "indices": indices,
+                "mask": mask_tensor,
+                "valid_mask": valid,
+                "vq_loss": vq_loss,
+                "vq_metrics": vq_metrics,
+            }
+
+        dec_hidden = self.decoder_transformer(quantized, mask=valid)
+        recon_coords, final_pose = self.rotation_decoder(dec_hidden, mask=valid)
 
         rec_loss, rec_components = reconstruction_loss(
             recon_coords,
             coords,
-            mask=mask,
+            mask=valid,
             return_components=True,
         )
 
-        total_loss = rec_loss
-        total_loss = total_loss + vq_losses["commitment"]
-        total_loss = total_loss + vq_losses["codebook"]
-        total_loss = total_loss + vq_losses["orthogonality"]
+        total_loss = rec_loss + vq_loss
 
         return {
             "gcp_embeddings": embeddings,
@@ -317,9 +369,11 @@ class GCPVQVAE(nn.Module):
             "quantized": quantized,
             "indices": indices,
             "decoded": recon_coords,
-            "mask": mask,
+            "mask": mask_tensor,
+            "valid_mask": valid,
             "pose": final_pose,
-            "vq_losses": vq_losses,
+            "vq_loss": vq_loss,
+            "vq_metrics": vq_metrics,
             "reconstruction": rec_loss,
             "reconstruction_components": rec_components,
             "total_loss": total_loss,
@@ -390,9 +444,20 @@ class GCPVQVAE(nn.Module):
         gcp_out = self.encoder_gcp(proto)
         embeddings = gcp_out["node_embedding"].unsqueeze(0)
         projected = self._project_embeddings(embeddings)
-        enc_hidden = self.encoder_transformer(projected, mask=mask.unsqueeze(0))
-        quantized, indices, vq_losses = self.vq(enc_hidden, mask=mask.unsqueeze(0))
-        return embeddings, enc_hidden, quantized, {"indices": indices, "vq": vq_losses}
+        valid = mask.unsqueeze(0)
+        enc_hidden = self.encoder_transformer(projected, mask=valid)
+        vq_out = self.vq(enc_hidden, mask=valid, return_metrics=True)
+        quantized, indices, vq_loss, vq_metrics = vq_out
+        return (
+            embeddings,
+            enc_hidden,
+            quantized,
+            {
+                "indices": indices,
+                "vq_loss": vq_loss,
+                "vq_metrics": vq_metrics,
+            },
+        )
 
     # ------------------------------------------------------------------- encode
     @torch.no_grad()
@@ -421,6 +486,8 @@ class GCPVQVAE(nn.Module):
             if record.nan_mask.numel():
                 mask = mask & ~record.nan_mask
 
+            valid = mask
+
             embeddings, enc_hidden, quantized, extras = self._run_encoder(
                 features["node_scalars"],
                 features["node_vectors"],
@@ -429,16 +496,18 @@ class GCPVQVAE(nn.Module):
                 features["edge_scalars"],
                 features["edge_vectors"],
                 features["edge_frames"],
-                mask,
+                valid,
             )
 
             indices = extras["indices"].squeeze(0).cpu()
-            vq_losses = extras["vq"]
+            vq_loss = extras["vq_loss"]
+            vq_metrics = extras["vq_metrics"]
 
             result = {
                 "tokens": indices.clone(),
                 "length": int(record.length),
                 "mask": mask.clone().cpu(),
+                "valid_mask": valid.clone().cpu(),
                 "pose_header": (
                     record.rotation.clone().cpu(),
                     record.translation.clone().cpu(),
@@ -446,7 +515,8 @@ class GCPVQVAE(nn.Module):
                 "gcp_embeddings": embeddings.squeeze(0).cpu(),
                 "encoder_embeddings": enc_hidden.squeeze(0).cpu(),
                 "quantized": quantized.squeeze(0).cpu(),
-                "vq_losses": {k: v.detach().cpu() for k, v in vq_losses.items()},
+                "vq_loss": vq_loss.squeeze(0).detach().cpu(),
+                "vq_metrics": {k: v.detach().cpu() for k, v in vq_metrics.items()},
                 "metadata": self._build_metadata(record),
             }
             return result
@@ -489,10 +559,8 @@ class GCPVQVAE(nn.Module):
                 decoded = self.vq.get_output_from_indices(flat_indices)
                 dequant[valid] = decoded.to(dtype)
 
-            dec_hidden = self.decoder_transformer(dequant, mask=mask_tensor)
-            coords_central, final_pose = self.rotation_decoder(
-                dec_hidden, mask=mask_tensor
-            )
+            dec_hidden = self.decoder_transformer(dequant, mask=valid)
+            coords_central, final_pose = self.rotation_decoder(dec_hidden, mask=valid)
 
             if pose_header is not None:
                 rot, trans = pose_header
@@ -509,7 +577,7 @@ class GCPVQVAE(nn.Module):
             coords_global = coords_central @ rot_t.transpose(-1, -2)
             coords_global = coords_global + trans_t.unsqueeze(1).unsqueeze(2)
 
-            mask_cpu = mask_tensor.clone().cpu()
+            mask_cpu = valid.clone().cpu()
 
             records_out: Optional[Any]
             if metadata is not None:
@@ -567,6 +635,7 @@ class GCPVQVAE(nn.Module):
                 if batch == 1
                 else coords_central.cpu(),
                 "mask": mask_cpu.squeeze(0) if batch == 1 else mask_cpu,
+                "valid_mask": mask_cpu.squeeze(0) if batch == 1 else mask_cpu,
                 "pose": (final_pose[0].cpu(), final_pose[1].cpu()),
                 "pose_header": (rot_t.cpu(), trans_t.cpu()),
                 "records": records_out,

--- a/src/gcpvqvae/models/vq.py
+++ b/src/gcpvqvae/models/vq.py
@@ -81,8 +81,9 @@ class VectorQuantizer(nn.Module):
         latents: Tensor,
         *,
         mask: Optional[Tensor] = None,
-    ) -> Tuple[Tensor, Tensor, Dict[str, Tensor]]:
-        """Quantise ``latents`` and return embeddings, indices, and loss terms."""
+        return_metrics: bool = False,
+    ) -> Tuple[Tensor, Tensor, Tensor] | Tuple[Tensor, Tensor, Tensor, Dict[str, Tensor]]:
+        """Quantise ``latents`` and return embeddings, indices, and the scalar loss."""
 
         if latents.size(-1) != self.dim:
             raise ValueError(f"Expected latent dim {self.dim}, got {latents.size(-1)}")
@@ -98,10 +99,12 @@ class VectorQuantizer(nn.Module):
         if indices.ndim > latents.ndim - 1:
             indices = indices.squeeze(-1)
 
-        losses = self._build_loss_dict(total_loss, breakdown)
-        losses["perplexity"] = self._perplexity(indices, mask_tensor, latents.dtype)
+        metrics = self._build_loss_dict(total_loss, breakdown)
+        metrics["perplexity"] = self._perplexity(indices, mask_tensor, latents.dtype)
 
-        return quantized, indices, losses
+        if return_metrics:
+            return quantized, indices, metrics["total"], metrics
+        return quantized, indices, metrics["total"]
 
     def freeze_codebook(self) -> None:
         """Prevent further codebook updates."""

--- a/src/gcpvqvae/system/eval.py
+++ b/src/gcpvqvae/system/eval.py
@@ -329,7 +329,9 @@ def run_model_evaluation(
                 outputs = model(batch)
 
                 decoded = outputs["decoded"].detach()
-                mask = outputs.get("mask")
+                mask = outputs.get("valid_mask")
+                if mask is None:
+                    mask = outputs.get("mask")
                 if mask is None:
                     mask = batch["mask"].to(decoded.device)
                 mask = mask.to(torch.bool)
@@ -387,9 +389,9 @@ def run_model_evaluation(
                         if valid_unique.numel() > 0:
                             code_usage[valid_unique.cpu()] = True
 
-                vq_losses = outputs.get("vq_losses")
-                if isinstance(vq_losses, dict) and "perplexity" in vq_losses:
-                    perplexity = vq_losses["perplexity"]
+                vq_metrics = outputs.get("vq_metrics")
+                if isinstance(vq_metrics, dict) and "perplexity" in vq_metrics:
+                    perplexity = vq_metrics["perplexity"]
                     perplexities.append(float(perplexity.detach().cpu().item()))
 
                 if runtime_cfg.max_batches is not None and batch_idx + 1 >= runtime_cfg.max_batches:

--- a/src/gcpvqvae/system/train.py
+++ b/src/gcpvqvae/system/train.py
@@ -985,7 +985,9 @@ class Trainer:
                                 self.model.commit_updates()
                             accum_counter += 1
 
-                            batch_mask = batch["mask"]
+                            batch_mask = outputs.get("valid_mask")
+                            if batch_mask is None:
+                                batch_mask = batch["mask"]
                             batch_size = int(batch_mask.shape[0])
                             residue_count = int(batch_mask.sum().item())
 
@@ -1023,27 +1025,30 @@ class Trainer:
                                 target_coords = batch["coords"].to(
                                     device=self.device, dtype=outputs["decoded"].dtype
                                 )
+                                rmsd_mask = outputs.get("valid_mask", outputs["mask"])
                                 rmsd_val = rmsd(
-                                    outputs["decoded"].detach(), target_coords, mask=outputs["mask"]
+                                    outputs["decoded"].detach(),
+                                    target_coords,
+                                    mask=rmsd_mask,
                                 ).item()
                                 trackers["rmsd"].update(rmsd_val, batch_size)
-                                vq_losses = outputs.get("vq_losses", {})
-                                commitment_loss = vq_losses.get("commitment")
+                                vq_metrics = outputs.get("vq_metrics", {})
+                                commitment_loss = vq_metrics.get("commitment")
                                 if commitment_loss is not None:
                                     trackers["vq_commitment"].update(
                                         float(commitment_loss.detach().item()), batch_size
                                     )
-                                codebook_loss = vq_losses.get("codebook")
+                                codebook_loss = vq_metrics.get("codebook")
                                 if codebook_loss is not None:
                                     trackers["vq_codebook"].update(
                                         float(codebook_loss.detach().item()), batch_size
                                     )
-                                orth_loss = vq_losses.get("orthogonality")
+                                orth_loss = vq_metrics.get("orthogonality")
                                 if orth_loss is not None:
                                     trackers["vq_orthogonality"].update(
                                         float(orth_loss.detach().item()), batch_size
                                     )
-                                perplexity = vq_losses.get("perplexity")
+                                perplexity = vq_metrics.get("perplexity")
                                 if perplexity is not None:
                                     trackers["perplexity"].update(float(perplexity.detach().item()))
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -106,13 +106,14 @@ def test_vq_decoder_pipeline_runs() -> None:
     decoder = RotationDecoder(dim, translation_scale=0.5)
 
     latents = torch.randn(batch, length, dim, requires_grad=True)
-    quantized, indices, losses = vq(latents)
+    quantized, indices, vq_loss, metrics = vq(latents, return_metrics=True)
     coords, _ = decoder(quantized)
 
     assert coords.shape == (batch, length, 3, 3)
     assert indices.shape == (batch, length)
-    total_loss = losses["commitment"] + losses["codebook"]
-    total_loss.backward()
+    total_loss = metrics["commitment"] + metrics["codebook"]
+    assert torch.allclose(total_loss, vq_loss)
+    vq_loss.backward()
     assert torch.isfinite(latents.grad).all()
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -140,8 +140,14 @@ class FakeModel(nn.Module):
             torch.zeros_like(mask, dtype=torch.long),
             torch.full_like(mask, -1, dtype=torch.long),
         )
-        vq_losses = {"perplexity": torch.tensor(2.0, device=self.dummy.device)}
-        return {"decoded": decoded, "mask": mask, "indices": indices, "vq_losses": vq_losses}
+        vq_metrics = {"perplexity": torch.tensor(2.0, device=self.dummy.device)}
+        return {
+            "decoded": decoded,
+            "mask": mask,
+            "valid_mask": mask,
+            "indices": indices,
+            "vq_metrics": vq_metrics,
+        }
 
 
 def test_evaluate_reports_summary(tmp_path, monkeypatch) -> None:

--- a/tests/test_vq.py
+++ b/tests/test_vq.py
@@ -33,14 +33,13 @@ def test_vector_quantizer_forward_shapes() -> None:
     vq = _make_vq(dim, num_codes)
 
     latents = torch.randn(batch, length, dim, requires_grad=True)
-    quantized, indices, losses = vq(latents)
+    quantized, indices, loss, metrics = vq(latents, return_metrics=True)
 
     assert quantized.shape == (batch, length, dim)
     assert indices.shape == (batch, length)
-    assert {"commitment", "codebook", "orthogonality", "perplexity"} <= set(losses)
+    assert {"commitment", "codebook", "orthogonality", "perplexity"} <= set(metrics)
 
-    total_loss = losses["commitment"] + losses["codebook"] + losses["orthogonality"]
-    total_loss.backward()
+    loss.backward()
     assert torch.isfinite(latents.grad).all()
 
 
@@ -52,11 +51,11 @@ def test_vector_quantizer_supports_masks() -> None:
     latents = torch.randn(batch, length, dim, requires_grad=True)
     mask = torch.tensor([[True, True, False, True, False, False]])
 
-    quantized, indices, losses = vq(latents, mask=mask)
+    quantized, indices, loss, metrics = vq(latents, mask=mask, return_metrics=True)
 
     assert quantized.shape == (batch, length, dim)
     assert torch.equal(indices[~mask], torch.full((3,), -1, dtype=torch.long))
-    assert losses["perplexity"].item() >= 1.0
+    assert metrics["perplexity"].item() >= 1.0
 
 
 def test_get_output_from_indices_matches_quantized_vectors() -> None:


### PR DESCRIPTION
## Summary
- extend the transformer bridge forward path to accept decoder-only usage, compute a single valid mask, and expose the new VQ loss output
- switch the vector-quantiser wrapper to return a scalar loss with optional metrics and propagate the API through encode/decode helpers and runtime evaluation
- align the end-to-end integration coverage with the scalar VQ loss output expected by the new API

## Testing
- pytest -q --disable-warnings


------
https://chatgpt.com/codex/tasks/task_b_68e0a6534b34832388facf47f2e7db0d