### PR TITLE
Align VQ defaults with 128-dim latent size

### DIFF
--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -58,12 +58,14 @@ model:
     return_zeros_for_masked_padding: true
   encoder:
     model_dim: 1024
+    output_dim: 128
     num_layers: 12
     num_heads: 16
     num_kv_heads: 4
     dropout: 0.0
     ffn_multiplier: 4.0
   decoder:
+    input_dim: 128
     model_dim: 1024
     num_layers: 16
     num_heads: 16

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -53,11 +53,13 @@ model:
     orthogonal_reg_weight: 1.0
   encoder:
     model_dim: 384
+    output_dim: 128
     num_layers: 4
     num_heads: 6
     num_kv_heads: 2
     dropout: 0.0
   decoder:
+    input_dim: 128
     model_dim: 384
     num_layers: 6
     num_heads: 6

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -44,20 +44,22 @@ model:
     strict_init: false
   adapter:
     enabled: true
-    output_dim: 16
+    output_dim: 32
   vq:
     num_codes: 16
-    dim: 16
+    dim: 128
     beta: 0.25
     decay: 0.99
     kmeans_iters: 1
   encoder:
     model_dim: 64
+    output_dim: 128
     num_layers: 2
     num_heads: 2
     num_kv_heads: 1
     dropout: 0.0
   decoder:
+    input_dim: 128
     model_dim: 64
     num_layers: 2
     num_heads: 2

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -73,11 +73,11 @@ class GCPVQVAEConfig:
 
     gcp: GCPNetConfig = field(default_factory=GCPNetConfig)
     encoder: TransformerConfig = field(
-        default_factory=lambda: TransformerConfig(input_dim=256, output_dim=256)
+        default_factory=lambda: TransformerConfig(input_dim=128, output_dim=128)
     )
     decoder: TransformerConfig = field(
         default_factory=lambda: TransformerConfig(
-            input_dim=256, num_layers=16, num_heads=16, num_kv_heads=1
+            input_dim=128, num_layers=16, num_heads=16, num_kv_heads=1
         )
     )
     vq: VectorQuantizerConfig = field(default_factory=VectorQuantizerConfig)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -74,13 +74,13 @@ def _make_small_config() -> GCPVQVAEConfig:
         ),
         message_passing=GCPMessagePassingConfig(width=GCPWidthConfig(scalar=32, vector=4)),
         feed_forward=GCPFeedForwardConfig(width=GCPWidthConfig(scalar=64, vector=4)),
-        latent_dim=32,
+        latent_dim=64,
         num_layers=2,
     )
-    vq_cfg = VectorQuantizerConfig(num_codes=16, dim=32, beta=0.25, decay=0.9, kmeans_iters=1)
+    vq_cfg = VectorQuantizerConfig(num_codes=16, dim=128, beta=0.25, decay=0.9, kmeans_iters=1)
     enc_cfg = TransformerConfig(
         input_dim=gcp_cfg.latent_dim,
-        model_dim=64,
+        model_dim=128,
         output_dim=vq_cfg.dim,
         num_layers=2,
         num_heads=4,
@@ -89,13 +89,13 @@ def _make_small_config() -> GCPVQVAEConfig:
     )
     dec_cfg = TransformerConfig(
         input_dim=vq_cfg.dim,
-        model_dim=64,
+        model_dim=128,
         num_layers=2,
         num_heads=4,
         num_kv_heads=1,
         dropout=0.0,
     )
-    rot_cfg = RotationHeadConfig(input_dim=64, translation_scale=1.0)
+    rot_cfg = RotationHeadConfig(input_dim=128, translation_scale=1.0)
     data_cfg = DataPipelineConfig(length_cap=256, knn=4)
     return GCPVQVAEConfig(gcp=gcp_cfg, encoder=enc_cfg, decoder=dec_cfg, vq=vq_cfg, rotation=rot_cfg, data=data_cfg)
 

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -92,13 +92,13 @@ def _make_config() -> GCPVQVAEConfig:
         ),
         message_passing=GCPMessagePassingConfig(width=GCPWidthConfig(scalar=64, vector=8)),
         feed_forward=GCPFeedForwardConfig(width=GCPWidthConfig(scalar=128, vector=8)),
