### PR TITLE
Resolve default GCPNet checkpoint path at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ gpcvq train-gpcnet data.root=path/to/backbones
 
 The resulting checkpoints expose a `gcp_state` entry that can be referenced from
 `model.gcp.init` (alongside `model.gcp.init_checkpoint`) in the full training
-configuration to load the encoder weights.
+configuration to load the encoder weights.  When the bundled configurations set
+`model.gcp.init: "pretrained"` but leave `model.gcp.init_checkpoint` unset, the
+trainer resolves the packaged checkpoint relative to the module at runtime, so
+the defaults work regardless of the current working directory.
 
 ### Experiment logging with Weights & Biases
 

--- a/src/gcpvqvae/configs/README.md
+++ b/src/gcpvqvae/configs/README.md
@@ -65,9 +65,10 @@ Additional top-level options control auxiliary behaviour:
 - `use_gcp_dropout` (`True`): selects coupled scalar/vector dropout; disable to fall back to independent dropout.
 - `norm_pos_diff` (`False`): toggles normalisation of positional differences.
 - `init` (`"random"`), `init_checkpoint` (`null`), `strict_init` (`True`): checkpoint initialisation controls.  The packaged
-  training configurations default to `init: "pretrained"` with
-  `init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"`; override
-  these fields to fall back to random initialisation or to use a custom encoder checkpoint.
+  training configurations default to `init: "pretrained"` and rely on the runtime
+  to resolve the bundled checkpoint relative to the model definition when
+  `init_checkpoint` is left as `null`.  Override these fields to fall back to
+  random initialisation or to use a custom encoder checkpoint.
 
 ### `model.adapter` – Latent projection (`LatentAdapterConfig`)
 

--- a/src/gcpvqvae/configs/base.yaml
+++ b/src/gcpvqvae/configs/base.yaml
@@ -41,7 +41,7 @@ model:
     use_gcp_dropout: true
     norm_pos_diff: false
     init: pretrained            # set to "random" to disable checkpoint initialisation
-    init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"
+    init_checkpoint: null
     strict_init: false
   vq:
     num_codes: 4096

--- a/src/gcpvqvae/configs/small.yaml
+++ b/src/gcpvqvae/configs/small.yaml
@@ -39,7 +39,7 @@ model:
     use_gcp_dropout: true
     norm_pos_diff: false
     init: pretrained            # set to "random" to disable checkpoint initialisation
-    init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"
+    init_checkpoint: null
     strict_init: false
   adapter:
     enabled: true

--- a/src/gcpvqvae/configs/xsmall.yaml
+++ b/src/gcpvqvae/configs/xsmall.yaml
@@ -40,7 +40,7 @@ model:
     use_gcp_dropout: true
     norm_pos_diff: false
     init: pretrained            # set to "random" to disable checkpoint initialisation
-    init_checkpoint: "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt"
+    init_checkpoint: null
     strict_init: false
   adapter:
     enabled: true

--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
 
 import numpy as np
@@ -168,9 +169,20 @@ class GCPVQVAE(nn.Module):
 
         checkpoint = getattr(self.config.gcp, "init_checkpoint", None)
         if not checkpoint:
-            raise ValueError(
-                "GCPNet pretrained initialisation requires 'checkpoint' to be set"
-            )
+            default_checkpoint = self._default_gcp_checkpoint_path()
+            if default_checkpoint is None:
+                raise ValueError(
+                    "GCPNet pretrained initialisation requires 'checkpoint' to be set "
+                    "when the packaged default checkpoint cannot be resolved"
+                )
+            if not default_checkpoint.is_file():
+                raise ValueError(
+                    "GCPNet pretrained initialisation requires 'checkpoint' to be set "
+                    f"when the packaged default checkpoint is unavailable at "
+                    f"{default_checkpoint}"
+                )
+            checkpoint = str(default_checkpoint)
+            self.config.gcp.init_checkpoint = checkpoint
 
         state = load_checkpoint(checkpoint, map_location="cpu")
         state_dict = self._extract_gcp_state_dict(state)
@@ -196,6 +208,17 @@ class GCPVQVAE(nn.Module):
                 % (missing, unexpected),
                 UserWarning,
             )
+
+    @staticmethod
+    def _default_gcp_checkpoint_path() -> Optional[Path]:
+        base_dir = Path(__file__).resolve()
+        try:
+            project_root = base_dir.parents[3]
+        except IndexError:
+            return None
+
+        checkpoint = project_root / "models" / "checkpoints" / "gcpnet" / "structure_denoising" / "ca_bb" / "last.ckpt"
+        return checkpoint
 
     @staticmethod
     def _extract_gcp_state_dict(state: Mapping[str, Any]) -> Optional[Dict[str, Tensor]]:


### PR DESCRIPTION
## Summary
- leave the packaged configs' `model.gcp.init_checkpoint` unset by default and document the lazy resolution
- resolve the pretrained GCPNet checkpoint relative to the model module when no explicit path is provided
- update the README to describe the working-directory independent default

## Testing
- pytest *(fails: missing optional dependencies such as x_transformers, h5py, and vector-quantize-pytorch)*

------
https://chatgpt.com/codex/tasks/task_b_68e5af69ea048323b5a7a3648566c080