### PR TITLE
Support training from HDF5 preprocessing outputs

### DIFF
--- a/src/gcpvqvae/data/dataset.py
+++ b/src/gcpvqvae/data/dataset.py
@@ -6,11 +6,12 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
+import numpy as np
 import torch
 from torch.utils.data import Dataset
 
 from .featurize import featurize_backbone
-from .mmcif import PAD_INDEX, BackboneRecord, load_mmcif
+from .mmcif import AA_TO_INDEX, ONE_TO_THREE, PAD_INDEX, BackboneRecord, load_mmcif
 
 Tensor = torch.Tensor
 
@@ -123,6 +124,20 @@ def _trim_sample(sample: Dict[str, Any], max_length: int) -> Dict[str, Any]:
     return sample
 
 
+def _decode_h5_sequence(raw: Any) -> str:
+    if isinstance(raw, bytes):
+        return raw.decode("ascii").replace("\x00", "")
+    if isinstance(raw, np.ndarray):
+        if raw.dtype.kind in {"S", "a"}:
+            return raw.tobytes().decode("ascii").replace("\x00", "")
+        if raw.dtype.kind in {"U"}:
+            return "".join(raw.tolist())
+        raw = raw.tolist()
+    if isinstance(raw, (list, tuple)):
+        return "".join(_decode_h5_sequence(item) for item in raw)
+    return str(raw)
+
+
 class BackboneDataset(Dataset):
     """Dataset of protein backbones ready for GCP featurization."""
 
@@ -148,6 +163,8 @@ class BackboneDataset(Dataset):
         self._keys: List[Tuple[str, str]] = []
         self._preprocessed = False
         self._preprocessed_files: List[Path] = []
+        self._preprocessed_formats: List[str] = []
+        self._preprocessed_metadata: List[Dict[str, Any]] = []
         self._source_length_cap: Optional[int] = None
 
         if self.root.is_dir():
@@ -258,6 +275,30 @@ class BackboneDataset(Dataset):
         with manifest_path.open("r", encoding="utf-8") as handle:
             manifest = json.load(handle)
 
+        entries = manifest.get("entries")
+        if isinstance(entries, list):
+            self._init_from_torch_manifest(manifest_path, manifest, entries, chain_ids, length_cap, k)
+            return
+
+        chains = manifest.get("chains")
+        if isinstance(chains, list):
+            self._init_from_hdf5_manifest(manifest_path, chains, chain_ids, length_cap, k)
+            return
+
+        version = manifest.get("version")
+        raise ValueError(
+            f"Unsupported preprocessed dataset manifest format with version {version!r}"
+        )
+
+    def _init_from_torch_manifest(
+        self,
+        manifest_path: Path,
+        manifest: Dict[str, Any],
+        entries: List[Dict[str, Any]],
+        chain_ids: Optional[Iterable[str]],
+        length_cap: int,
+        k: int,
+    ) -> None:
         version = manifest.get("version")
         if version != PREPROCESSED_VERSION:
             raise ValueError(
@@ -270,10 +311,6 @@ class BackboneDataset(Dataset):
                 f"Preprocessed dataset was generated with k={manifest_k} "
                 f"but k={k} was requested"
             )
-
-        entries = manifest.get("entries")
-        if not isinstance(entries, list):
-            raise ValueError("Invalid preprocessed dataset manifest: missing 'entries'")
 
         chain_filter = set(chain_ids) if chain_ids is not None else None
 
@@ -305,6 +342,8 @@ class BackboneDataset(Dataset):
         self.chain_filter = chain_filter
         self._preprocessed = True
         self._preprocessed_files = []
+        self._preprocessed_formats = []
+        self._preprocessed_metadata = []
         self._keys = []
 
         for entry in filtered:
@@ -319,6 +358,76 @@ class BackboneDataset(Dataset):
             key = (source_path, chain_id)
             self._keys.append(key)
             self._preprocessed_files.append(sample_path)
