### PR TITLE
Introduce Dim6 rigid decoder head with flattened outputs

### DIFF
--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -115,7 +115,7 @@ Additional top-level options control auxiliary behaviour:
 | key | default | description |
 | --- | --- | --- |
 | `input_dim` | derived | Automatically matches the decoder output width. |
-| `translation_scale` | `1.0` | Scale factor applied to predicted translations. |
+| `decoder_output_scaling_factor` | `1.0` | Multiplier applied to the flattened decoder outputs. |
 | `template` | `null` | Optional tensor describing a template structure. |
 
 ### `model.data` – Training-time preprocessing (`DataPipelineConfig`)

--- a/src/gcpvqvae/configs/gcpnet_pretrain.yaml
+++ b/src/gcpvqvae/configs/gcpnet_pretrain.yaml
@@ -42,7 +42,7 @@ model:
     norm_pos_diff: false
   rotation:
     input_dim: null
-    translation_scale: 1.0
+    decoder_output_scaling_factor: 1.0
 
 train:
   seed: 42

--- a/src/gcpvqvae/models/decoder.py
+++ b/src/gcpvqvae/models/decoder.py
@@ -1,140 +1,136 @@
-"""Rotation-based decoder mapping latents to backbone coordinates."""
+"""Structure decoding head producing rigid frames from latent features."""
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 from torch import Tensor, nn
 
 
-def _normalize(vec: Tensor, eps: float = 1e-8) -> Tensor:
+def _normalize(vec: Tensor, eps: float = 1e-5) -> Tensor:
     norm = torch.linalg.norm(vec, dim=-1, keepdim=True)
     return vec / torch.clamp(norm, min=eps)
 
 
-class RotationDecoder(nn.Module):
-    """6D rotation decoder head operating on transformer outputs.
+def _gram_schmidt(vec_a: Tensor, vec_b: Tensor, eps: float = 1e-5) -> Tensor:
+    """Construct an orthonormal frame using Gram–Schmidt orthogonalisation."""
 
-    The module implements the rigid-body update described in Algorithm 1 of the
-    GCP-VQVAE manuscript.  Given a stream of latent vectors it predicts per-step
-    rotation and translation updates which are accumulated to reconstruct the
-    backbone coordinates from an idealised local template.
-    """
+    u1 = _normalize(vec_a, eps)
+    proj = (u1 * vec_b).sum(dim=-1, keepdim=True) * u1
+    u2 = vec_b - proj
+
+    needs_fallback = torch.linalg.norm(u2, dim=-1, keepdim=True) < eps
+    if needs_fallback.any():
+        fallback = torch.zeros_like(u2)
+        fallback[..., 1] = 1.0
+        fallback = fallback - (fallback * u1).sum(dim=-1, keepdim=True) * u1
+        u2 = torch.where(needs_fallback, fallback, u2)
+
+    u2 = _normalize(u2, eps)
+    u3 = torch.cross(u1, u2, dim=-1)
+    u3 = _normalize(u3, eps)
+    u2 = torch.cross(u3, u1, dim=-1)
+
+    return torch.stack((u1, u2, u3), dim=-1)
+
+
+class Dim6RotStructureHead(nn.Module):
+    """Decode latent representations into rigid frames and backbone coordinates."""
 
     def __init__(
         self,
         in_dim: int,
         *,
-        translation_scale: float = 1.0,
         template: Optional[Tensor] = None,
+        decoder_output_scaling_factor: float = 1.0,
     ) -> None:
         super().__init__()
 
         self.in_dim = in_dim
-        self.translation_scale = translation_scale
-        self.proj = nn.Linear(in_dim, 9, bias=True)
+        self.output_scale = decoder_output_scaling_factor
+
+        self.linear = nn.Linear(in_dim, in_dim, bias=True)
+        self.activation = nn.GELU()
+        self.norm = nn.LayerNorm(in_dim)
+        self.out_proj = nn.Linear(in_dim, 9, bias=True)
 
         if template is None:
-            # Idealised backbone geometry (Å).  The coordinates are centred so
-            # that the Cα atom sits at the origin which improves numerical
-            # stability when composing transforms.
             template = torch.tensor(
                 [
-                    [-0.525, 0.000, 0.000],  # N
-                    [0.000, 0.000, 0.000],   # Cα
-                    [0.626, 0.000, 0.000],   # C
+                    [0.5256, 1.3612, 0.0],  # Cα
+                    [0.0, 0.0, 0.0],       # N
+                    [-1.5251, 0.0, 0.0],   # C
                 ]
             )
         self.register_buffer("template", template, persistent=False)
