### PR TITLE
Include GCPNet checkpoint in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,8 @@ gpcvq = "gcpvqvae.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"gcpvqvae" = [
+    "models/checkpoints/gcpnet/structure_denoising/ca_bb/last.ckpt",
+]


### PR DESCRIPTION
## Summary
- ensure the packaged distribution ships with the GCPNet checkpoint by adding it to setuptools package data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5bb82974883238d316a24f1001246