+            self._preprocessed_formats.append("pt")
+            self._preprocessed_metadata.append(
+                {
+                    "chain_id": chain_id,
+                    "source_path": source_path,
+                    "sequence": entry.get("sequence"),
+                    "length": entry.get("length"),
+                }
+            )
+
+    def _init_from_hdf5_manifest(
+        self,
+        manifest_path: Path,
+        chains: List[Dict[str, Any]],
+        chain_ids: Optional[Iterable[str]],
+        length_cap: int,
+        k: int,
+    ) -> None:
+        chain_filter = set(chain_ids) if chain_ids is not None else None
+
+        filtered: List[Dict[str, Any]] = []
+        for entry in chains:
+            if not isinstance(entry, dict):
+                continue
+            chain_id = entry.get("chain_id")
+            file_rel = entry.get("h5_path")
+            if not isinstance(chain_id, str) or not isinstance(file_rel, str):
+                continue
+            if chain_filter is not None and chain_id not in chain_filter:
+                continue
+            filtered.append(entry)
+
+        if not filtered:
+            raise ValueError("Dataset does not contain any valid backbone chains")
+
+        lengths = [entry.get("length") for entry in filtered if isinstance(entry.get("length"), int)]
+        self._source_length_cap = max(lengths) if lengths else None
+
+        self.length_cap = length_cap
+        if self._source_length_cap is not None:
+            self.length_cap = min(self.length_cap, self._source_length_cap)
+        self.k = k
+        self.chain_filter = chain_filter
+        self._preprocessed = True
+        self._preprocessed_files = []
+        self._preprocessed_formats = []
+        self._preprocessed_metadata = []
+        self._keys = []
+
+        for entry in filtered:
+            file_rel = entry["h5_path"]
+            sample_path = manifest_path.parent / file_rel
+            if not sample_path.exists():
+                raise FileNotFoundError(sample_path)
+            source_path = entry.get("source_path")
+            if not isinstance(source_path, str):
+                source_path = str(sample_path)
+            chain_id = entry["chain_id"]
+            key = (source_path, chain_id)
+            self._keys.append(key)
+            self._preprocessed_files.append(sample_path)
+            self._preprocessed_formats.append("h5")
+            self._preprocessed_metadata.append(
+                {
+                    "chain_id": chain_id,
+                    "source_path": source_path,
+                    "sequence": entry.get("sequence"),
+                    "length": entry.get("length"),
+                }
+            )
 
     def _get_preprocessed_sample(
         self, index: int, key: Tuple[str, str]
@@ -327,15 +436,118 @@ class BackboneDataset(Dataset):
             cached = self._records[key]
         else:
             sample_path = self._preprocessed_files[index]
-            cached = torch.load(sample_path, map_location="cpu")
-            if not isinstance(cached, dict):
-                raise TypeError(f"Preprocessed sample at {sample_path} is not a mapping")
+            fmt = self._preprocessed_formats[index] if index < len(self._preprocessed_formats) else "pt"
+            if fmt == "pt":
+                cached = torch.load(sample_path, map_location="cpu")
+                if not isinstance(cached, dict):
+                    raise TypeError(f"Preprocessed sample at {sample_path} is not a mapping")
+            elif fmt == "h5":
+                metadata = self._preprocessed_metadata[index] if index < len(self._preprocessed_metadata) else {}
+                cached = self._load_h5_sample(sample_path, key, metadata)
+            else:
+                raise ValueError(f"Unknown preprocessed sample format: {fmt}")
             if self._cache_enabled:
                 self._records[key] = cached
 
         sample = _clone_nested(cached)
         if self.length_cap and self.length_cap > 0:
             sample = _trim_sample(sample, self.length_cap)
+        return sample
+
+    def _load_h5_sample(
+        self,
+        sample_path: Path,
+        key: Tuple[str, str],
+        metadata: Dict[str, Any],
+    ) -> Dict[str, Tensor | Dict[str, object]]:
+        try:
+            import h5py  # type: ignore[import-not-found]
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "Loading preprocessed HDF5 datasets requires the 'h5py' package"
+            ) from exc
+
+        with h5py.File(sample_path, "r") as handle:
+            seq_raw = handle["seq"][()]
+            coords_raw = np.asarray(handle["N_CA_C_O_coord"][()])
+            plddt_raw = np.asarray(handle["plddt_scores"][()], dtype=np.float32)
+
+        seq_str = _decode_h5_sequence(seq_raw)
+        seq_indices = [AA_TO_INDEX.get(aa, AA_TO_INDEX["X"]) for aa in seq_str]
+        seq_tensor = torch.tensor(seq_indices, dtype=torch.long)
+
+        coords_backbone = np.asarray(coords_raw[:, :3, :], dtype=np.float32)
+        valid_atoms = ~np.isnan(coords_backbone)
+        atom_mask = valid_atoms.all(axis=2)
+
+        coords_filled = np.where(valid_atoms, coords_backbone, 0.0)
+        coords_tensor = torch.from_numpy(coords_filled)
+        atom_mask_tensor = torch.from_numpy(atom_mask.astype(np.bool_))
+        mask_tensor = atom_mask_tensor.all(dim=1)
+        ca_mask_tensor = atom_mask_tensor[:, 1]
+        nan_mask_tensor = ~ca_mask_tensor
+
+        ca_positions = coords_tensor[:, 1, :]
+        if bool(ca_mask_tensor.any()):
+            centroid = ca_positions[ca_mask_tensor].mean(dim=0)
+        else:
+            centroid = ca_positions.mean(dim=0)
+        coords_tensor = coords_tensor - centroid.view(1, 1, 3)
+        rotation = torch.eye(3, dtype=coords_tensor.dtype)
+        translation = centroid
+
+        residue_names = [ONE_TO_THREE.get(aa, "UNK") for aa in seq_str]
+        residue_ids = [(idx + 1, "") for idx in range(len(seq_str))]
+
+        record = BackboneRecord(
+            path=metadata.get("source_path", str(sample_path)),
+            chain_id=metadata.get("chain_id", key[1]),
+            coords=coords_tensor,
+            mask=mask_tensor,
+            atom_mask=atom_mask_tensor,
+            seq=seq_tensor,
+            seq_string=seq_str,
+            residue_names=residue_names,
+            residue_ids=residue_ids,
+            rotation=rotation,
+            translation=translation,
+            nan_mask=nan_mask_tensor,
+        )
+
+        features = featurize_backbone(record, k=self.k)
+
+        plddt_tensor = torch.from_numpy(plddt_raw)
+
+        sample: Dict[str, Tensor | Dict[str, object]] = {
+            "coords": record.coords.clone(),
+            "mask": record.mask.clone(),
+            "atom_mask": record.atom_mask.clone(),
+            "seq": record.seq.clone(),
+            "seq_str": record.seq_string,
+            "nan_mask": record.nan_mask.clone(),
+            "node_scalars": features["node_scalars"],
+            "node_vectors": features["node_vectors"],
+            "backbone_vectors": features["backbone_vectors"],
+            "torsion_angles": features["torsion_angles"],
+            "edge_index": features["edge_index"],
+            "edge_scalars": features["edge_scalars"],
+            "edge_vectors": features["edge_vectors"],
+            "edge_frames": features["edge_frames"],
+            "pose": {
+                "rotation": record.rotation.clone(),
+                "translation": record.translation.clone(),
+            },
+            "metadata": {
+                "path": record.path,
+                "chain_id": record.chain_id,
+                "sequence": record.seq_string,
+                "residue_ids": list(record.residue_ids),
+                "residue_names": list(record.residue_names),
+                "source_h5": str(sample_path),
+            },
+            "plddt_scores": plddt_tensor,
+        }
+
         return sample
 
 

