### PR TITLE
Handle mixed CIF and PDB inputs during preprocessing

### DIFF
--- a/src/gcpvqvae/__init__.py
+++ b/src/gcpvqvae/__init__.py
@@ -1,18 +1,25 @@
 """Top-level package for the GCP-VQVAE project."""
 
-from .models.gcpvqvae import (
-    DataPipelineConfig,
-    GCPVQVAE,
-    GCPVQVAEConfig,
-    RotationHeadConfig,
-    VectorQuantizerConfig,
-)
+from importlib import import_module
+from typing import Any
 
-__all__ = [
-    "cli",
+_MODEL_EXPORTS = {
     "GCPVQVAE",
     "GCPVQVAEConfig",
     "VectorQuantizerConfig",
     "RotationHeadConfig",
     "DataPipelineConfig",
-]
+}
+
+__all__ = ["cli", *_MODEL_EXPORTS]
+
+
+def __getattr__(name: str) -> Any:
+    if name in _MODEL_EXPORTS:
+        module = import_module(".models.gcpvqvae", package=__name__)
+        return getattr(module, name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | _MODEL_EXPORTS)

--- a/src/gcpvqvae/cli.py
+++ b/src/gcpvqvae/cli.py
@@ -83,11 +83,6 @@ def gpcvq() -> None:
     help="Maximum worker processes to use while preprocessing.",
 )
 @click.option(
-    "--use-cif",
-    is_flag=True,
-    help="Treat INPUT as mmCIF data instead of the default PDB parsing.",
-)
-@click.option(
     "--no-file-index",
     is_flag=True,
     help="Skip writing the auxiliary file index alongside OUTPUT.",
@@ -104,7 +99,6 @@ def preprocess_dataset_command(
     max_len: Optional[int],
     min_len: Optional[int],
     max_workers: Optional[int],
-    use_cif: bool,
     no_file_index: bool,
     gap_threshold: Optional[float],
 ) -> None:
@@ -134,7 +128,6 @@ def preprocess_dataset_command(
             max_len=max_len,
             min_len=min_len,
             max_workers=max_workers,
-            use_cif=use_cif,
             file_index=not no_file_index,
             gap_threshold=gap_threshold,
         )

--- a/src/gcpvqvae/data/preprocess.py
+++ b/src/gcpvqvae/data/preprocess.py
@@ -404,15 +404,22 @@ def _process_structure_file(
         stats["parsing_errors"] += 1
         return [], stats
 
+    if not structure or len(structure) == 0:
+        stats["parsing_errors"] += 1
+        return [], stats
+
     polymer_chains: List[gemmi.Chain] = []
-    if structure:
-        model = structure[0]
+    model = structure[0] if structure else None
+    if model is not None:
         for chain in model:
             if _is_polymer_chain(chain):
                 polymer_chains.append(chain)
 
     if not polymer_chains:
-        stats["missing_coordinates"] += 1
+        if model is None or len(model) == 0:
+            stats["parsing_errors"] += 1
+        else:
+            stats["missing_coordinates"] += 1
         return [], stats
 
     if len({chain.name for chain in polymer_chains}) > 1:

--- a/src/gcpvqvae/data/preprocess.py
+++ b/src/gcpvqvae/data/preprocess.py
@@ -359,28 +359,26 @@ def _write_h5(
     return file_path
 
 
-def _discover_structure_files(input_root: Path, *, use_cif: bool) -> List[Path]:
+def _discover_structure_files(input_root: Path) -> List[Path]:
     if input_root.is_file():
         return [input_root]
 
-    if use_cif:
-        patterns = ["*.cif", "*.cif.gz", "*.mmcif", "*.mmcif.gz"]
-    else:
-        patterns = [
-            "*.cif",
-            "*.cif.gz",
-            "*.mmcif",
-            "*.mmcif.gz",
-            "*.pdb",
-            "*.pdb.gz",
-            "*.ent",
-            "*.ent.gz",
-        ]
+    patterns = [
+        "*.cif",
+        "*.cif.gz",
+        "*.mmcif",
+        "*.mmcif.gz",
+        "*.pdb",
+        "*.pdb.gz",
+        "*.ent",
+        "*.ent.gz",
+    ]
 
-    files: List[Path] = []
+    files: set[Path] = set()
     for pattern in patterns:
-        files.extend(sorted(input_root.rglob(pattern)))
-    return files
+        files.update(input_root.rglob(pattern))
+
+    return sorted(files, key=lambda path: path.as_posix())
 
 
 def _is_polymer_chain(chain: gemmi.Chain) -> bool:
@@ -599,14 +597,13 @@ def preprocess_dataset(
     max_len: Optional[int] = None,
     min_len: Optional[int] = None,
     max_workers: Optional[int] = None,
-    use_cif: bool = False,
     file_index: bool = True,
     gap_threshold: Optional[float] = None,
 ):
     """Preprocess AlphaFold-style structures into backbone summaries."""
 
     print(f"\nSearching for structure files in {input_root.resolve()}...", flush=True)
-    files = _discover_structure_files(input_root, use_cif=use_cif)
+    files = _discover_structure_files(input_root)
     print(
         f"  found {len(files)} structure files.",
         flush=True,

--- a/tests/test_cli_preprocess.py
+++ b/tests/test_cli_preprocess.py
@@ -18,7 +18,6 @@ def test_preprocess_dataset_help_lists_reference_options():
         "--max-len",
         "--min-len",
         "--max-workers",
-        "--use-cif",
         "--no-file-index",
         "--gap-threshold",
     ):
@@ -39,7 +38,6 @@ def test_preprocess_dataset_invokes_reference_driver(monkeypatch, tmp_path):
         max_len,
         min_len,
         max_workers,
-        use_cif,
         file_index,
         gap_threshold,
     ):
@@ -48,7 +46,6 @@ def test_preprocess_dataset_invokes_reference_driver(monkeypatch, tmp_path):
             "max_len": max_len,
             "min_len": min_len,
             "max_workers": max_workers,
-            "use_cif": use_cif,
             "file_index": file_index,
             "gap_threshold": gap_threshold,
         }
@@ -75,7 +72,6 @@ def test_preprocess_dataset_invokes_reference_driver(monkeypatch, tmp_path):
             "64",
             "--max-workers",
             "8",
-            "--use-cif",
             "--no-file-index",
             "--gap-threshold",
             "1.5",
@@ -88,7 +84,6 @@ def test_preprocess_dataset_invokes_reference_driver(monkeypatch, tmp_path):
         "max_len": 512,
         "min_len": 64,
         "max_workers": 8,
-        "use_cif": True,
         "file_index": False,
         "gap_threshold": 1.5,
     }