+        self.register_buffer(
+            "reorder_index", torch.tensor([1, 0, 2], dtype=torch.long), persistent=False
+        )
 
-    def forward(
+    def _decode_params(
         self,
-        latents: Tensor,
-        *,
+        params: Tensor,
         mask: Optional[Tensor] = None,
-        init_pose: Optional[Tuple[Tensor, Tensor]] = None,
-    ) -> Tuple[Tensor, Tuple[Tensor, Tensor]]:
-        """Decode latent representations into backbone coordinates.
+    ) -> Tuple[Tensor, Dict[str, Tensor]]:
+        if params.ndim != 3 or params.size(-1) != 9:
+            raise ValueError("params must have shape (batch, length, 9)")
 
-        Parameters
-        ----------
-        latents:
-            Tensor of shape ``(batch, length, in_dim)``.
-        mask:
-            Optional boolean mask of shape ``(batch, length)``.  Masked positions
-            are ignored and their coordinates are filled with zeros.
-        init_pose:
-            Optional tuple ``(R, t)`` providing the initial rigid transform for
-            each sequence in the batch.  ``R`` has shape ``(batch, 3, 3)`` and
-            ``t`` has shape ``(batch, 3)``.
-        """
-
-        if latents.ndim != 3:
-            raise ValueError("latents must have shape (batch, length, dim)")
-
-        batch, length, _ = latents.shape
-        device = latents.device
-        dtype = latents.dtype
+        batch, length, _ = params.shape
+        device = params.device
+        dtype = params.dtype
 
         if mask is None:
             mask = torch.ones((batch, length), dtype=torch.bool, device=device)
         else:
             mask = mask.to(torch.bool)
 
-        if init_pose is None:
-            R = torch.eye(3, device=device, dtype=dtype).expand(batch, 3, 3).clone()
-            t = torch.zeros((batch, 3), device=device, dtype=dtype)
-        else:
-            R, t = init_pose
-            if R.shape != (batch, 3, 3) or t.shape != (batch, 3):
-                raise ValueError("Initial pose must match batch dimensions")
-            R = R.clone()
-            t = t.clone()
+        translation, hint_a, hint_b = torch.split(params, 3, dim=-1)
+        hint_a = hint_a + translation
+        hint_b = hint_b + translation
 
-        out_coords = []
+        rotations = _gram_schmidt(hint_a, hint_b)
 
-        projected = self.proj(latents)
-        translation, vec_a, vec_b = torch.split(projected, 3, dim=-1)
+        template = self.template.to(device=device, dtype=dtype).transpose(0, 1)
+        rotated = torch.matmul(rotations, template).transpose(-1, -2)
+        coords = rotated + translation.unsqueeze(-2)
 
-        for idx in range(length):
-            active = mask[:, idx].view(batch, 1)
-            if not active.any():
-                out_coords.append(torch.zeros((batch, 3, 3), device=device, dtype=dtype))
-                continue
+        # Reorder to the conventional (N, Cα, C) atom ordering expected downstream.
+        coords = coords.index_select(-2, self.reorder_index.to(device=device))
 
-            a = _normalize(vec_a[:, idx, :], eps=1e-6)
-            b_raw = vec_b[:, idx, :]
-            b = b_raw - (a * b_raw).sum(dim=-1, keepdim=True) * a
-            needs_fallback = torch.linalg.norm(b, dim=-1, keepdim=True) < 1e-6
-            if needs_fallback.any():
-                fallback = torch.zeros((batch, 3), device=device, dtype=dtype)
-                fallback[:, 1] = 1.0
-                fallback = fallback - (fallback * a).sum(dim=-1, keepdim=True) * a
-                b = torch.where(needs_fallback, fallback, b)
-            b = _normalize(b, eps=1e-6)
-            c = torch.cross(a, b, dim=-1)
-            c = _normalize(c, eps=1e-6)
-            b = torch.cross(c, a, dim=-1)
+        mask_expanded = mask.unsqueeze(-1).unsqueeze(-1)
+        coords = torch.where(mask_expanded, coords, torch.zeros_like(coords))
 
-            R_local = torch.stack((a, b, c), dim=-1)  # (batch, 3, 3)
+        identity = torch.eye(3, device=device, dtype=dtype).view(1, 1, 3, 3)
+        rotations = torch.where(mask_expanded, rotations, identity)
+        translation = torch.where(mask.unsqueeze(-1), translation, torch.zeros_like(translation))
 
-            t_local = self.translation_scale * translation[:, idx, :]
+        flat = coords.reshape(batch, length, 9)
+        scaled = flat * self.output_scale
 
-            R_candidate = R @ R_local
-            t_candidate = (R @ t_local.unsqueeze(-1)).squeeze(-1) + t
+        aux = {
+            "rotations": rotations,
+            "translations": translation,
+            "coordinates": coords,
+            "mask": mask,
+        }
+        return scaled, aux
 
-            coords = torch.einsum("bij,aj->bai", R_candidate, self.template) + t_candidate.unsqueeze(-2)
+    def forward(
+        self,
+        latents: Tensor,
+        *,
+        mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Dict[str, Tensor]]:
+        if latents.ndim != 3 or latents.size(-1) != self.in_dim:
+            raise ValueError("latents must have shape (batch, length, in_dim)")
 
-            R = torch.where(active.view(batch, 1, 1), R_candidate, R)
-            t = torch.where(active, t_candidate, t)
-            coords = torch.where(active.view(batch, 1, 1), coords, torch.zeros_like(coords))
-            out_coords.append(coords)
+        hidden = self.linear(latents)
+        hidden = self.activation(hidden)
+        hidden = self.norm(hidden)
+        params = self.out_proj(hidden)
 
-        stacked = torch.stack(out_coords, dim=1)
-        final_pose = (R, t)
-
-        return stacked, final_pose
+        return self._decode_params(params, mask=mask)
 
 
-__all__ = ["RotationDecoder"]
+__all__ = ["Dim6RotStructureHead"]

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -13,7 +13,7 @@ from torch import Tensor, nn
 from gcpvqvae.data.batch import EdgeStorage, ProteinBatch, protein_batch_from_graph_dict
 from gcpvqvae.data.featurize import featurize_backbone
 from gcpvqvae.data.mmcif import PAD_INDEX, BackboneRecord, load_mmcif
-from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.decoder import Dim6RotStructureHead
 from gcpvqvae.models.decoders import GeometricTransformerDecoder
 from gcpvqvae.models.gcpnet import GCPNetConfig, GCPNetEncoder
 from gcpvqvae.models.losses import reconstruction_loss
@@ -64,7 +64,7 @@ class RotationHeadConfig:
     """Parameters for the rigid 6D rotation decoder head."""
 
     input_dim: Optional[int] = None
-    translation_scale: float = 1.0
+    decoder_output_scaling_factor: float = 1.0
     template: Optional[Tensor] = None
 
 
@@ -151,10 +151,10 @@ class GCPVQVAE(nn.Module):
             options=vq_options,
         )
         self.decoder_transformer = GeometricTransformerDecoder(self.config.decoder)