--- a/tests/test_pdb_to_hdf5_integration.py
+++ b/tests/test_pdb_to_hdf5_integration.py
@@ -1,0 +1,179 @@
+"""Integration tests covering preprocessing and training on real structures."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+h5py = pytest.importorskip("h5py")
+
+from gcpvqvae.data.dataset import BackboneDataset
+from gcpvqvae.data.preprocess import preprocess_dataset, preprocess_structure
+from gcpvqvae.system.train import train
+
+
+_SUBSET_FILES = ["1A2N.cif", "1ACX.cif", "1B0I.cif"]
+
+
+def _prepare_subset(tmp_path: Path, filenames: list[str] | None = None) -> Path:
+    source_root = Path(__file__).resolve().parent / "test_data" / "cif_50"
+    subset_root = tmp_path / "structures"
+    subset_root.mkdir(parents=True, exist_ok=True)
+
+    selected = filenames or _SUBSET_FILES
+    for name in selected:
+        shutil.copy2(source_root / name, subset_root / name)
+
+    return subset_root
+
+
+def _decode_sequence(raw) -> str:
+    if isinstance(raw, bytes):
+        return raw.decode("ascii")
+    if hasattr(raw, "tobytes"):
+        return raw.tobytes().decode("ascii")
+    return str(raw)
+
+
+def test_preprocess_dataset_generates_hdf5_matching_structures(tmp_path: Path) -> None:
+    subset_dir = _prepare_subset(tmp_path)
+    output_dir = tmp_path / "processed"
+
+    manifest_path, stats = preprocess_dataset(
+        subset_dir,
+        output_dir,
+        min_len=0,
+        max_workers=1,
+        file_index=False,
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    chains = manifest["chains"]
+
+    assert chains, "expected at least one chain to be preprocessed"
+    assert stats.get("files_total", 0) == len(_SUBSET_FILES)
+    assert stats.get("chains_written", 0) == len(chains)
+
+    dataset = BackboneDataset(output_dir, k=4, progress=False)
+    dataset_samples = {}
+    for idx in range(len(dataset)):
+        sample = dataset[idx]
+        metadata = sample["metadata"]
+        assert isinstance(metadata, dict)
+        key = (metadata.get("path"), metadata.get("chain_id"))
+        dataset_samples[key] = sample
+
+    for entry in chains:
+        h5_path = output_dir / entry["h5_path"]
+        assert h5_path.exists()
+
+        with h5py.File(h5_path, "r") as handle:
+            seq = _decode_sequence(handle["seq"][()])
+            coords = handle["N_CA_C_O_coord"][()]
+            plddt = handle["plddt_scores"][()]
+
+        expected = preprocess_structure(entry["source_path"], entry["chain_id"])
+        assert seq == expected.protein_seq
+        np.testing.assert_allclose(coords, expected.coords, atol=1e-6, equal_nan=True)
+        np.testing.assert_allclose(plddt, expected.plddt, atol=1e-6, equal_nan=True)
+
+        key = (entry["source_path"], entry["chain_id"])
+        sample = dataset_samples.get(key)
+        assert sample is not None, f"missing dataset sample for {key}"
+        assert sample["seq_str"] == expected.protein_seq
+        np.testing.assert_allclose(
+            sample["plddt_scores"].numpy(), expected.plddt, atol=1e-6, equal_nan=True
+        )
+        metadata = sample["metadata"]
+        assert isinstance(metadata, dict)
+        assert metadata.get("source_h5", "").endswith(entry["h5_path"])
+
+
+def _make_training_config(output_dir: Path, data_root: Path) -> dict:
+    return {
+        "data": {
+            "root": str(data_root),
+            "k": 4,
+            "num_dataloader_workers": 0,
+            "cache": True,
+        },
+        "model": {
+            "gcp": {
+                "embedding": {
+                    "node_scalar_dim": 6,
+                    "node_vector_dim": 3,
+                    "edge_scalar_dim": 8,
+                    "edge_vector_dim": 1,
+                    "output": {"scalar": 32, "vector": 4},
+                },
+                "message_passing": {"width": {"scalar": 32, "vector": 4}},
+                "feed_forward": {"width": {"scalar": 64, "vector": 4}},
+                "latent_dim": 64,
+                "num_layers": 2,
+            },
+            "vq": {
+                "num_codes": 32,
+                "dim": 64,
+                "beta": 0.25,
+                "decay": 0.99,
+                "kmeans_iters": 1,
+            },
+            "encoder": {
+                "model_dim": 64,
+                "num_layers": 2,
+                "num_heads": 4,
+                "num_kv_heads": 2,
+            },
+            "decoder": {
+                "model_dim": 64,
+                "num_layers": 2,
+                "num_heads": 4,
+                "num_kv_heads": 1,
+            },
+        },
+        "train": {
+            "seed": 777,
+            "amp": False,
+            "clip_grad": 1.0,
+            "random_rotation": False,
+            "checkpoint_interval": 1,
+            "output_dir": str(output_dir),
+            "log": {"interval": 1},
+            "export": {"enabled": False},
+            "stages": [
+                {
+                    "name": "pilot",
+                    "length_cap": 128,
+                    "batch_size": 1,
+                    "base_lr": 0.001,
+                    "min_lr": 1e-5,
+                    "warmup_steps": 1,
+                    "epochs": 1,
+                    "accumulation_steps": 1,
+                    "nan_mask_prob": 0.0,
+                }
+            ],
+        },
+    }
+
+
+def test_training_pipeline_uses_preprocessed_hdf5(tmp_path: Path) -> None:
+    subset_dir = _prepare_subset(tmp_path, filenames=["1A2N.cif", "1ACX.cif"])
+    processed_root = tmp_path / "processed"
+    preprocess_dataset(subset_dir, processed_root, min_len=0, max_workers=1, file_index=False)
+
+    output_dir = tmp_path / "runs"
+    config = _make_training_config(output_dir, processed_root)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    train(str(config_path))
+
+    checkpoint_dir = output_dir / "checkpoints"
+    checkpoints = list(checkpoint_dir.glob("*.pt"))
+    assert checkpoints, "training did not emit any checkpoints"


### PR DESCRIPTION
## Summary
- add support for HDF5 preprocessing manifests to `BackboneDataset` so training can consume `.h5` samples directly
- reconstruct backbone features from the stored sequence and coordinates, including metadata and pLDDT scores
- extend the integration test to assert the dataset consumes the generated HDF5 files before running the training smoke test

## Testing
- python -m compileall src/gcpvqvae/data/dataset.py tests/test_pdb_to_hdf5_integration.py

------
https://chatgpt.com/codex/tasks/task_b_68e636f0bc8c832385084d66488f836a