### PR TITLE
Add configurable geometric transformer decoder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "hydra-core>=1.3",
     "wandb",
     "tqdm",
+    "x-transformers>=2.8.2",
 ]
 
 [project.optional-dependencies]

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -72,6 +72,12 @@ model:
     num_kv_heads: 1
     dropout: 0.0
     ffn_multiplier: 4.0
+    use_ndlinear: true
+    max_length: 2048
+    num_memory_tokens: 0
+    use_flash_attn: false
+    use_qk_norm: false
+    causal: false
 
 train:
   seed: 42

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -65,6 +65,12 @@ model:
     num_heads: 6
     num_kv_heads: 1
     dropout: 0.0
+    use_ndlinear: false
+    max_length: 512
+    num_memory_tokens: 0
+    use_flash_attn: false
+    use_qk_norm: false
+    causal: false
 
 train:
   seed: 1234

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -65,6 +65,12 @@ model:
     num_heads: 2
     num_kv_heads: 1
     dropout: 0.0
+    use_ndlinear: false
+    max_length: 128
+    num_memory_tokens: 0
+    use_flash_attn: false
+    use_qk_norm: false
+    causal: false
 
 train:
   seed: 7

--- a/src/gcpvqvae/models/decoders.py
+++ b/src/gcpvqvae/models/decoders.py
@@ -1,0 +1,146 @@
+"""Transformer-based geometric decoder modules."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+from torch import Tensor, nn
+
+from x_transformers import ContinuousTransformerWrapper, Encoder
+
+from gcpvqvae.models.transformer import TransformerConfig
+
+
+class NdLinear(nn.Module):
+    """Position-aware linear layer matching reference checkpoint shapes."""
+
+    def __init__(
+        self,
+        input_dims: tuple[int, int],
+        hidden_size: tuple[int, int],
+        *,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+
+        if len(input_dims) != 2 or len(hidden_size) != 2:
+            raise ValueError("NdLinear currently supports 2D inputs (length, features)")
+        max_length_in, in_features = input_dims
+        max_length_out, out_features = hidden_size
+        if max_length_in != max_length_out:
+            raise ValueError(
+                "Input and output length dimensions must match for NdLinear"
+            )
+
+        self.max_length = max_length_in
+        self.in_features = in_features
+        self.out_features = out_features
+
+        weight = torch.empty(self.max_length, self.out_features, self.in_features)
+        nn.init.kaiming_uniform_(weight.view(self.max_length * self.out_features, self.in_features), a=math.sqrt(5))
+        self.weight = nn.Parameter(weight)
+
+        if bias:
+            bound = 1 / math.sqrt(self.in_features)
+            bias_param = torch.empty(self.max_length, self.out_features)
+            nn.init.uniform_(bias_param, -bound, bound)
+            self.bias = nn.Parameter(bias_param)
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x: Tensor) -> Tensor:
+        if x.shape[-1] != self.in_features:
+            raise ValueError(
+                f"Expected input feature dimension {self.in_features}, got {x.shape[-1]}"
+            )
+        seq_len = x.shape[-2]
+        if seq_len > self.max_length:
+            raise ValueError(
+                f"Sequence length {seq_len} exceeds NdLinear maximum of {self.max_length}"
+            )
+
+        weight = self.weight[:seq_len]
+        out = torch.einsum("...ld, lod -> ...lo", x, weight)
+        if self.bias is not None:
+            out = out + self.bias[:seq_len]
+        return out
+
+
+class GeometricTransformerDecoder(nn.Module):
+    """Decoder aligning latent tokens with geometric reconstruction heads."""
+
+    def __init__(self, config: TransformerConfig) -> None:
+        super().__init__()
+        self.config = config
+
+        if config.use_ndlinear:
+            if config.max_length is None:
+                raise ValueError("NdLinear projection requires `max_length` to be set")
+            self.input_proj: nn.Module = NdLinear(
+                input_dims=(config.max_length, config.input_dim),
+                hidden_size=(config.max_length, config.model_dim),
+                bias=False,
+            )
+        else:
+            self.input_proj = nn.Linear(config.input_dim, config.model_dim, bias=False)
+
+        attn_kwargs: dict[str, object] = {
+            "dim": config.model_dim,
+            "depth": config.num_layers,
+            "heads": config.num_heads,
+            "ff_mult": config.ffn_multiplier,
+            "ff_dropout": config.dropout,
+            "attn_dropout": config.dropout,
+            "ff_glu": True,
+            "ff_swish": True,
+            "rotary_pos_emb": config.use_rope,
+            "attn_dim_head": config.model_dim // config.num_heads,
+            "attn_kv_heads": config.num_kv_heads,
+        }
+
+        if getattr(config, "rotary_xpos", False):
+            attn_kwargs["rotary_xpos"] = True
+
+        if config.use_flash_attn:
+            attn_kwargs["attn_flash"] = True
+
+        if config.use_qk_norm:
+            attn_kwargs.update(
+                {
+                    "attn_qk_norm": True,
+                    "attn_qk_norm_groups": config.qk_norm_groups,
+                    "attn_qk_norm_scale": config.qk_norm_scale,
+                    "attn_qk_norm_dim_scale": config.qk_norm_dim_scale,
+                }
+            )
+
+        self.transformer = ContinuousTransformerWrapper(
+            max_seq_len=config.max_length or 0,
+            attn_layers=Encoder(**attn_kwargs),
+            dim_in=None,
+            dim_out=config.output_dim or config.model_dim,
+            emb_dropout=config.dropout,
+            num_memory_tokens=config.num_memory_tokens or None,
+        )
+
+    def forward(self, latents: Tensor, *, mask: Optional[Tensor] = None) -> Tensor:
+        if latents.ndim != 3:
+            raise ValueError("Decoder inputs must have shape (batch, length, dim)")
+
+        projected = self.input_proj(latents)
+
+        attn_mask: Optional[Tensor] = None
+        if self.config.causal:
+            seq_len = projected.shape[1]
+            attn_mask = torch.ones(
+                seq_len, seq_len, device=projected.device, dtype=torch.bool
+            ).tril()
+
+        pad_mask = mask.to(torch.bool) if mask is not None else None
+
+        return self.transformer(projected, mask=pad_mask, attn_mask=attn_mask)
+
+
+__all__ = ["GeometricTransformerDecoder", "NdLinear"]

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -14,6 +14,7 @@ from gcpvqvae.data.batch import EdgeStorage, ProteinBatch, protein_batch_from_gr
 from gcpvqvae.data.featurize import featurize_backbone
 from gcpvqvae.data.mmcif import PAD_INDEX, BackboneRecord, load_mmcif
 from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.decoders import GeometricTransformerDecoder
 from gcpvqvae.models.gcpnet import GCPNetConfig, GCPNetEncoder
 from gcpvqvae.models.losses import reconstruction_loss
 from gcpvqvae.models.transformer import GCPTokensTransformer, TransformerConfig
@@ -107,6 +108,8 @@ class GCPVQVAEConfig:
             decoder_out = self.decoder.output_dim
         if self.rotation.input_dim is None:
             self.rotation.input_dim = decoder_out
+        if self.decoder.use_ndlinear and self.decoder.max_length is None:
+            raise ValueError("Decoder NdLinear projection requires 'max_length' to be set")
 
 
 class GCPVQVAE(nn.Module):
@@ -147,7 +150,7 @@ class GCPVQVAE(nn.Module):
             orthogonal_reg_max_codes=self.config.vq.orthogonal_reg_max_codes,
             options=vq_options,
         )
-        self.decoder_transformer = GCPTokensTransformer(self.config.decoder)
+        self.decoder_transformer = GeometricTransformerDecoder(self.config.decoder)
         self.rotation_decoder = RotationDecoder(
             self.config.rotation.input_dim,
             translation_scale=self.config.rotation.translation_scale,

--- a/src/gcpvqvae/models/transformer.py
+++ b/src/gcpvqvae/models/transformer.py
@@ -176,6 +176,16 @@ class TransformerConfig:
     dropout: float = 0.0
     ffn_multiplier: float = 4.0
     use_rope: bool = True
+    use_ndlinear: bool = False
+    max_length: Optional[int] = None
+    num_memory_tokens: int = 0
+    use_flash_attn: bool = False
+    use_qk_norm: bool = False
+    qk_norm_groups: int = 1
+    qk_norm_scale: float = 10.0
+    qk_norm_dim_scale: bool = False
+    rotary_xpos: bool = False
+    causal: bool = False
 
 
 class GCPTokensTransformer(nn.Module):


### PR DESCRIPTION
## Summary
- add a geometric decoder module backed by x-transformers with optional NdLinear input projection
- extend decoder configuration schema and YAML presets with reference alignment flags
- wire the new decoder into GCPVQVAE and declare the x-transformers dependency

## Testing
- pytest tests/test_model_api.py::test_model_forward_runs -q

------
https://chatgpt.com/codex/tasks/task_b_68e156b6aa3c8323b3172a8f11e6ce47