-        self.rotation_decoder = RotationDecoder(
+        self.rotation_decoder = Dim6RotStructureHead(
             self.config.rotation.input_dim,
-            translation_scale=self.config.rotation.translation_scale,
             template=self.config.rotation.template,
+            decoder_output_scaling_factor=self.config.rotation.decoder_output_scaling_factor,
         )
 
     # ------------------------------------------------------------------ utils
@@ -312,15 +312,17 @@ class GCPVQVAE(nn.Module):
                 quantized[valid] = decoded.to(dtype)
 
             dec_hidden = self.decoder_transformer(quantized, mask=valid)
-            recon_coords, final_pose = self.rotation_decoder(dec_hidden, mask=valid)
+            decoded_flat, rigid = self.rotation_decoder(dec_hidden, mask=valid)
+            recon_coords = rigid["coordinates"]
 
             return {
                 "quantized": quantized,
                 "indices": indices,
                 "decoded": recon_coords,
+                "decoded_flat": decoded_flat,
                 "mask": mask_tensor,
                 "valid_mask": valid,
-                "pose": final_pose,
+                "pose": rigid,
                 "vq_loss": torch.zeros((), device=device, dtype=dtype),
                 "vq_metrics": {},
             }
@@ -355,7 +357,8 @@ class GCPVQVAE(nn.Module):
             }
 
         dec_hidden = self.decoder_transformer(quantized, mask=valid)