--- a/tests/test_reference_preprocessing_module.py
+++ b/tests/test_reference_preprocessing_module.py
@@ -68,6 +68,7 @@ def _write_structure(
     num_residues: int,
     chain_ids: Iterable[str] = ("A",),
     missing_ca: Iterable[int] | None = None,
+    format: str = "cif",
 ) -> None:
     missing_set = set(missing_ca or [])
 
@@ -95,8 +96,13 @@ def _write_structure(
 
     structure.add_model(model)
     structure.setup_entities()
-    doc = structure.make_mmcif_document()
-    doc.write_file(str(path))
+    if format == "cif":
+        doc = structure.make_mmcif_document()
+        doc.write_file(str(path))
+    elif format == "pdb":
+        structure.write_pdb(str(path))
+    else:  # pragma: no cover - guardrail for unexpected formats
+        raise ValueError(f"Unsupported format: {format}")
 
 
 def _assert_h5_matches_expected(generated_path: Path, expected: dict[str, object]) -> None:
@@ -164,9 +170,14 @@ def test_preprocess_dataset_collects_stats(tmp_path: Path) -> None:
     input_dir = tmp_path / "input"
     input_dir.mkdir()
 
-    _write_structure(input_dir / "valid.cif", num_residues=10)
+    _write_structure(input_dir / "valid.pdb", num_residues=10, format="pdb")
     _write_structure(input_dir / "short.cif", num_residues=4)
-    _write_structure(input_dir / "ratio.cif", num_residues=10, missing_ca={7, 8, 9})
+    _write_structure(
+        input_dir / "ratio.pdb",
+        num_residues=10,
+        missing_ca={7, 8, 9},
+        format="pdb",
+    )
     _write_structure(
         input_dir / "block.cif",
         num_residues=80,
@@ -178,7 +189,7 @@ def test_preprocess_dataset_collects_stats(tmp_path: Path) -> None:
     complex_path = input_dir / "complex.cif"
     _write_structure(complex_path, num_residues=6, chain_ids=["A", "B"])
 
-    (input_dir / "invalid.cif").write_text("not a cif", encoding="utf-8")
+    (input_dir / "invalid.pdb").write_text("not a pdb", encoding="utf-8")
 
     output_dir = tmp_path / "output"
     manifest_path, stats = preprocess_dataset(
@@ -187,7 +198,6 @@ def test_preprocess_dataset_collects_stats(tmp_path: Path) -> None:
         max_len=90,
         min_len=5,
         max_workers=2,
-        use_cif=True,
         file_index=True,
     )
 
@@ -227,13 +237,12 @@ def test_preprocess_dataset_collects_stats(tmp_path: Path) -> None:
 def test_preprocess_dataset_h5_matches_fixture(tmp_path: Path) -> None:
     input_dir = tmp_path / "input"
     input_dir.mkdir()
-    _write_structure(input_dir / "valid.cif", num_residues=5)
+    _write_structure(input_dir / "valid.pdb", num_residues=5, format="pdb")
 
     output_dir = tmp_path / "output"
     manifest_path, _ = preprocess_dataset(
         input_dir,
         output_dir,
-        use_cif=True,
         file_index=True,
     )
 
@@ -256,7 +265,6 @@ def test_preprocess_dataset_h5_preserves_nans(tmp_path: Path) -> None:
     manifest_path, _ = preprocess_dataset(
         input_dir,
         output_dir,
-        use_cif=True,
         file_index=True,
     )
 
@@ -276,7 +284,6 @@ def test_preprocess_dataset_omits_index_when_requested(tmp_path: Path) -> None:
     manifest_path, stats = preprocess_dataset(
         input_dir,
         output_dir,
-        use_cif=True,
         file_index=False,
     )
 


### PR DESCRIPTION
## Summary
- remove the `--use-cif` switch and make `preprocess_dataset` automatically discover CIF and PDB files
- update the CLI wrapper and regression tests to reflect automatic structure format detection
- extend preprocessing tests to write both CIF and PDB fixtures so mixed directories are covered

## Testing
- `pytest tests/test_reference_preprocessing_module.py::test_preprocess_dataset_collects_stats` *(fails: missing `x_transformers` dependency during import)*

------
https://chatgpt.com/codex/tasks/task_b_68e5a44f54fc832383d9bd4fb9456fdc