-        latent_dim=32,
+        latent_dim=64,
         num_layers=2,
     )
-    vq_cfg = VectorQuantizerConfig(num_codes=32, dim=24, beta=0.25, decay=0.9, kmeans_iters=1)
+    vq_cfg = VectorQuantizerConfig(num_codes=32, dim=128, beta=0.25, decay=0.9, kmeans_iters=1)
     enc_cfg = TransformerConfig(
         input_dim=gcp_cfg.latent_dim,
-        model_dim=48,
+        model_dim=128,
         output_dim=vq_cfg.dim,
         num_layers=2,
         num_heads=4,
@@ -107,13 +107,13 @@ def _make_config() -> GCPVQVAEConfig:
     )
     dec_cfg = TransformerConfig(
         input_dim=vq_cfg.dim,
-        model_dim=48,
+        model_dim=128,
         num_layers=2,
         num_heads=4,
         num_kv_heads=1,
         dropout=0.0,
     )
-    rot_cfg = RotationHeadConfig(input_dim=48, translation_scale=1.0)
+    rot_cfg = RotationHeadConfig(input_dim=128, translation_scale=1.0)
     data_cfg = DataPipelineConfig(length_cap=512, knn=4)
     return GCPVQVAEConfig(
         gcp=gcp_cfg,
@@ -193,14 +193,14 @@ def test_latent_adapter_projects_embeddings(tmp_path) -> None:
         ),
         message_passing=GCPMessagePassingConfig(width=GCPWidthConfig(scalar=128, vector=16)),
         feed_forward=GCPFeedForwardConfig(width=GCPWidthConfig(scalar=256, vector=16)),
-        latent_dim=256,
+        latent_dim=128,
         num_layers=3,
     )
     adapter_cfg = LatentAdapterConfig(enabled=True, output_dim=32, bias=True)
-    vq_cfg = VectorQuantizerConfig(num_codes=16, dim=24, beta=0.25, decay=0.9, kmeans_iters=1)
+    vq_cfg = VectorQuantizerConfig(num_codes=16, dim=128, beta=0.25, decay=0.9, kmeans_iters=1)
     enc_cfg = TransformerConfig(
         input_dim=gcp_cfg.latent_dim,
-        model_dim=48,
+        model_dim=128,
         output_dim=vq_cfg.dim,
         num_layers=2,
         num_heads=4,
@@ -209,13 +209,13 @@ def test_latent_adapter_projects_embeddings(tmp_path) -> None:
     )
     dec_cfg = TransformerConfig(
         input_dim=vq_cfg.dim,
-        model_dim=48,
+        model_dim=128,
         num_layers=2,
         num_heads=4,
         num_kv_heads=1,
         dropout=0.0,
     )
-    rot_cfg = RotationHeadConfig(input_dim=48, translation_scale=1.0)
+    rot_cfg = RotationHeadConfig(input_dim=128, translation_scale=1.0)
     data_cfg = DataPipelineConfig(length_cap=512, knn=2)
     config = GCPVQVAEConfig(
         gcp=gcp_cfg,


### PR DESCRIPTION
## Summary
- default the VQ-connected transformer components to 128-d latents
- update the packaged training configs to advertise 128-d codebooks and wire encoder/decoder interfaces accordingly
- refresh API/end-to-end tests to exercise the wider 128-dim quantiser pathway

## Testing
- pytest tests/test_model_api.py tests/test_end_to_end.py::test_vq_decoder_pipeline_runs -q *(fails: missing optional dependency vector-quantize-pytorch in the test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0ae85c5e4832386716f593b82b29f