-        recon_coords, final_pose = self.rotation_decoder(dec_hidden, mask=valid)
+        decoded_flat, rigid = self.rotation_decoder(dec_hidden, mask=valid)
+        recon_coords = rigid["coordinates"]
 
         rec_loss, rec_components = reconstruction_loss(
             recon_coords,
@@ -372,9 +375,10 @@ class GCPVQVAE(nn.Module):
             "quantized": quantized,
             "indices": indices,
             "decoded": recon_coords,
+            "decoded_flat": decoded_flat,
             "mask": mask_tensor,
             "valid_mask": valid,
-            "pose": final_pose,
+            "pose": rigid,
             "vq_loss": vq_loss,
             "vq_metrics": vq_metrics,
             "reconstruction": rec_loss,
@@ -563,7 +567,8 @@ class GCPVQVAE(nn.Module):
                 dequant[valid] = decoded.to(dtype)
 
             dec_hidden = self.decoder_transformer(dequant, mask=valid)
-            coords_central, final_pose = self.rotation_decoder(dec_hidden, mask=valid)
+            decoded_flat, rigid = self.rotation_decoder(dec_hidden, mask=valid)
+            coords_central = rigid["coordinates"]
 
             if pose_header is not None:
                 rot, trans = pose_header
@@ -632,14 +637,21 @@ class GCPVQVAE(nn.Module):
             else:
                 records_out = None
 
+            pose_out = {
+                "rotations": rigid["rotations"].cpu(),
+                "translations": rigid["translations"].cpu(),
+            }
             result = {
                 "coords": coords_global.squeeze(0).cpu() if batch == 1 else coords_global.cpu(),
                 "coords_central": coords_central.squeeze(0).cpu()
                 if batch == 1
                 else coords_central.cpu(),
+                "coords_flat": decoded_flat.squeeze(0).cpu()
+                if batch == 1
+                else decoded_flat.cpu(),
                 "mask": mask_cpu.squeeze(0) if batch == 1 else mask_cpu,
                 "valid_mask": mask_cpu.squeeze(0) if batch == 1 else mask_cpu,
-                "pose": (final_pose[0].cpu(), final_pose[1].cpu()),
+                "pose": pose_out,
                 "pose_header": (rot_t.cpu(), trans_t.cpu()),
                 "records": records_out,
             }

--- a/src/gcpvqvae/system/train_gcpnet.py
+++ b/src/gcpvqvae/system/train_gcpnet.py
@@ -18,7 +18,7 @@ from torch.utils.data import DataLoader
 
 from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
 from gcpvqvae.geometry.metrics import rmsd
-from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.decoder import Dim6RotStructureHead
 from gcpvqvae.data.batch import protein_batch_from_graph_dict
 from gcpvqvae.models.gcpnet import GCPNetConfig, GCPNetEncoder
 from gcpvqvae.models.gcpvqvae import RotationHeadConfig
@@ -228,10 +228,10 @@ class GCPNetPretrainModule(nn.Module):
     def __init__(self, config: PretrainModelConfig) -> None:
         super().__init__()
         self.encoder = GCPNetEncoder(config.gcp)
-        self.rotation = RotationDecoder(
+        self.rotation = Dim6RotStructureHead(
             config.rotation.input_dim,
-            translation_scale=config.rotation.translation_scale,
             template=config.rotation.template,
+            decoder_output_scaling_factor=config.rotation.decoder_output_scaling_factor,
         )
 
     def forward(self, batch: Dict[str, Tensor]) -> Dict[str, Tensor]:
@@ -252,7 +252,8 @@ class GCPNetPretrainModule(nn.Module):
         padded.index_copy_(0, proto.valid_indices, flat_embeddings)
         embeddings = padded.reshape(batch_size, max_len, latent)
 
-        recon_coords, pose = self.rotation(embeddings, mask=mask)
+        decoded_flat, rigid = self.rotation(embeddings, mask=mask)
+        recon_coords = rigid["coordinates"]
         rec_loss, rec_components = reconstruction_loss(
             recon_coords, coords, mask=mask, return_components=True
         )
@@ -262,7 +263,9 @@ class GCPNetPretrainModule(nn.Module):
             "reconstruction": rec_loss,
             "reconstruction_components": rec_components,
             "coords": recon_coords,
+            "coords_flat": decoded_flat,
             "mask": mask,
+            "pose": rigid,
         }
 
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -4,85 +4,66 @@ from __future__ import annotations
 
 import torch
 
-from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.decoder import Dim6RotStructureHead
 
 
-def _identity_decoder(in_dim: int) -> RotationDecoder:
-    decoder = RotationDecoder(in_dim, translation_scale=1.0)
-    with torch.no_grad():
-        decoder.proj.weight.zero_()
-        decoder.proj.bias.zero_()
-        decoder.proj.weight.copy_(torch.eye(9, in_dim))
-    return decoder
+def test_structure_head_identity_template() -> None:
+    head = Dim6RotStructureHead(9, decoder_output_scaling_factor=1.0)
+    params = torch.tensor([[[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]]], dtype=torch.float32)
 
+    flat, aux = head._decode_params(params)
 
-def test_rotation_decoder_identity_frame() -> None:
-    decoder = _identity_decoder(9)
-    latents = torch.tensor([[[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]]])
-    coords, (R, t) = decoder(latents)
-
-    template = decoder.template
+    coords = aux["coordinates"]
+    template = head.template.index_select(0, torch.tensor([1, 0, 2]))
+    assert flat.shape == (1, 1, 9)
     assert torch.allclose(coords[0, 0], template, atol=1e-6)
-    assert torch.allclose(R, torch.eye(3))
-    assert torch.allclose(t, torch.zeros(3))
 
 
-def test_rotation_decoder_accumulates_translations() -> None:
-    decoder = _identity_decoder(9)
-    latents = torch.tensor(
+def test_structure_head_respects_mask() -> None:
+    head = Dim6RotStructureHead(9, decoder_output_scaling_factor=1.0)
+    params = torch.tensor(
         [
             [
-                [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
-                [0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
-            ]
-        ],
-        dtype=torch.float32,
-    )
-
-    coords, (R, t) = decoder(latents)
-
-    ca_positions = coords[0, :, 1, :]
-    assert torch.allclose(ca_positions[0], torch.tensor([1.0, 0.0, 0.0]))
-    assert torch.allclose(ca_positions[1], torch.tensor([1.0, 1.0, 0.0]))
-    assert torch.allclose(t, torch.tensor([1.0, 1.0, 0.0]))
-    assert torch.allclose(R, torch.eye(3))
-
-
-def test_rotation_decoder_respects_mask() -> None:
-    decoder = _identity_decoder(9)
-    latents = torch.tensor(
-        [
-            [
-                [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
-                [0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0, 0.5, 0.1, -0.2, -0.3, 0.4, 0.2],
+                [2.0, -1.0, 0.5, 0.3, -0.2, 0.1, 0.4, -0.3, 0.2],
             ]
         ],
         dtype=torch.float32,
     )
     mask = torch.tensor([[True, False]])
 
-    coords, (R, t) = decoder(latents, mask=mask)
+    flat, aux = head._decode_params(params, mask=mask)
 
-    ca_positions = coords[0, :, 1, :]
-    assert torch.allclose(ca_positions[0], torch.tensor([1.0, 0.0, 0.0]))
-    assert torch.allclose(ca_positions[1], torch.zeros(3))
-    assert torch.allclose(t, torch.tensor([1.0, 0.0, 0.0]))
+    coords = aux["coordinates"]
+    rotations = aux["rotations"]
+    translations = aux["translations"]
+
+    assert torch.all(flat[0, 1] == 0.0)
+    assert torch.all(coords[0, 1] == 0.0)
+    assert torch.allclose(rotations[0, 1], torch.eye(3), atol=1e-6)
+    assert torch.all(translations[0, 1] == 0.0)
 
 
-def test_rotation_decoder_produces_valid_rotations() -> None:
+def test_structure_head_scaling_factor() -> None:
+    head = Dim6RotStructureHead(9, decoder_output_scaling_factor=2.5)
+    params = torch.zeros(1, 1, 9)
+
+    flat, aux = head._decode_params(params)
+    coords = aux["coordinates"].reshape(1, 1, 9)
+
+    assert torch.allclose(flat, coords * 2.5, atol=1e-6)
+
+
+def test_structure_head_produces_orthonormal_rotations() -> None:
     torch.manual_seed(0)
-    decoder = RotationDecoder(9)
+    head = Dim6RotStructureHead(16)
+    params = torch.randn(3, 7, 9)
 
-    latents = torch.randn(2, 5, 9)
-    _, (R, _t) = decoder(latents)
+    _, aux = head._decode_params(params)
+    rotations = aux["rotations"].reshape(-1, 3, 3)
 
-    identity = torch.eye(3).expand(R.shape[0], 3, 3)
-    rt_r = torch.matmul(R.transpose(-1, -2), R)
-    assert torch.allclose(rt_r, identity, atol=1e-5)
-    det = torch.linalg.det(R)
+    identity = torch.eye(3)
+    rt_r = torch.matmul(rotations.transpose(-1, -2), rotations)
+    assert torch.allclose(rt_r, identity.expand_as(rt_r), atol=1e-5)
+    det = torch.linalg.det(rotations)
     assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
-
-    basis = torch.eye(3)
-    rotated = torch.matmul(R, basis)
-    norms = torch.linalg.norm(rotated, dim=-2)
-    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -10,7 +10,7 @@ import torch
 from gcpvqvae.data.dataset import BackboneDataset, collate_backbones
 from gcpvqvae.geometry.frames import kabsch_align
 from gcpvqvae.geometry.metrics import rmsd
-from gcpvqvae.models.decoder import RotationDecoder
+from gcpvqvae.models.decoder import Dim6RotStructureHead
 from gcpvqvae.models.gcpnet import (
     GCPEmbeddingConfig,
     GCPFeedForwardConfig,
@@ -95,7 +95,7 @@ def _make_small_config() -> GCPVQVAEConfig:
         num_kv_heads=1,
         dropout=0.0,
     )
-    rot_cfg = RotationHeadConfig(input_dim=128, translation_scale=1.0)
+    rot_cfg = RotationHeadConfig(input_dim=128, decoder_output_scaling_factor=1.0)
     data_cfg = DataPipelineConfig(length_cap=256, knn=4)
     return GCPVQVAEConfig(gcp=gcp_cfg, encoder=enc_cfg, decoder=dec_cfg, vq=vq_cfg, rotation=rot_cfg, data=data_cfg)
 
@@ -103,12 +103,14 @@ def _make_small_config() -> GCPVQVAEConfig:
 def test_vq_decoder_pipeline_runs() -> None:
     batch, length, dim = 2, 4, 3
     vq = VectorQuantizer(num_codes=4, dim=dim, beta=0.1, decay=0.9, rotation_trick=True)
-    decoder = RotationDecoder(dim, translation_scale=0.5)
+    decoder = Dim6RotStructureHead(dim, decoder_output_scaling_factor=0.5)
 
     latents = torch.randn(batch, length, dim, requires_grad=True)
     quantized, indices, vq_loss, metrics = vq(latents, return_metrics=True)
-    coords, _ = decoder(quantized)
+    flat, aux = decoder(quantized)
+    coords = aux["coordinates"]
 
+    assert flat.shape == (batch, length, 9)
     assert coords.shape == (batch, length, 3, 3)
     assert indices.shape == (batch, length)
     total_loss = metrics["commitment"] + metrics["codebook"]

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -113,7 +113,7 @@ def _make_config() -> GCPVQVAEConfig:
         num_kv_heads=1,
         dropout=0.0,
     )
-    rot_cfg = RotationHeadConfig(input_dim=128, translation_scale=1.0)
+    rot_cfg = RotationHeadConfig(input_dim=128, decoder_output_scaling_factor=1.0)
     data_cfg = DataPipelineConfig(length_cap=512, knn=4)
     return GCPVQVAEConfig(
         gcp=gcp_cfg,
@@ -215,7 +215,7 @@ def test_latent_adapter_projects_embeddings(tmp_path) -> None:
         num_kv_heads=1,
         dropout=0.0,
     )
-    rot_cfg = RotationHeadConfig(input_dim=128, translation_scale=1.0)
+    rot_cfg = RotationHeadConfig(input_dim=128, decoder_output_scaling_factor=1.0)
     data_cfg = DataPipelineConfig(length_cap=512, knn=2)
     config = GCPVQVAEConfig(
         gcp=gcp_cfg,


### PR DESCRIPTION
## Summary
- replace the legacy rotation decoder with a Dim6RotStructureHead that orthogonalises orientation hints, uses the updated template, and outputs flattened scaled coordinates
- adapt GCPVQVAE, the GCPNet pretrain module, and configuration docs to consume the flattened tensor and expose a decoder_output_scaling_factor knob
- refresh decoder and integration tests to target the new head API and verify flattened outputs alongside existing behaviours

## Testing
- pytest tests/test_decoder.py tests/test_end_to_end.py tests/test_model_api.py *(fails: ModuleNotFoundError: No module named 'x_transformers')*

------
https://chatgpt.com/codex/tasks/task_b_68e18fba12d883238e17533e55293126