### PR TITLE
Fix default GCPNet checkpoint lookup

### DIFF
--- a/src/gcpvqvae/models/gcpvqvae.py
+++ b/src/gcpvqvae/models/gcpvqvae.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
+from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
 
@@ -211,6 +212,19 @@ class GCPVQVAE(nn.Module):
 
     @staticmethod
     def _default_gcp_checkpoint_path() -> Optional[Path]:
+        try:
+            resource = files("gcpvqvae") / "models" / "checkpoints" / "gcpnet" / "structure_denoising" / "ca_bb" / "last.ckpt"
+        except ModuleNotFoundError:
+            resource = None
+
+        if resource is not None:
+            try:
+                with as_file(resource) as checkpoint_path:
+                    if checkpoint_path.is_file():
+                        return checkpoint_path
+            except FileNotFoundError:
+                pass
+
         base_dir = Path(__file__).resolve()
         try:
             project_root = base_dir.parents[3]


### PR DESCRIPTION
## Summary
- resolve the default GCPNet checkpoint path via importlib resources before falling back to the repository layout
- keep the previous project-root based fallback when the packaged resource is unavailable

## Testing
- pytest tests/test_gcpnet.py::test_gcpnet_reference_checkpoint_loads -q *(fails: ModuleNotFoundError: No module named 'x_transformers')*

------
https://chatgpt.com/codex/tasks/task_b_68e5b2a43b008323b3225f3ad3ffea81